### PR TITLE
fix: l2 loss stddev scaling

### DIFF
--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -131,11 +131,11 @@ def from_linear_measurements(
         loss = 0.0
         for M in measurements:
             mu = marginals.project(M.clique)
-            diff = M.query(mu) - M.noisy_measurement
+            diff = (M.query(mu) - M.noisy_measurement) / M.stddev
             if norm == "l2":
-                loss += (diff @ diff) / (2 * M.stddev**2)
+                loss += (diff @ diff) / 2
             elif norm == "l1":
-                loss += jnp.sum(jnp.abs(diff)) / M.stddev
+                loss += jnp.sum(jnp.abs(diff))
 
         if normalize:
             total = marginals.project(()).datavector(flatten=False)

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -133,7 +133,7 @@ def from_linear_measurements(
             mu = marginals.project(M.clique)
             diff = M.query(mu) - M.noisy_measurement
             if norm == "l2":
-                loss += (diff @ diff) / (2 * M.stddev)
+                loss += (diff @ diff) / (2 * M.stddev**2)
             elif norm == "l1":
                 loss += jnp.sum(jnp.abs(diff)) / M.stddev
 

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -131,9 +131,11 @@ def from_linear_measurements(
         loss = 0.0
         for M in measurements:
             mu = marginals.project(M.clique)
-            diff = (M.query(mu) - M.noisy_measurement) / M.stddev
+            # avoid introducing inf/nan from invariants
+            stddev = jnp.maximum(M.stddev, 1e-12)
+            diff = (M.query(mu) - M.noisy_measurement) / stddev
             if norm == "l2":
-                loss += (diff @ diff) / 2
+                loss += 0.5 * jnp.vdot(diff, diff)
             elif norm == "l1":
                 loss += jnp.sum(jnp.abs(diff))
 

--- a/test/test_marginal_loss.py
+++ b/test/test_marginal_loss.py
@@ -7,13 +7,13 @@ from mbi.clique_vector import CliqueVector
 
 class TestMarginalLoss(unittest.TestCase):
     def test_l2_lipschitz_disjoint(self):
-        """Verify that Lipschitz constant is max(1/stddev) for disjoint measurements."""
+        """Verify that Lipschitz constant is max(1/stddev^2) for disjoint measurements."""
         domain = Domain.fromdict({'a': 10, 'b': 10, 'c': 10})
 
         # Create disjoint measurements
-        # m1 on ('a',) with stddev 0.5 -> 1/stddev = 2.0
-        # m2 on ('b',) with stddev 0.2 -> 1/stddev = 5.0
-        # m3 on ('c',) with stddev 1.0 -> 1/stddev = 1.0
+        # m1 on ('a',) with stddev 0.5 -> 1/stddev^2 = 4.0
+        # m2 on ('b',) with stddev 0.2 -> 1/stddev^2 = 25.0
+        # m3 on ('c',) with stddev 1.0 -> 1/stddev^2 = 1.0
 
         m1 = LinearMeasurement(jnp.zeros(10), ('a',), stddev=0.5)
         m2 = LinearMeasurement(jnp.zeros(10), ('b',), stddev=0.2)
@@ -25,14 +25,14 @@ class TestMarginalLoss(unittest.TestCase):
         loss_fn = from_linear_measurements(measurements, norm='l2', domain=domain)
 
         calculated_L = loss_fn.lipschitz
-        expected_L = max(1.0 / m.stddev for m in measurements)
+        expected_L = max(1.0 / m.stddev**2 for m in measurements)
 
         # We expect calculated_L to be very close to expected_L
         # Using a slightly looser tolerance because power iteration is approximate
         self.assertAlmostEqual(calculated_L, expected_L, delta=1e-3)
 
     def test_l2_lipschitz_single(self):
-        """Verify that Lipschitz constant is 1/stddev for a single measurement."""
+        """Verify that Lipschitz constant is 1/stddev^2 for a single measurement."""
         domain = Domain.fromdict({'a': 10})
         m1 = LinearMeasurement(jnp.zeros(10), ('a',), stddev=0.5)
         measurements = [m1]
@@ -40,7 +40,7 @@ class TestMarginalLoss(unittest.TestCase):
         loss_fn = from_linear_measurements(measurements, norm='l2', domain=domain)
 
         calculated_L = loss_fn.lipschitz
-        expected_L = 1.0 / m1.stddev
+        expected_L = 1.0 / m1.stddev**2
 
         self.assertAlmostEqual(calculated_L, expected_L, delta=1e-3)
 


### PR DESCRIPTION
We know that $y \mid x \sim \mathcal{N}(x,\ \sigma^2 I)$. So

```math
p(y\mid x)=(2\pi\sigma^2)^{-n/2}\exp\left(-\frac{1}{2\sigma^2}\,\lVert y-x\rVert_2^2\right),
```
therefore (ignoring the constant term)
```math
-\log p(y\mid x)\equiv\frac{1}{2\sigma^2}\,\lVert y-x\rVert_2^2 = \texttt{(diff @ diff) / (2 * M.stddev**2)}.
```

It's currently $1/\sigma$, not $1/\sigma^2$, meaning high-variance estimates are given too much importance.

Let me know if I've misunderstood your API!

EDIT: The code is consistent with the distribution estimation problem as written in the AIM paper section 2.3, which weights squared errors by $1/\sigma$ (and $\sigma$ is stddev). But under the paper's stated noise model the MLE for gaussian noise should weight squared errors by $1/\sigma^2$ (ignoring the half). With this change you then get equivalence to inverse variance weighting (known to be MLE for gaussian).

In AIM, this means later rounds won't improve utility as much as they should if they overlap with a query in an earlier round, which repeatedly triggers the "not significant" criterion and pushes the budget up until early exhaustion. Effect might also be negligible though, haven't tested.