### PR TITLE
Add docstrings to dataclasses

### DIFF
--- a/src/mbi/clique_vector.py
+++ b/src/mbi/clique_vector.py
@@ -28,11 +28,19 @@ from .factor import Factor, Projectable
 )
 @attr.dataclass
 class CliqueVector:
-    """This is a convenience class for simplifying arithmetic over the
-    concatenated vector of marginals and potentials.
+    """Manages a collection of factors, each associated with a clique.
 
-    These vectors are represented as a dictionary mapping cliques (subsets of attributes)
-    to marginals/potentials (Factor objects)
+    This class provides a structure for holding and operating on multiple
+    `Factor` objects, where each factor corresponds to a clique (a subset of
+    attributes) within a larger domain. It's particularly useful in the context
+    of graphical models for representing sets of potentials or marginals.
+
+    Attributes:
+        domain (Domain): The overall domain that encompasses all cliques.
+        cliques (list[Clique]): A list of cliques (tuples of attribute names)
+            for which factors are stored.
+        arrays (dict[Clique, Factor]): A dictionary mapping each clique in
+            `cliques` to its corresponding `Factor` object.
     """
 
     domain: Domain

--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -98,6 +98,21 @@ class Dataset:
 )
 @attr.dataclass(frozen=True)
 class JaxDataset:
+    """Represents a dataset for use with JAX, optimized for JIT compilation.
+
+    This class is similar to the standard `Dataset` but is designed to work
+    efficiently within JAX's ecosystem, particularly with JIT-compiled functions.
+    It stores data as JAX arrays and ensures compatibility with JAX transformations.
+
+    Attributes:
+        data (jax.Array): A 2D JAX array where rows represent records and columns
+            represent attributes. The data should be integral.
+        domain (Domain): A `Domain` object describing the attributes and their
+            possible discrete values.
+        weights (jax.Array | None): An optional 1D JAX array representing the
+            weight for each record in the dataset. If None, all records are
+            assumed to have a weight of 1.
+    """
     data: jax.Array = attr.field(converter=jnp.asarray)
     domain: Domain
     weights: jax.Array | None = None

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -19,7 +19,22 @@ from .factor import Factor
 
 @chex.dataclass(frozen=True, kw_only=False)
 class MarkovRandomField:
-    """Represents a learned graphical model, storing potentials, marginals, and the total count."""
+    """Represents a learned graphical model.
+
+    This class encapsulates the components of a Markov Random Field that has been
+    learned from data. It stores the learned potentials, the resulting marginal
+    distributions over specified cliques, and the total count (e.g., number of
+    records or equivalent sample size) associated with the model.
+
+    Attributes:
+        potentials (CliqueVector): A `CliqueVector` containing the learned
+            potential functions for the cliques in the model.
+        marginals (CliqueVector): A `CliqueVector` containing the marginal
+            distributions for a set of cliques, derived from the potentials.
+        total (chex.Numeric): The total count or effective sample size
+            represented by the model. This is often used for scaling or
+            interpreting the marginals.
+    """
     potentials: CliqueVector
     marginals: CliqueVector
     total: chex.Numeric = 1


### PR DESCRIPTION
Added Google-style docstrings to the following dataclasses, focusing on detailing their attributes:

- JaxDataset in src/mbi/dataset.py
- CliqueVector in src/mbi/clique_vector.py
- MarkovRandomField in src/mbi/markov_random_field.py

Verified existing docstrings for:
- Domain in src/mbi/domain.py
- Factor in src/mbi/factor.py

Manual linting and formatting review was performed due to issues with the automated linting environment.