### PR TITLE
Add remaining docstrings to src/mbi and fix omissions

### DIFF
--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -1,3 +1,10 @@
+"""Main entry point for the mbi package.
+
+This module exposes the core classes and submodules of the mbi library,
+making them available for direct import. It simplifies access to functionalities
+like data representation (Domain, Dataset), factor manipulation (Factor),
+and various estimation and oracle modules.
+"""
 from .domain import Domain
 from .dataset import Dataset
 from .factor import Factor

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -60,6 +60,7 @@ class StatefulMarginalOracle(Protocol):
 
 
 def build_graph(domain: Domain, cliques: list[tuple[str, ...]]) -> ...:
+    """Builds the region graph for convex generalized belief propagation."""
     # Hard-code minimal=True, convex=True
     # Counting numbers = 1 for all regions
     # Alg 11.3 of Koller & Friedman

--- a/src/mbi/callbacks.py
+++ b/src/mbi/callbacks.py
@@ -1,3 +1,10 @@
+"""Defines callback mechanisms for monitoring optimization processes.
+
+This module provides a `Callback` class that can be used to track and log
+various metrics during iterative algorithms, such as those used in estimating
+differentially private marginals. It allows for periodic logging of loss values
+and other relevant statistics.
+"""
 import attr
 import jax
 from .marginal_loss import LinearMeasurement
@@ -8,6 +15,7 @@ import pandas as pd
 
 
 def _pad(string: str, length: int):
+    """Pads a string with spaces on both sides to a target length."""
     if len(string) > length:
         return string[:length]
     left_pad = (length - len(string)) // 2
@@ -47,6 +55,7 @@ def default(
     data: Dataset | None = None,
     frequency: int = 50,
 ) -> Callback:
