### PR TITLE
docs: fix typos, broken link, and outdated version pin

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,13 +3,13 @@
 `mbi` requires Python>=3.9. You can install `mbi` from PyPI by running:
 
 ```
-pip install mbi==1.0.0
+pip install mbi
 ```
 
-If you are interested in making changes or contributing to `mbi`, you can install it from source:
+If you are interested in making changes or contributing to `mbi`, you can install it from source in editable mode:
 
 ```
 git clone https://github.com/ryan112358/mbi.git
 cd mbi
-pip install .
+pip install -e ".[dev]"
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -16,12 +16,12 @@ by combining all sources of information in a principled manner (e.g., by maximiz
 Published articles: 
 
 - McKenna, Ryan, Terrance Liu, "A simple recipe for private synthetic data generation."
-[https://differentialprivacy.org/synth-data-1/](https://differentialprivacy.org/synth-data-1)
+[https://differentialprivacy.org/synth-data-1/](https://differentialprivacy.org/synth-data-1/)
 
 - McKenna, Ryan, Daniel Sheldon, and Gerome Miklau. 2021. "Winning the NIST Contest: A scalable and general approach to differentially private synthetic data."  *Journal of Privacy and Confidentiality* 11 (3).  [![DOI:10.29012/jpc.778](https://zenodo.org/badge/DOI/10.29012/jpc.778.svg)](https://doi.org/10.29012/jpc.778) 
 
 - McKenna, Ryan, Daniel Sheldon, and Gerome Miklau. "Graphical-model based estimation and inference for differential privacy." In Proceedings of the 36th International Conference on Machine Learning. 2019. https://arxiv.org/abs/1901.09136
 
-- McKenna, Ryan, Siddhant Pradhan, Daniel Sheldon, and Gerome Miklau. "Relaxed Marginal Consistency for Differentially Private Query Answering".  In Proceedings of the 35th Conference on Nueral Information Processing Systems, 2021. https://arxiv.org/pdf/2109.06153
+- McKenna, Ryan, Siddhant Pradhan, Daniel Sheldon, and Gerome Miklau. "Relaxed Marginal Consistency for Differentially Private Query Answering".  In Proceedings of the 35th Conference on Neural Information Processing Systems, 2021. https://arxiv.org/pdf/2109.06153
 
 - McKenna, Ryan, Brett Mullins, Daniel Sheldon, and Gerome Miklau. "AIM: An Adaptive and Iterative Mechanism for Differentially Private Synthetic Data".  In Proceedings of the VLDB Endowment, Vol 15, 2023. https://arxiv.org/abs/2201.12677


### PR DESCRIPTION
Small documentation cleanup:

- **`docs/installation.md`**: Remove hardcoded version pin (`pip install mbi==1.0.0` → `pip install mbi`) so docs stay current with new releases. Recommend editable install with `[dev]` extras for contributors.
- **`docs/introduction.md`**: Fix broken blog post link (was missing trailing `/`, causing a 404).
- **`docs/introduction.md`**: Fix typo *Nueral* → *Neural* in the NeurIPS 2021 citation.