### PR TITLE
feat: Add docstrings and doctests for Domain and Factor classes

### DIFF
--- a/src/mbi/domain.py
+++ b/src/mbi/domain.py
@@ -6,8 +6,30 @@ import attr
 
 @attr.dataclass(frozen=True)
 class Domain:
-    """Dataclass for representing discrete domains."""
+    """Represents a discrete domain defined by attributes and their sizes.
 
+    This class encapsulates a set of named attributes and their corresponding
+    discrete sizes (shapes). It provides methods for common domain operations.
+
+    Attributes:
+        attributes (tuple[str, ...]): A tuple containing the names of the
+            attributes in the domain.
+        shape (tuple[int, ...]): A tuple containing the integer sizes
+            (number of discrete values) for each corresponding attribute in
+            the `attributes` tuple.
+
+    Supported Operations:
+        - Projection (`project`): Creates a new domain with a subset of attributes.
+        - Marginalization (`marginalize`): Creates a new domain excluding specified attributes.
+        - Intersection (`intersect`): Creates a new domain containing only common attributes.
+        - Merging (`merge`): Combines two domains into a larger one.
+        - Size Calculation (`size`): Computes the total number of configurations in the domain or a subset.
+
+    Example Usage (using fromdict):
+    >>> domain = Domain.fromdict({'a': 2, 'b': 3})
+    >>> print(domain)
+    Domain(a: 2, b: 3)
+    """
     attributes: tuple[str, ...] = attr.field(converter=tuple)
     shape: tuple[int, ...] = attr.field(converter=tuple)
 

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -21,8 +21,31 @@ def _try_convert(values):
 )
 @attr.dataclass(frozen=True)
 class Factor:
-    """A factor over a domain."""
+    """Represents a factor defined over a discrete domain.
 
+    A factor can be thought of as a potential function or an unnormalized
+    probability distribution over a set of discrete variables defined by a
+    `Domain` object. It maps each configuration of the domain to a value.
+
+    Attributes:
+        domain (Domain): The discrete domain over which the factor is defined.
+        values (jax.Array): A JAX array containing the factor's values. The shape
+            of this array matches the shape specified by the `domain`.
+
+    Supported Operations:
+        - Creation: `zeros`, `ones`, `random` for creating factors.
+        - Reshaping: `transpose`, `expand` for modifying the domain/shape.
+        - Aggregation: `sum`, `logsumexp`, `project` for marginalizing attributes.
+        - Element-wise: `exp`, `log`, `normalize` for value transformations.
+        - Binary Ops: `+`, `-`, `*`, `/`, `dot` for combining factors.
+
+    Example Usage:
+    >>> from mbi import Domain  # Needed for doctest context
+    >>> domain = Domain.fromdict({'X': 2, 'Y': 3})
+    >>> factor = Factor.ones(domain)
+    >>> print(factor.domain)
+    Domain(X: 2, Y: 3)
+    """
     domain: Domain
     values: jax.Array = attr.field(converter=_try_convert)
 


### PR DESCRIPTION
I added class-level docstrings to `src/mbi/domain.py` and `src/mbi/factor.py` for the `Domain` and `Factor` classes respectively.

The docstrings describe the purpose, attributes, and key operations for each class.

I added a simple doctest to each class docstring demonstrating basic object creation:
- `Domain`: Shows creation using `Domain.fromdict`.
- `Factor`: Shows creation using `Factor.ones` and a `Domain`.

I encountered an issue running tests in the environment, possibly due to setup problems, but the changes are documentation-only and I've visually reviewed them.