### PR TITLE
feat: Add missing module-level docstrings

### DIFF
--- a/src/mbi/clique_utils.py
+++ b/src/mbi/clique_utils.py
@@ -1,3 +1,10 @@
+"""Utility functions for manipulating cliques (subsets of attributes).
+
+This module provides helper functions for common operations on cliques,
+such as finding maximal subsets and creating mappings between cliques and
+their maximal counterparts. Cliques are typically represented as tuples of
+attribute names (strings).
+"""
 from typing import TypeAlias
 
 Clique: TypeAlias = tuple[str, ...]

--- a/src/mbi/domain.py
+++ b/src/mbi/domain.py
@@ -1,3 +1,10 @@
+"""Defines the Domain class for representing attribute domains.
+
+This module provides the `Domain` class, which encapsulates a set of named
+attributes and their corresponding discrete sizes (shapes). It facilitates
+representing the structure of datasets and graphical models and supports
+various operations like projection, marginalization, and merging of domains.
+"""
 import functools
 from collections.abc import Iterator, Sequence
 

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -1,3 +1,11 @@
+"""Defines the MarkovRandomField class representing learned graphical models.
+
+This module provides the `MarkovRandomField` class, which encapsulates the
+results of learning a graphical model. It stores the learned potentials,
+the resulting marginal distributions, and the associated total count (e.g.,
+number of records). It also offers methods for querying marginals and
+generating synthetic data.
+"""
 from collections.abc import Sequence
 import attr
 import chex


### PR DESCRIPTION
Adds module-level docstrings to the following files to improve documentation coverage:
- src/mbi/clique_utils.py
- src/mbi/domain.py
- src/mbi/markov_random_field.py

These docstrings provide concise summaries of each module's purpose, following the conventions established in the repository.

Reviewed other potentially missing docstrings and confirmed that functions like `build_graph` in `approximate_oracles.py` are internal helpers and do not require docstrings per the contribution guidelines.