### PR TITLE
fix: allow empty cliques

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -225,6 +225,11 @@ def mirror_descent(
 def _optimize(loss_and_grad_fn, params, iters=250, callback_fn=lambda _: None):
     """Runs an optimization loop using Optax L-BFGS."""
 
+    if len(jax.tree.leaves(params)) == 0:
+        # Nothing to optimize
+        callback_fn(params)
+        return params
+
     def loss_fn(theta):
         return loss_and_grad_fn(theta)[0]
 

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -157,6 +157,9 @@ def brute_force_marginals(
     potentials: CliqueVector, total: float = 1, mesh: jax.sharding.Mesh | None = None
 ) -> CliqueVector:
     """Compute marginals from (log-space) potentials by materializing the full joint distribution."""
+    if len(potentials.cliques) == 0:
+        return CliqueVector(potentials.domain, [], {})
+
     P = (
         sum(potentials.arrays.values())
         .normalize(total, log=True)
@@ -179,6 +182,10 @@ def einsum_marginals(
 
     This is a "brute-force" approach and is not recommended in practice.
     """
+    # not strictly necessary, but consistent
+    if len(potentials.cliques) == 0:
+        return CliqueVector(potentials.domain, [], {})
+
     inputs = list(potentials.arrays.values())
     return CliqueVector(
         potentials.domain,
@@ -218,6 +225,9 @@ def message_passing_stable(
         The marginals of the graphical model, defined over the same set of cliques
         as the input potentials.  Each marginal is non-negative and sums to "total".
     """
+    if len(potentials.cliques) == 0:
+        return CliqueVector(potentials.domain, [], {})
+
     potentials = potentials.apply_sharding(mesh)
     domain, cliques = potentials.domain, potentials.cliques
 
@@ -270,6 +280,9 @@ def message_passing_shafer_shenoy(
         The marginals of the graphical model, defined over the same set of cliques
         as the input potentials.  Each marginal is non-negative and sums to "total".
     """
+    if len(potentials.cliques) == 0:
+        return CliqueVector(potentials.domain, [], {})
+
     potentials = potentials.apply_sharding(mesh)
     domain, cliques = potentials.domain, potentials.cliques
 
@@ -317,7 +330,7 @@ def message_passing_fast(
 ) -> CliqueVector:
     """Compute marginals from (log-space) potentials using the message passing algorithm.
 
-    This implementation leverages the "einsum" primitve to compute clique marginals
+    This implementation leverages the "einsum" primitive to compute clique marginals
     without materializing marginals over the super cliques first (nodes in the
     junction tree).  It can be much faster and more memory efficient than
     message_passing_stable, but there are some cases where this
@@ -337,6 +350,9 @@ def message_passing_fast(
         The marginals of the graphical model, defined over the same set of cliques
         as the input potentials.  Each marginal is non-negative and sums to "total".
     """
+    if len(potentials.cliques) == 0:
+        return CliqueVector(potentials.domain, [], {})
+
     potentials = potentials.apply_sharding(mesh)
     domain, cliques = potentials.active_domain, potentials.cliques
 

--- a/test/test_approximate_oracles.py
+++ b/test/test_approximate_oracles.py
@@ -20,7 +20,7 @@ _CLIQUE_SETS = [
     [("a", "b", "c", "d")],  # full materialization
     [("d",)],  # singleton
     [("a", "b", "c"), ("c", "b", "a"), ("b", "d")],  # (permuted) duplicates
-    # [],  empty is currently not supported
+    [],  # trivial empty set
 ]
 
 

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -18,6 +18,7 @@ _CLIQUE_SETS = [
     [("a", "b", "c", "d")],  # full materialization
     [("d",)],  # singleton
     [("a", "b", "c"), ("c", "b", "a"), ("b", "d")],  # (permuted) duplicates
+    [],  # trivial empty set
 ]
 
 

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -64,7 +64,7 @@ _CLIQUE_SETS = [
     [("d",)],  # singleton
     [("a", "b", "c"), ("c", "b", "a"), ("b", "d")],  # (permuted) duplicates
     [("a", "b"), ("c", "d")],  # disconnected
-    # [],  empty is currently not supported
+    [],  # trivial empty set
 ]
 
 _ALL_CLIQUES = list(itertools.chain.from_iterable(


### PR DESCRIPTION
Supporting this makes downstream code in OpenDP a smidge simpler. Seems to have regressed since PyPI 1.0.