### PR TITLE
Refactor import statements for clarity and robustness

### DIFF
--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -7,3 +7,15 @@ from . import estimation
 from . import callbacks
 from . import junction_tree
 from . import marginal_oracles
+
+__all__ = [
+    'Domain',
+    'Dataset',
+    'Factor',
+    'CliqueVector',
+    'LinearMeasurement',
+    'estimation',
+    'callbacks',
+    'junction_tree',
+    'marginal_oracles',
+]

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -16,7 +16,9 @@ import jax
 import networkx as nx
 import itertools
 from scipy.cluster.hierarchy import DisjointSet
-from mbi import Domain, CliqueVector, Factor
+from .domain import Domain
+from .clique_vector import CliqueVector
+from .factor import Factor
 from typing import TypeAlias, Protocol, Any
 import functools
 

--- a/src/mbi/callbacks.py
+++ b/src/mbi/callbacks.py
@@ -1,7 +1,9 @@
 import attr
 import jax
-from mbi import LinearMeasurement, Dataset, CliqueVector
-from mbi import marginal_loss
+from .marginal_oracles import LinearMeasurement # Assuming LinearMeasurement is in marginal_oracles.py
+from .dataset import Dataset
+from .clique_vector import CliqueVector
+from . import marginal_loss
 import pandas as pd
 
 

--- a/src/mbi/callbacks.py
+++ b/src/mbi/callbacks.py
@@ -1,6 +1,6 @@
 import attr
 import jax
-from .marginal_oracles import LinearMeasurement # Assuming LinearMeasurement is in marginal_oracles.py
+from .marginal_loss import LinearMeasurement
 from .dataset import Dataset
 from .clique_vector import CliqueVector
 from . import marginal_loss

--- a/src/mbi/clique_vector.py
+++ b/src/mbi/clique_vector.py
@@ -1,5 +1,6 @@
 import numpy as np
-from mbi import Domain, Factor
+from .domain import Domain
+from .factor import Factor
 import jax
 import jax.numpy as jnp
 import functools

--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import os
 import json
-from mbi import Domain
+from .domain import Domain
 
 
 class Dataset:

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -15,7 +15,7 @@ import numpy as np
 from .domain import Domain
 from .clique_vector import CliqueVector
 from .factor import Factor
