### PR TITLE
Fixed set.union in the case of no cliques

### DIFF
--- a/mechanisms/mst.py
+++ b/mechanisms/mst.py
@@ -191,6 +191,7 @@ if __name__ == "__main__":
   workload = list(itertools.combinations(data.domain, args.degree))
   workload = [cl for cl in workload if data.domain.size(cl) <= args.max_cells]
   if args.num_marginals is not None:
+    prng = np.random.RandomState(None)
     workload = [
       workload[i]
       for i in prng.choice(len(workload), args.num_marginals, replace=False)

--- a/mechanisms/mst.py
+++ b/mechanisms/mst.py
@@ -191,7 +191,6 @@ if __name__ == "__main__":
   workload = list(itertools.combinations(data.domain, args.degree))
   workload = [cl for cl in workload if data.domain.size(cl) <= args.max_cells]
   if args.num_marginals is not None:
-    prng = np.random.RandomState(None)
     workload = [
       workload[i]
       for i in prng.choice(len(workload), args.num_marginals, replace=False)

--- a/src/mbi/synthetic_data.py
+++ b/src/mbi/synthetic_data.py
@@ -40,7 +40,7 @@ def from_marginals(
 
     for col in order[1:]:
         relevant = [cl for cl in cliques if col in cl]
-        relevant = used.intersection(set.union(*relevant) if relevant else set())
+        relevant = used.intersection(set().union(*relevant))
         proj = tuple(relevant)
         used.add(col)
         # Will this work without having the maximal cliques of the junction tree?

--- a/src/mbi/synthetic_data.py
+++ b/src/mbi/synthetic_data.py
@@ -40,7 +40,7 @@ def from_marginals(
 
     for col in order[1:]:
         relevant = [cl for cl in cliques if col in cl]
-        relevant = used.intersection(set.union(*relevant))
+        relevant = used.intersection(set.union(*relevant) if relevant else set())
         proj = tuple(relevant)
         used.add(col)
         # Will this work without having the maximal cliques of the junction tree?


### PR DESCRIPTION
Solves https://github.com/ryan112358/private-pgm/issues/23.

The instruction `set.union(*sets)` is only defined when `sets` contains at least one set, so I just added this sanity check.
This is an unelegant feature of Python, similar to `sum()` raising an error instead of returning zero.
