### PR TITLE
Fix Pandas groupby FutureWarning

### DIFF
--- a/src/mbi/graphical_model.py
+++ b/src/mbi/graphical_model.py
@@ -243,7 +243,7 @@ class GraphicalModel:
                 return group
 
             if len(proj) >= 1:
-                df = df.groupby(list(proj)).apply(foo)
+                df = df.groupby(list(proj), group_keys=False).apply(foo)
             else:
                 df[col] = synthetic_col(marg, df.shape[0])
 


### PR DESCRIPTION
Explicitly set group_keys in groupby call to silence future warnings of Pandas >=1.5.0:

> Changed in version 1.5.0: Warns that group_keys will no longer be ignored when the result from apply is a like-indexed Series or DataFrame. Specify group_keys explicitly to include the group keys or not.

https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.groupby.html