-from .marginal_loss import LinearMeasurement # Corrected import source
+from .marginal_loss import LinearMeasurement
 from . import marginal_oracles, marginal_loss, synthetic_data
 from .marginal_oracles import MarginalOracle
 from .approximate_oracles import StatefulMarginalOracle

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -12,10 +12,13 @@ intialize the potentials to zero for you.  Any CliqueVector of potentials that
 support the cliques of the marginal-based loss function can be used here.
 """
 import numpy as np
-from mbi import Domain, CliqueVector, Factor, LinearMeasurement
-from mbi import marginal_oracles, marginal_loss, synthetic_data
-from mbi.marginal_oracles import MarginalOracle
-from mbi.approximate_oracles import StatefulMarginalOracle
+from .domain import Domain
+from .clique_vector import CliqueVector
+from .factor import Factor
+from .marginal_oracles import LinearMeasurement
+from . import marginal_oracles, marginal_loss, synthetic_data
+from .marginal_oracles import MarginalOracle
+from .approximate_oracles import StatefulMarginalOracle
 from typing import Any, Callable, NamedTuple, Protocol
 import jax
 import jax.numpy as jnp
@@ -88,7 +91,7 @@ class GraphicalModel:
     def project(self, attrs: tuple[str, ...]) -> Factor:
         try:
             return self.marginals.project(attrs)
-        except:
+        except Exception: # Added Exception type for clarity
             return marginal_oracles.variable_elimination(
                 self.potentials, attrs, self.total
             )

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -15,7 +15,7 @@ import numpy as np
 from .domain import Domain
 from .clique_vector import CliqueVector
 from .factor import Factor
-from .marginal_oracles import LinearMeasurement
+from .marginal_loss import LinearMeasurement # Corrected import source
 from . import marginal_oracles, marginal_loss, synthetic_data
 from .marginal_oracles import MarginalOracle
 from .approximate_oracles import StatefulMarginalOracle

--- a/src/mbi/experimental/mixture_of_products.py
+++ b/src/mbi/experimental/mixture_of_products.py
@@ -9,9 +9,6 @@ from scipy.sparse.linalg import lsmr
 import pandas as pd
 import jax.numpy as jnp
 import optax
-import numpy as np
-
-""" This file is experimental.
 
 It is a close approximation to the method described in RAP (https://arxiv.org/abs/2103.06641)
 and an even closer approximation to RAP^{softmax} (https://arxiv.org/abs/2106.07153). This 

--- a/src/mbi/experimental/public_support.py
+++ b/src/mbi/experimental/public_support.py
@@ -1,4 +1,10 @@
-from mbi import Dataset, Factor, CliqueVector, estimation, Domain, marginal_loss, LinearMeasurement
+from ..dataset import Dataset
+from ..factor import Factor
+from ..clique_vector import CliqueVector
+from .. import estimation
+from ..domain import Domain
+from .. import marginal_loss
+from ..marginal_loss import LinearMeasurement
 from scipy.optimize import minimize
 from collections import defaultdict
 import numpy as np

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -5,7 +5,7 @@ import jax
 import jax.numpy as jnp
 import attr
 import functools
-from mbi import Domain
+from .domain import Domain
 import numpy as np
 
 jax.config.update("jax_enable_x64", True)

--- a/src/mbi/junction_tree.py
+++ b/src/mbi/junction_tree.py
@@ -5,7 +5,7 @@ from typing import TypeAlias, Collection
 import networkx as nx
 import numpy as np
 
-from mbi import Domain
+from .domain import Domain
 
 
 Clique: TypeAlias = tuple[str, ...]

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -1,6 +1,7 @@
 import attr
 from typing import Any, Callable, TypeAlias, Protocol, Mapping
-from mbi import Factor, CliqueVector
+from .factor import Factor
+from .clique_vector import CliqueVector
 
 import jax
 import jax.numpy as jnp

--- a/src/mbi/synthetic_data.py
+++ b/src/mbi/synthetic_data.py
@@ -1,5 +1,6 @@
-from mbi import CliqueVector, Dataset
-from mbi import junction_tree
+from .clique_vector import CliqueVector
+from .dataset import Dataset
+from . import junction_tree
 import pandas as pd
 import numpy as np
 

--- a/test/test_approximate_oracles.py
+++ b/test/test_approximate_oracles.py
@@ -1,5 +1,8 @@
 import unittest
-from mbi import Domain, Factor, CliqueVector, LinearMeasurement
+from mbi.domain import Domain
+from mbi.factor import Factor
+from mbi.clique_vector import CliqueVector
+from mbi.marginal_loss import LinearMeasurement
 from mbi import approximate_oracles, estimation
 import numpy as np
 from parameterized import parameterized

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -1,5 +1,7 @@
 import unittest
-from mbi import Domain, Factor, CliqueVector
+from mbi.domain import Domain
+from mbi.factor import Factor
+from mbi.clique_vector import CliqueVector
 from mbi import marginal_loss, estimation
 import numpy as np
 from parameterized import parameterized

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -1,5 +1,7 @@
 import unittest
-from mbi import Domain, Factor, CliqueVector
+from mbi.domain import Domain
+from mbi.factor import Factor
+from mbi.clique_vector import CliqueVector
 from mbi import marginal_oracles
 import numpy as np
 from parameterized import parameterized


### PR DESCRIPTION
This commit refactors the import statements within the `mbi` package and its tests according to the following principles:

1.  **Internal Relative Imports:** Imports between modules within the `src/mbi/` directory now use explicit relative imports (e.g., `from .domain import Domain`). This clarifies internal dependencies and reduces reliance on `__init__.py` structure.

2.  **Explicit Public API:** `src/mbi/__init__.py` now includes an `__all__` list, explicitly defining the public interface of the package. Imports within `__init__.py` remain relative.

3.  **Explicit Absolute Test Imports:** Imports within the `test/` directory now use explicit absolute paths from the `mbi` root (e.g., `from mbi.domain import Domain`). This makes test dependencies clear and robust.

These changes improve code maintainability and reduce the potential for circular import errors.