### PR TITLE
feat(einsum): Add custom_einsum for arbitrary semiring reductions

### DIFF
--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -141,7 +141,7 @@ def _infer_shapes(
 
 
 def scan_einsum(
-    formula: str, *arrays: jax.Array, sequential: str = "", **kwargs
+    formula: str, *arrays: jax.Array, sequential: str = "", einsum_fn: Callable = jnp.einsum, **kwargs
 ) -> jax.Array:
     """Einsum implementation that allows sequential execution across any axes.
 
@@ -157,13 +157,14 @@ def scan_einsum(
         and the results are accumulated.  When sequential is a string with
         multiple axis names, sequential einsums are executed along all axis
         names given.
-      **kwargs: Keyword arguments to pass to jnp.einsum in the base case.
+      einsum_fn: The underlying einsum function to use (defaults to jnp.einsum).
+      **kwargs: Keyword arguments to pass to the underlying einsum function.
 
     Returns:
       The einsum result.
     """
     if not sequential:
-        return jnp.einsum(formula, *arrays, **kwargs)
+        return einsum_fn(formula, *arrays, **kwargs)
 
     ax = sequential[0]
     if ax not in formula:
@@ -181,7 +182,7 @@ def scan_einsum(
 
     def small_einsum(i):
         new_arrays = _get_subarrays(arrays, ax_dims, i)
-        return scan_einsum(new_formula, *new_arrays, sequential=sequential[1:])
+        return scan_einsum(new_formula, *new_arrays, sequential=sequential[1:], einsum_fn=einsum_fn, **kwargs)
 
     if ax in output_axes:
         # Each smaller einsum is independent.

--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -141,7 +141,11 @@ def _infer_shapes(
 
 
 def scan_einsum(
-    formula: str, *arrays: jax.Array, sequential: str = "", einsum_fn: Callable = jnp.einsum, **kwargs
+    formula: str,
+    *arrays: jax.Array,
+    sequential: str = "",
+    einsum_fn: Callable = jnp.einsum,
+    **kwargs
 ) -> jax.Array:
     """Einsum implementation that allows sequential execution across any axes.
 
@@ -182,7 +186,9 @@ def scan_einsum(
 
     def small_einsum(i):
         new_arrays = _get_subarrays(arrays, ax_dims, i)
-        return scan_einsum(new_formula, *new_arrays, sequential=sequential[1:], einsum_fn=einsum_fn, **kwargs)
+        return scan_einsum(
+            new_formula, *new_arrays, sequential=sequential[1:], einsum_fn=einsum_fn, **kwargs
+        )
 
     if ax in output_axes:
         # Each smaller einsum is independent.
@@ -217,8 +223,8 @@ def custom_einsum(subscripts, *operands, combine_fn=jnp.multiply, reduce_fn=jnp.
                 custom_dot_general,
                 combine_fn=combine_fn,
                 # We must use jnp.sum here instead of reduce_fn because if reduce_fn contains
-                # a reduce_sum internally (like logsumexp), it would cause infinite recursion.
-                reduce_fn=jnp.sum  # Dummy reduction to intercept
+                # a reduce_sum internally (like logsumexp), it would cause problems.
+                reduce_fn=jnp.sum
             )
         )
     closed_jaxpr = jax.make_jaxpr(f)(*operands)
@@ -231,11 +237,14 @@ def custom_einsum(subscripts, *operands, combine_fn=jnp.multiply, reduce_fn=jnp.
             env[constvar] = const
 
         for eqn in closed_jaxpr.jaxpr.eqns:
-            invals = [var.val if isinstance(var, Literal) else env[var] for var in eqn.invars]
+            invals = [
+                var.val if isinstance(var, Literal) else env[var] for var in eqn.invars
+            ]
             if eqn.primitive.name == 'reduce_sum':
                 axes = eqn.params['axes']
                 outvals = [reduce_fn(invals[0], axis=axes)]
             else:
+                # Many JAX primitives do not implement get_bind_params
                 try:
                     bind_params = eqn.primitive.get_bind_params(eqn.params)
                     if isinstance(bind_params, tuple) and len(bind_params) == 2:
@@ -253,7 +262,10 @@ def custom_einsum(subscripts, *operands, combine_fn=jnp.multiply, reduce_fn=jnp.
             for outvar, outval in zip(eqn.outvars, outvals):
                 env[outvar] = outval
 
-        ans = [var.val if isinstance(var, Literal) else env[var] for var in closed_jaxpr.jaxpr.outvars]
+        ans = [
+            var.val if isinstance(var, Literal) else env[var]
+            for var in closed_jaxpr.jaxpr.outvars
+        ]
         return ans[0] if len(ans) == 1 else tuple(ans)
 
     return eval_rewritten(*operands)

--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -1,6 +1,8 @@
 """Prototype implementation of scan-based einsum implementation."""
 
 from collections.abc import Callable, Sequence
+import functools
+from jax._src.core import Literal
 
 import jax
 import jax.numpy as jnp
@@ -188,10 +190,6 @@ def scan_einsum(
     # Each smaller einsum contributes to the global einsum.
     init = jnp.zeros(tuple(shapes[i] for i in output_axes))
     return jax.lax.scan(lambda carry, i: (carry + small_einsum(i), ()), init, loop)[0]
-
-import functools
-from jax._src.core import Literal
-
 
 def custom_einsum(subscripts, *operands, combine_fn=jnp.multiply, reduce_fn=jnp.sum):
     """Custom einsum function that uses the given combine and reduce functions.

--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -188,3 +188,71 @@ def scan_einsum(
     # Each smaller einsum contributes to the global einsum.
     init = jnp.zeros(tuple(shapes[i] for i in output_axes))
     return jax.lax.scan(lambda carry, i: (carry + small_einsum(i), ()), init, loop)[0]
+
+import functools
+from jax._src.core import Literal
+
+
+def custom_einsum(subscripts, *operands, combine_fn=jnp.multiply, reduce_fn=jnp.sum):
+    """Custom einsum function that uses the given combine and reduce functions.
+
+    This function acts like jnp.einsum, but intercepts the reduction operations and
+    replaces them with the provided `reduce_fn`. The `combine_fn` replaces the
+    standard multiplication. This allows for einsum operations over arbitrary
+    semirings like (+, max), (+, logsumexp), etc.
+
+    Args:
+        subscripts: The einsum subscripts string.
+        *operands: The arrays to compute the einsum over.
+        combine_fn: A callable that combines two arrays.
+        reduce_fn: A callable that reduces an array along a given axis.
+
+    Returns:
+        The result of the custom einsum operation.
+    """
+    def f(*args):
+        return jnp.einsum(
+            subscripts,
+            *args,
+            _dot_general=functools.partial(
+                custom_dot_general,
+                combine_fn=combine_fn,
+                reduce_fn=jnp.sum  # Dummy reduction to intercept
+            )
+        )
+    closed_jaxpr = jax.make_jaxpr(f)(*operands)
+
+    def eval_rewritten(*args):
+        env = {}
+        for invar, arg in zip(closed_jaxpr.jaxpr.invars, args):
+            env[invar] = arg
+        for constvar, const in zip(closed_jaxpr.jaxpr.constvars, closed_jaxpr.consts):
+            env[constvar] = const
+
+        for eqn in closed_jaxpr.jaxpr.eqns:
+            invals = [var.val if isinstance(var, Literal) else env[var] for var in eqn.invars]
+            if eqn.primitive.name == 'reduce_sum':
+                axes = eqn.params['axes']
+                outvals = [reduce_fn(invals[0], axis=axes)]
+            else:
+                try:
+                    bind_params = eqn.primitive.get_bind_params(eqn.params)
+                    if isinstance(bind_params, tuple) and len(bind_params) == 2:
+                        subfuns, bind_params = bind_params
+                    else:
+                        subfuns = []
+                except AttributeError:
+                    subfuns = []
+                    bind_params = eqn.params
+                ans = eqn.primitive.bind(*subfuns, *invals, **bind_params)
+                if eqn.primitive.multiple_results:
+                    outvals = ans
+                else:
+                    outvals = [ans]
+            for outvar, outval in zip(eqn.outvars, outvals):
+                env[outvar] = outval
+
+        ans = [var.val if isinstance(var, Literal) else env[var] for var in closed_jaxpr.jaxpr.outvars]
+        return ans[0] if len(ans) == 1 else tuple(ans)
+
+    return eval_rewritten(*operands)

--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -217,6 +217,8 @@ def custom_einsum(subscripts, *operands, combine_fn=jnp.multiply, reduce_fn=jnp.
             _dot_general=functools.partial(
                 custom_dot_general,
                 combine_fn=combine_fn,
+                # We must use jnp.sum here instead of reduce_fn because if reduce_fn contains
+                # a reduce_sum internally (like logsumexp), it would cause infinite recursion.
                 reduce_fn=jnp.sum  # Dummy reduction to intercept
             )
         )

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -421,5 +421,37 @@ class TestScanEinsum(unittest.TestCase):
         )
 
 
+    def test_custom_einsum_max(self):
+        from mbi.einsum import custom_einsum
+        x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        y = jnp.array([[5.0, 6.0], [7.0, 8.0]])
+        # 'ij,jk->ik' with (+, max)
+        actual = custom_einsum('ij,jk->ik', x, y, combine_fn=jnp.add, reduce_fn=jnp.max)
+        expected = jnp.array([[9.0, 10.0], [11.0, 12.0]])
+        self.assertArraysAllClose(expected, actual, msg="custom_einsum with jnp.max")
+
+    def test_custom_einsum_logsumexp(self):
+        from mbi.einsum import custom_einsum
+        from jax.scipy.special import logsumexp
+        x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        y = jnp.array([[5.0, 6.0], [7.0, 8.0]])
+        actual = custom_einsum('ij,jk->ik', x, y, combine_fn=jnp.add, reduce_fn=logsumexp)
+        expected = jnp.array([
+            [logsumexp(jnp.array([6.0, 9.0])), logsumexp(jnp.array([7.0, 10.0]))],
+            [logsumexp(jnp.array([8.0, 11.0])), logsumexp(jnp.array([9.0, 12.0]))]
+        ])
+        self.assertArraysAllClose(expected, actual, msg="custom_einsum with logsumexp")
+
+    def test_custom_einsum_vmap_jit(self):
+        from mbi.einsum import custom_einsum
+        def f(x, y):
+            return custom_einsum('ij,jk->ik', x, y, combine_fn=jnp.add, reduce_fn=jnp.max)
+        f = jax.jit(jax.vmap(f, in_axes=(0, 0)))
+        x = jnp.array([[[1.0, 2.0], [3.0, 4.0]]])
+        y = jnp.array([[[5.0, 6.0], [7.0, 8.0]]])
+        actual = f(x, y)
+        expected = jnp.array([[[9.0, 10.0], [11.0, 12.0]]])
+        self.assertArraysAllClose(expected, actual, msg="custom_einsum vmap and jit")
+
 if __name__ == "__main__":
     unittest.main(argv=["first-arg-is-ignored"], exit=False)


### PR DESCRIPTION
This PR implements `custom_einsum`, a function that generalizes `jnp.einsum` to operate over arbitrary semirings such as `(+, max)` and `(+, logsumexp)`.

It does so by dynamically tracing a standard `jnp.einsum` invocation with `jax.make_jaxpr`, extracting the computed jaxpr, and rewriting it using a custom evaluator that seamlessly replaces standard summation reductions with the user-provided `reduce_fn`. The custom einsum function fully supports JAX transformations like `vmap` and `jit` correctly by operating dynamically on the bound tracer elements.

Unit tests have been added to `test/test_einsum.py` confirming correct values and properties when running `jnp.max` and `logsumexp` alongside `vmap`/`jit` transformations.

---
*PR created automatically by Jules for task [12428085751752372026](https://jules.google.com/task/12428085751752372026) started by @ryan112358*