### PR TITLE
config: add flake8 with selective rules matching JAX Privacy

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 80
+select = E9,F63,F7,F82,E225,E251

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "yapf",
     "pylint",
     "pydocstyle",
+    "flake8",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
Add flake8 configuration matching JAX Privacy's selective rule set. Only checks for critical issues: runtime errors (E9), invalid __all__ (F63), syntax errors (F7), undefined names (F82), missing whitespace around operators (E225), and unexpected spaces around defaults (E251). Also adds flake8 to dev dependencies.