+    """Creates a default Callback with standard loss functions (L1/L2 Loss/Error, Primal Feas)."""
     loss_fns = {}
     # Measures distance between input marginals and noisy marginals.
     loss_fns["L2 Loss"] = marginal_loss.from_linear_measurements(

--- a/src/mbi/callbacks.py
+++ b/src/mbi/callbacks.py
@@ -2,8 +2,7 @@
 
 This module provides a `Callback` class that can be used to track and log
 various metrics during iterative algorithms, such as those used in estimating
-differentially private marginals. It allows for periodic logging of loss values
-and other relevant statistics.
+marginals. It logs loss values and other relevant statistics.
 """
 import attr
 import jax

--- a/src/mbi/clique_vector.py
+++ b/src/mbi/clique_vector.py
@@ -1,3 +1,11 @@
+"""Defines the CliqueVector class for managing collections of factors over cliques.
+
+This module introduces the `CliqueVector`, a data structure designed to hold
+and manipulate sets of `Factor` objects, each associated with a specific clique
+(a subset of attributes) within a domain. It facilitates operations common in
+graphical models, such as projecting onto sub-cliques, expanding to larger cliques,
+and performing arithmetic operations on these collections.
+"""
 import numpy as np
 from .domain import Domain
 from .factor import Factor
@@ -59,46 +67,54 @@ class CliqueVector:
 
     @classmethod
     def zeros(cls, domain: Domain, cliques: list[Clique]) -> "CliqueVector":
+        """Creates a CliqueVector initialized with zero factors for each clique."""
         cliques = [tuple(cl) for cl in cliques]
         arrays = {cl: Factor.zeros(domain.project(cl)) for cl in cliques}
         return cls(domain, cliques, arrays)
 
     @classmethod
     def ones(cls, domain: Domain, cliques: list[Clique]) -> "CliqueVector":
+        """Creates a CliqueVector initialized with one factors for each clique."""
         cliques = [tuple(cl) for cl in cliques]
         arrays = {cl: Factor.ones(domain.project(cl)) for cl in cliques}
         return cls(domain, cliques, arrays)
 
     @classmethod
     def uniform(cls, domain: Domain, cliques: list[Clique]) -> "CliqueVector":
+        """Creates a CliqueVector initialized with uniform factors for each clique."""
         cliques = [tuple(cl) for cl in cliques]
         arrays = {cl: Factor.uniform(domain.project(cl)) for cl in cliques}
         return cls(domain, cliques, arrays)
 
     @classmethod
     def random(cls, domain: Domain, cliques: list[Clique]):
+        """Creates a CliqueVector initialized with random factors for each clique."""
         cliques = [tuple(cl) for cl in cliques]
         arrays = {cl: Factor.random(domain.project(cl)) for cl in cliques}
         return cls(domain, cliques, arrays)
 
     @classmethod
     def from_projectable(cls, data, cliques: list[Clique]):
+        """Creates a CliqueVector by projecting a data source onto the specified cliques."""
         cliques = [tuple(cl) for cl in cliques]
         arrays = {cl: data.project(cl) for cl in cliques}
         return cls(data.domain, cliques, arrays)
 
     @functools.cached_property
     def active_domain(self):
+        """Returns the merged domain encompassing all attributes across all cliques."""
         domains = [self.domain.project(cl) for cl in self.cliques]
         return functools.reduce(lambda a, b: a.merge(b), domains, Domain([], []))
 
     # @functools.lru_cache(maxsize=None)
     def parent(self, clique: Clique) -> Clique | None:
+        """Finds a clique in this vector that is a superset of the given clique."""
         for result in self.cliques:
             if set(clique) <= set(result):
                 return result
 
     def supports(self, clique: Clique) -> bool:
+        """Checks if the given clique is supported (is a subset of any clique in the vector)."""
         return self.parent(clique) is not None
 
     def project(self, clique: Clique, log: bool = False) -> Factor:
@@ -130,49 +146,61 @@ class CliqueVector:
         return CliqueVector(self.domain, cliques, arrays)
 
     def contract(self, cliques: list[Clique], log: bool = False) -> "CliqueVector":
-        """Compute a supported CliqueVector from this."""
+        """Computes a new CliqueVector by projecting this one onto a smaller set of cliques."""
         arrays = {cl: self.project(cl, log=log) for cl in cliques}
         return CliqueVector(self.domain, cliques, arrays)
 
     def normalize(self, total: float = 1, log: bool = True):
+        """Normalizes each factor within the CliqueVector."""
         is_leaf = lambda node: isinstance(node, Factor)
         return jax.tree.map(lambda f: f.normalize(total, log), self, is_leaf=is_leaf)
 
     def __mul__(self, const: chex.Numeric) -> "CliqueVector":
+        """Multiplies each factor in the vector by a constant."""
         return jax.tree.map(lambda f: f * const, self)
 
     def __rmul__(self, const: chex.Numeric) -> "CliqueVector":
+        """Right-multiplies each factor in the vector by a constant."""
         return self.__mul__(const)
 
     def __truediv__(self, const: chex.Numeric) -> "CliqueVector":
+        """Divides each factor in the vector by a constant."""
         return self.__mul__(1 / const)
 
     def __add__(self, other: chex.Numeric | "CliqueVector") -> "CliqueVector":
+        """Adds another CliqueVector or a constant to this vector elementwise."""
         if isinstance(other, CliqueVector):
             return jax.tree.map(jnp.add, self, other)
         return jax.tree.map(lambda f: f + other, self)
 
     def __sub__(self, other: chex.Numeric | "CliqueVector") -> "CliqueVector":
+        """Subtracts another CliqueVector or a constant from this vector elementwise."""
         return self + -1 * other
 
     def exp(self) -> "CliqueVector":
+        """Applies elementwise exponentiation (jnp.exp) to each factor."""
         return jax.tree.map(jnp.exp, self)
 
     def log(self) -> "CliqueVector":
+        """Applies elementwise logarithm (jnp.log) to each factor."""
         return jax.tree.map(jnp.log, self)
 
     def dot(self, other: "CliqueVector") -> chex.Numeric:
+        """Computes the dot product between this CliqueVector and another."""
         is_leaf = lambda node: isinstance(node, Factor)
         dots = jax.tree.map(Factor.dot, self, other, is_leaf=is_leaf)
         return jax.tree.reduce(operator.add, dots, 0)
 
     def size(self):
+        """Calculates the total number of parameters across all factors in the vector."""
         return sum(self.domain.size(cl) for cl in self.cliques)
 
     def __getitem__(self, clique: Clique) -> Factor:
+        """Retrieves the factor associated with the given clique."""
         return self.arrays[clique]
 
     def __setitem__(self, clique: Clique, value: Factor):
+        """Sets the factor for a given clique, replacing the existing one if present."""
         if clique in self.cliques:
             self.arrays[clique] = value
         else:

--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -1,3 +1,11 @@
+"""Provides the Dataset class for representing and manipulating tabular data.
+
+This module defines the `Dataset` class, which serves as a wrapper around a
+Pandas DataFrame, associating it with a `Domain` object. It allows for
+structured representation of data, facilitating operations like projection onto
+subsets of attributes and conversion into a data vector format suitable for
+various statistical and machine learning tasks.
+"""
 import numpy as np
 import pandas as pd
 import os
@@ -54,11 +62,13 @@ class Dataset:
         return Dataset(data, domain, self.weights)
 
     def drop(self, cols):
+        """Returns a new Dataset with the specified columns removed."""
         proj = [c for c in self.domain if c not in cols]
         return self.project(proj)
 
     @property
     def records(self):
+        """Returns the number of records (rows) in the dataset."""
         return self.df.shape[0]
 
     def datavector(self, flatten=True):

--- a/src/mbi/domain.py
+++ b/src/mbi/domain.py
@@ -91,15 +91,15 @@ class Domain:
         return self.project(proj)
 
     def contains(self, other: "Domain") -> bool:
-        """Determine if this domain contains another."""
+        """Checks if this domain contains all attributes present in another domain."""
         return set(other.attributes) <= set(self.attributes)
 
     def canonical(self, attrs):
-        """Return the canonical ordering of the attributes."""
+        """Returns attributes common to the domain and input, maintaining the domain's order."""
         return tuple(a for a in self.attributes if a in attrs)
 
     def invert(self, attrs):
-        """returns the attributes in the domain not in the list"""
+        """Returns attributes present in the domain but not in the provided list."""
         return [a for a in self.attributes if a not in attrs]
 
     def intersect(self, other: "Domain") -> "Domain":
@@ -169,6 +169,7 @@ class Domain:
 
     @property
     def attrs(self):
+        """Alias for the `attributes` tuple."""
         return self.attributes
 
     def __contains__(self, name: str) -> bool:

--- a/src/mbi/experimental/mixture_of_products.py
+++ b/src/mbi/experimental/mixture_of_products.py
@@ -10,20 +10,26 @@ import pandas as pd
 import jax.numpy as jnp
 import optax
 
-It is a close approximation to the method described in RAP (https://arxiv.org/abs/2103.06641)
-and an even closer approximation to RAP^{softmax} (https://arxiv.org/abs/2106.07153). This 
-implementation is not very optimized.  If you would like to improve it, pull requests 
-are welcome.
+"""Implements an experimental Mixture of Products model for synthetic data generation.
 
-Notable differences:
-- Code now shares the same interface as Private-PGM (see FactoredInference)
-- Named model "MixtureOfProducts", as that is one interpretation for the relaxed tabular format
-(at least when softmax is used).
-- Added support for unbounded-DP, with automatic estimate of total.
+This module provides an implementation of the Mixture of Products model, which
+approximates methods like RAP (https://arxiv.org/abs/2103.06641) and
+RAP^{softmax} (https://arxiv.org/abs/2106.07153). It aims to generate synthetic
+data by learning a mixture of simpler product distributions that match given
+marginal constraints.
+
+Notable differences from some related works include:
+- Adherence to the common interface used by other methods like Private-PGM.
+- Use of the name "MixtureOfProducts" reflecting the model structure.
+- Support for unbounded differential privacy with automatic total estimation.
+
+Note: This implementation is experimental and may not be fully optimized.
+Contributions are welcome.
 """
 
 
 def adam(loss_and_grad, x0, iters=250):
+    """Implements the Adam optimization algorithm (based on Kingma & Ba, 2014)."""
     # TODO: Rewrite using optax
     a = 1.0
     b1, b2 = 0.9, 0.999
@@ -41,9 +47,8 @@ def adam(loss_and_grad, x0, iters=250):
         vhat = v / (1 - b2 ** t)
         x = x - a * mhat / (jnp.sqrt(vhat) + eps)
     return x
-
-
 def synthetic_col(counts, total):
+    """Generates a synthetic column by rounding fractional counts based on total."""
     counts *= total / counts.sum()
     frac, integ = np.modf(counts)
     integ = integ.astype(int)
@@ -54,21 +59,27 @@ def synthetic_col(counts, total):
     vals = np.repeat(np.arange(counts.size), integ)
     np.random.shuffle(vals)
     return vals
-
-
 class MixtureOfProducts:
+    """Represents a probability distribution as a mixture of product distributions.
+
+    Stores the component product distributions (probabilities for each attribute
+    within each component) and the overall total count/mass.
+    """
     def __init__(self, products, domain, total):
+        """Initializes the MixtureOfProducts object with components, domain, and total."""
         self.products = products
         self.domain = domain
         self.total = total
         self.num_components = next(iter(products.values())).shape[0]
 
     def project(self, cols):
+        """Projects the mixture model onto a subset of specified columns."""
         products = {col: self.products[col] for col in cols}
         domain = self.domain.project(cols)
         return MixtureOfProducts(products, domain, self.total)
 
     def datavector(self, flatten=True):
+        """Computes the data vector (histogram) representation of the mixture distribution."""
         d = len(self.domain)
         letters = "bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"[:d]
         formula = ",".join(["a%s" % l for l in letters]) + "->" + "".join(letters)
@@ -77,6 +88,7 @@ class MixtureOfProducts:
         return ans.flatten() if flatten else ans
 
     def synthetic_data(self, rows=None):
+        """Generates synthetic tabular data samples from the mixture model."""
         total = rows or int(self.total)
         subtotal = total // self.num_components + 1
 
@@ -114,6 +126,7 @@ def mixture_of_products(
     letters = "bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
     def get_products(params):
+        """Converts raw parameters into per-attribute product distribution components via softmax."""
         products = {}
         idx = 0
         for col in domain:
@@ -123,6 +136,7 @@ def mixture_of_products(
         return products
 
     def marginals_from_params(params):
+        """Computes the marginals (as a CliqueVector) implied by the mixture parameters."""
         products = get_products(params)
         arrays = {}
         for cl in cliques:
@@ -134,6 +148,7 @@ def mixture_of_products(
         return CliqueVector(domain, cliques, arrays)
 
     def params_loss(params: jax.Array) -> float:
+        """Calculates the loss based on the marginals derived from current parameters."""
         mu = marginals_from_params(params)
         return loss_fn(mu)
 

--- a/src/mbi/experimental/public_support.py
+++ b/src/mbi/experimental/public_support.py
@@ -12,19 +12,26 @@ from scipy.sparse.linalg import lsmr
 from scipy.special import logsumexp
 import jax
 
-""" This file is experimental.  
-It is an attempt to re-implement and generalize the technique used in PMW^{Pub}.
-https://arxiv.org/pdf/2102.08598.pdf. This implementation is not optimized
-at all after the refactoring in 2024. Pull requestes are welcome on this file. 
+"""Experimental implementation of data synthesis using public data support.
 
-Notable differences:
-- Shares the same interface as other estimators in this repo.
-- Supports unbounded differential privacy, with automatic estimate of total
-- Supports arbitrary measurements over the data marginals, or more generally any MarginalLossFn.
+This module provides an experimental function, `public_support`, which aims to
+re-implement and generalize the technique presented in PMW^{Pub}
+(https://arxiv.org/pdf/2102.08598.pdf). The core idea is to re-weight a public
+dataset to match private marginal measurements, effectively generating synthetic
+data that respects privacy constraints while leveraging public information.
+
+Notable aspects and differences include:
+- Adherence to the common interface for estimators within this repository.
+- Support for unbounded differential privacy, including automatic total estimation.
+- Flexibility to handle arbitrary measurements via `MarginalLossFn`.
+
+Note: This implementation is experimental and not heavily optimized following
+refactoring. Contributions for improvement are welcome.
 """
 
 
 def entropic_mirror_descent(loss_and_grad, x0, total, iters=250):
+    """Performs optimization using entropic mirror descent to find optimal weights."""
     logP = np.log(x0 + np.nextafter(0, 1)) + np.log(total) - np.log(x0.sum())
     P = np.exp(logP)
     P = x0 * total / x0.sum()
@@ -54,6 +61,7 @@ def entropic_mirror_descent(loss_and_grad, x0, total, iters=250):
     return np.exp(logP)
 
 def _to_clique_vector(data, cliques):
+    """Converts a Dataset object into a CliqueVector representation of its marginals."""
     arrays = {}
     for cl in cliques:
         dom = data.domain.project(cl)
@@ -76,6 +84,7 @@ def public_support(
     cliques = loss_fn.cliques
 
     def loss_and_grad(weights):
+        """Calculates the loss and gradient with respect to the public data weights."""
         est = Dataset(public_data.df, public_data.domain, weights)
         mu = _to_clique_vector(est, cliques)
         loss, dL = loss_and_grad_mu(mu)

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -11,6 +11,7 @@ import numpy as np
 jax.config.update("jax_enable_x64", True)
 
 def _try_convert(values):
+    """Attempts to convert input to a JAX array, returning original if it fails."""
     try:
         return jnp.array(values)
     except:
@@ -56,18 +57,22 @@ class Factor:
     # Constructors
     @classmethod
     def zeros(cls, domain: Domain) -> "Factor":
+        """Creates a Factor object with all values initialized to zero."""
         return cls(domain, jnp.zeros(domain.shape))
 
     @classmethod
     def ones(cls, domain: Domain) -> "Factor":
+        """Creates a Factor object with all values initialized to one."""
         return cls(domain, jnp.ones(domain.shape))
 
     @classmethod
     def random(cls, domain: Domain) -> "Factor":
+        """Creates a Factor object with random values (uniform 0-1)."""
         return cls(domain, np.random.rand(*domain.shape))
 
     # Reshaping operations
     def transpose(self, attrs: Sequence[str]) -> "Factor":
+        """Rearranges the factor's axes according to the new attribute order."""
         if set(attrs) != set(self.domain.attrs):
             raise ValueError("attrs must be same as domain attributes")
         newdom = self.domain.project(attrs)
@@ -76,6 +81,7 @@ class Factor:
         return Factor(newdom, values)
 
     def expand(self, domain):
+        """Expands the factor's domain to include new attributes."""
         if not domain.contains(self.domain):
             raise ValueError("Expanded domain must contain domain.")
         dims = len(domain) - len(self.domain)
@@ -89,6 +95,7 @@ class Factor:
     def _aggregate(
         self, fn: Callable, attrs: Sequence[str] | None = None
     ) -> "Factor":
+        """Helper for aggregating values along specified attribute axes."""
         attrs = self.domain.attrs if attrs is None else attrs
         axes = self.domain.axes(attrs)
         values = fn(self.values, axis=axes)
@@ -96,15 +103,19 @@ class Factor:
         return Factor(newdom, values)
 
     def max(self, attrs: Sequence[str] | None = None) -> "Factor":
+        """Computes the maximum value along specified attribute axes."""
         return self._aggregate(jnp.max, attrs)
 
     def sum(self, attrs: Sequence[str] | None = None) -> "Factor":
+        """Computes the sum along specified attribute axes."""
         return self._aggregate(jnp.sum, attrs)
 
     def logsumexp(self, attrs: Sequence[str] | None = None) -> "Factor":
+        """Computes the log-sum-exp along specified attribute axes."""
         return self._aggregate(jax.scipy.special.logsumexp, attrs)
 
     def project(self, attrs: str | tuple[str, ...], log: bool = False) -> "Factor":
+        """Computes the marginal distribution by summing/logsumexp'ing out other attributes."""
         if isinstance(attrs, str):
             attrs = (attrs,)
         marginalized = self.domain.marginalize(attrs).attrs
@@ -113,17 +124,21 @@ class Factor:
 
     # Functions that operate element-wise
     def exp(self, out=None) -> "Factor":
+        """Applies element-wise exponentiation (jnp.exp) to the factor's values."""
         return Factor(self.domain, jnp.exp(self.values))
 
     def log(self, out=None) -> "Factor":
+        """Applies element-wise logarithm (jnp.log) to the factor's values."""
         return Factor(self.domain, jnp.log(self.values))
 
     def normalize(self, total: float = 1.0, log: bool = False) -> "Factor":
+        """Normalizes the factor so its values sum to `total` (or log-normalize)."""
         if log:
             return self + jnp.log(total) - self.logsumexp()
         return self * total / self.sum()
 
     def copy(self) -> "Factor":
+        """Returns a copy of the factor (potentially shallow due to JAX)."""
         return self
 
     def __float__(self):
@@ -133,6 +148,7 @@ class Factor:
 
     # Binary operations between two factors
     def _binaryop(self, fn: Callable, other: "Factor" | chex.Numeric) -> "Factor":
+        """Helper for applying binary operations between this factor and another factor or scalar."""
         if isinstance(other, chex.Numeric) and jnp.ndim(other) == 0:
             other = Factor(Domain([], []), other)
         newdom = self.domain.merge(other.domain)
@@ -182,4 +198,5 @@ class Factor:
         return jnp.sum(self.values * other.values)
 
     def datavector(self, flatten: bool = True) -> jax.Array:
+        """Returns the factor's values as a flattened vector or original array."""
         return self.values.flatten() if flatten else self.values

--- a/src/mbi/junction_tree.py
+++ b/src/mbi/junction_tree.py
@@ -1,3 +1,11 @@
+"""Utilities for constructing and working with junction trees.
+
+This module provides functions for building junction trees from a given domain
+and set of cliques. Junction trees are fundamental structures in graphical model
+inference, enabling efficient message passing algorithms. Functions include
+finding maximal cliques, determining message passing orders, graph triangulation,
+computing greedy elimination orders, and estimating model size.
+"""
 from collections import OrderedDict
 import itertools
 from typing import TypeAlias, Collection

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -1,3 +1,13 @@
+"""Defines loss functions based on linear measurements of marginals.
+
+This module provides structures and functions for defining and calculating loss
+based on potentially noisy linear measurements of marginal distributions. Key
+components include the `LinearMeasurement` class to represent individual
+measurements and the `MarginalLossFn` class to define loss functions over
+`CliqueVector` objects, enabling the evaluation of model fit against observed
+or noisy data. Utilities for clique manipulation and feasibility checks are also
+included.
+"""
 import attr
 from typing import Any, Callable, TypeAlias, Protocol, Mapping
 from .factor import Factor
@@ -64,6 +74,7 @@ def clique_mapping(
     return mapping
 
 def identity_fn(x: jax.Array) -> jax.Array:
+    """Simple identity function: returns the input `x` unchanged."""
     return x
 
 @functools.partial(
@@ -132,6 +143,7 @@ def from_linear_measurements(
 
 
 def primal_feasibility(mu: CliqueVector) -> chex.Numeric:
+    """Calculates the average L1 distance between overlapping marginals in `mu` (consistency)."""
     ans = 0
     count = 0
     for r in mu.cliques:

--- a/src/mbi/synthetic_data.py
+++ b/src/mbi/synthetic_data.py
@@ -1,3 +1,11 @@
+"""Generates synthetic tabular data from marginal distributions.
+
+This module provides the `from_marginals` function, which takes a `CliqueVector`
+representing marginal distributions and generates a synthetic `Dataset` that
+approximates the underlying joint distribution. It uses techniques based on
+junction trees and variable elimination orders to sample or round data points,
+ensuring consistency with the provided marginals.
+"""
 from .clique_vector import CliqueVector
 from .dataset import Dataset
 from . import junction_tree
@@ -19,6 +27,7 @@ def from_marginals(
     jtree, elimination_order = junction_tree.make_junction_tree(domain, cliques)
 
     def synthetic_col(counts, total):
+        """Generates a synthetic column by sampling or rounding based on counts and total."""
         if method == "sample":
             probas = counts / counts.sum()
             return np.random.choice(counts.size, total, True, probas)


### PR DESCRIPTION
This change completes the process of adding missing docstrings throughout the `src/mbi` directory and its subdirectories, addressing the original issue and incorporating your feedback regarding omissions.

Specifically, this commit adds docstrings for:
- Remaining methods in `factor.py` (transpose, expand, project, etc.)
- `contract` and `normalize` methods in `clique_vector.py`
- Helper function `synthetic_col` in `synthetic_data.py`
- Class, methods, and helper functions in `experimental/mixture_of_products.py`
- Helper functions in `experimental/public_support.py`

All functions, methods, properties, and modules targeted by the plan should now have appropriate docstrings.