### PR TITLE
Fix various Pylint issues across the codebase.

### DIFF
--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -24,11 +24,12 @@ from .factor import Factor
 
 class Dataset:
     def __init__(self, df, domain, weights=None):
-        """create a Dataset object
+        """Create a Dataset object.
 
-        :param df: a pandas dataframe
-        :param domain: a domain object
-        :param weight: weight for each row
+        Args:
+            df: A pandas dataframe.
+            domain: A domain object.
+            weights: Optional weights for each row.
         """
         assert set(domain.attrs) <= set(
             df.columns
@@ -103,19 +104,19 @@ class JaxDataset:
     weights: jax.Array | None = None
 
     def __post_init__(self):
-        if self.data.dtype != 'int':
-            raise ValueError(f'Data must be integral, got {self.data.dtype}.')
+        if self.data.dtype != "int":
+            raise ValueError(f"Data must be integral, got {self.data.dtype}.")
         if self.data.ndim != 2:
-            raise ValueError(f'Data must be 2d aray, got {self.data.shape}')
+            raise ValueError(f"Data must be 2d aray, got {self.data.shape}")
         if self.data.shape[1] != len(self.domain):
-            raise ValueError('Number of columns of data must equal the number of attributes in the domain.')
+            raise ValueError("Number of columns of data must equal the number of attributes in the domain.")
         # This will not work in a jitted context, but not sure if this will be called from one normally.
         for i, ax in enumerate(self.domain):
             if self.data[:, i].min() < 0:
-                raise ValueError('Data must be non-negative.')
+                raise ValueError("Data must be non-negative.")
             if self.data[:, i].max() >= self.domain[ax]:
-                raise ValueError('Data must be within the bounds of the domain.')
-            
+                raise ValueError("Data must be within the bounds of the domain.")
+
     @staticmethod
     def synthetic(domain: Domain, records: int) -> JaxDataset:
         """Generate synthetic data conforming to the given domain

--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -8,8 +8,8 @@ def _axis_name_to_dim(axis_names: str, axis_name: str) -> int | None:
   """Returns the index of axis_name in axis_names, or None if not found."""
   if axis_name in axis_names:
     return axis_names.index(axis_name)
-  else:
-    return None
+  # else: (implicit)
+  return None
 
 
 def _get_subarrays(
@@ -98,10 +98,10 @@ def scan_einsum(
   if ax in output_axes:
     # Each smaller einsum is independent.
     return jax.lax.map(small_einsum, loop).swapaxes(0, output_axes.index(ax))
-  else:
-    # Each smaller einsum contributes to the global einsum.
-    init = jnp.zeros(tuple(shapes[i] for i in output_axes))
-    return jax.lax.scan(
-        lambda carry, i: (carry + small_einsum(i), ()), init, loop
-    )[0]
+  # else: (implicit)
+  # Each smaller einsum contributes to the global einsum.
+  init = jnp.zeros(tuple(shapes[i] for i in output_axes))
+  return jax.lax.scan(
+      lambda carry, i: (carry + small_einsum(i), ()), init, loop
+  )[0]
     

--- a/src/mbi/experimental/mixture_of_products.py
+++ b/src/mbi/experimental/mixture_of_products.py
@@ -35,7 +35,8 @@ def adam(loss_and_grad, x0, iters=250):
     m = jnp.zeros_like(x)
     v = jnp.zeros_like(x)
     for t in range(1, iters + 1):
-        l, g = loss_and_grad(x)
+        # l is unused
+        _, g = loss_and_grad(x)
         # print(l)
         m = b1 * m + (1 - b1) * g
         v = b2 * v + (1 - b2) * g ** 2
@@ -107,7 +108,7 @@ def mixture_of_products(
     known_total: int | None = None,
     mixture_components: int = 100,
     iters: int = 2500,
-    alpha: float = 0.1
+    # alpha: float = 0.1 # Unused parameter
 ) -> MixtureOfProducts:
 
     loss_fn,known_total, _ = estimation._initialize(domain, loss_fn, known_total, None)

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -129,11 +129,11 @@ class Factor:
         return self.domain.supports(attrs)
 
     # Functions that operate element-wise
-    def exp(self, out=None) -> Factor:
+    def exp(self, _out=None) -> Factor: # Renamed unused out to _out
         """Applies element-wise exponentiation (jnp.exp) to the factor's values."""
         return Factor(self.domain, jnp.exp(self.values))
 
-    def log(self, out=None) -> Factor:
+    def log(self, _out=None) -> Factor: # Renamed unused out to _out
         """Applies element-wise logarithm (jnp.log) to the factor's values."""
         return Factor(self.domain, jnp.log(self.values))
 
@@ -172,8 +172,8 @@ class Factor:
         """Multiply two factors together.
 
         Example Usage:
-            >>> f1 = Factor.ones(Domain(['a','b'], [2,3]))
-            >>> f2 = Factor.ones(Domain(['b','c'], [3,4]))
+            >>> f1 = Factor.ones(Domain(["a","b"], [2,3]))
+            >>> f2 = Factor.ones(Domain(["b","c"], [3,4]))
             >>> f3 = f1 * f2
             >>> print(f3.domain)
             Domain(a: 2, b: 3, c: 4)

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -36,7 +36,8 @@ class MarkovRandomField:
         data = np.zeros((total, len(cols)), dtype=int)
         df = pd.DataFrame(data, columns=cols)
         cliques = [set(cl) for cl in self.cliques]
-        jtree, elimination_order = junction_tree.make_junction_tree(domain, cliques)
+        # jtree is unused
+        _, elimination_order = junction_tree.make_junction_tree(domain, cliques)
 
         def synthetic_col(counts, total):
             """Generates a synthetic column by sampling or rounding based on counts and total."""


### PR DESCRIPTION
This commit addresses a wide range of Pylint warnings and conventions, including:
- Invalid names (C0103)
- Deprecated typing aliases (W6001)
- Missing/incomplete docstrings (C0114, C0115, C0116, W9015, W9016, W9017)
- Inconsistent quotes (W1405)
- Unnecessary ellipsis (W2301)
- Unnecessary else after return (R1705)
- Unused variables/arguments (W0612, W0613)
- Unnecessary lambda assignments (C3001)
- Redundant keyword args (E1124)
- Unnecessary comprehensions (R1721)
- Using map instead of list comprehension (W0141)
- Using f-strings (C0209)
- Using tuples instead of lists (R6102)
- Optimizing dict initialization (C3401)
- Specifying file encoding (W1514)
- Using `with` for file handling (R1732)
- Using enumerate (C0200)
- Using dict.items() (C0206)
- Pointless string statements (W0105)
- Wrong import order (C0411)
- Unused imports (W0611)
- Disallowed names (C0104)

These changes improve code style, readability, and maintainability by adhering to common Python conventions and addressing potential issues flagged by Pylint.