### PR TITLE
feat: Enhance Sphinx API documentation generation

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,31 @@
+{{ fullname | escape | underline }}
+
+.. autoclass:: {{ fullname }}
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :member-order: bysource
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: Methods
+
+   .. autosummary::
+      :nosignatures:
+      {% for item in methods %}
+         ~{{ name }}.{{ item }}
+      {% endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :nosignatures:
+      {% for item in attributes %}
+         ~{{ name }}.{{ item }}
+      {% endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,13 @@ extensions = [
     'sphinx.ext.doctest',
 ]
 
+# Add this line if it doesn't exist, or ensure it's True if it does
+autosummary_generate = True
+
+# Configure autodoc settings
+autodoc_typehints = "signature"
+autoclass_content = "both"
+
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 

--- a/docs/mbi.rst
+++ b/docs/mbi.rst
@@ -3,8 +3,8 @@ mbi package
 
 .. currentmodule:: mbi
 
-Classes
--------
+Top-Level Classes
+-----------------
 .. autosummary::
    :toctree: _autosummary_output
    :nosignatures:
@@ -13,15 +13,24 @@ Classes
    Factor
    CliqueVector
    Dataset
-   LinearMeasurement
+   # LinearMeasurement was present originally, let's keep it for now assuming it's a key class
+   LinearMeasurement 
 
-Modules & Functions
--------------------
+Modules
+-------
 .. autosummary::
    :toctree: _autosummary_output
    :nosignatures:
 
-   estimation
+   approximate_oracles
    callbacks
+   clique_vector
+   dataset
+   domain
+   estimation
+   # experimental # Let's hold off on adding experimental for now
+   factor
    junction_tree
+   marginal_loss
    marginal_oracles
+   synthetic_data


### PR DESCRIPTION
I've configured Sphinx using autodoc and autosummary to improve the API documentation generation for the 'mbi' package.

Here's what I did:
- Enabled `autosummary_generate = True` for automatic stub file creation.
- Configured `mbi.rst` to use `autosummary` with `:toctree:` for a centralized API listing and dedicated pages per module/class.
- Set `autodoc_typehints = "signature"` for accurate signatures with type hints.
- Set `autoclass_content = "both"` to include `__init__` documentation prominently on class pages.
- Added a custom autosummary class template (`_templates/autosummary/class.rst`) to include summary tables for methods and attributes within each class page.
- Verified that the API documentation (`mbi.rst`) is included in the main `index.rst` toctree.

These changes should result in a clearer, more automated, and user-friendly API reference, addressing your requirements. Building the documentation now should produce the desired output.