### PR TITLE
config: align pydocstyle rules with JAX Privacy

### DIFF
--- a/.pydocstylerc
+++ b/.pydocstylerc
@@ -1,3 +1,3 @@
 [pydocstyle]
 convention = google
-
+add_ignore = D101,D102,D103,D105,D202,D402


### PR DESCRIPTION
Align pydocstyle configuration with JAX Privacy by ignoring D101, D102, D103, D105, D202, and D402. These rules are overly strict for an open-source library and cause unnecessary noise. The Google convention is still enforced for all other docstring rules.