### PR TITLE
ci: enable lint checks and split into lint/test jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test on Ubuntu
+name: Continuous Integration
 
 on:
   push:
@@ -10,14 +10,47 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Check formatting with pyink
+        run: |
+          pyink --check --diff src test mechanisms examples
+
+      - name: Lint with flake8
+        run: |
+          flake8 src test mechanisms examples
+
+      - name: Check docstrings with pydocstyle
+        run: |
+          pydocstyle src/mbi/
+
+      - name: Lint with pylint
+        run: |
+          pylint src/mbi/
+
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -26,18 +59,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[dev,docs]
           pip install pandas
-
-      # - name: Check formatting with yapf
-        # run: |
-        #  yapf --diff --recursive --exit-code src test mechanisms examples setup.py docs/conf.py
-
-      # - name: Lint with pylint
-        # run: |
-        #  pylint src test mechanisms examples setup.py docs/conf.py
-
-      # - name: Check docstrings with pydocstyle
-        #run: |
-        #  pydocstyle src test mechanisms examples setup.py docs/conf.py
 
       - name: Set PYTHONPATH
         run: |
@@ -50,7 +71,7 @@ jobs:
       - name: Doc tests
         run: |
           pytest --doctest-modules src/mbi/*.py
-  
+
       - name: Type checking
         run: |
           pytype src/mbi/*.py

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -30,8 +30,7 @@ Clique: TypeAlias = tuple[str, ...]
 
 
 class StatefulMarginalOracle(Protocol):
-    """
-    Defines the callable signature for stateful marginal oracle functions.
+    """Defines the callable signature for stateful marginal oracle functions.
 
     A stateful marginal oracle computes (approximate) marginals from
     log-space potentials while also managing an internal state, often
@@ -46,8 +45,7 @@ class StatefulMarginalOracle(Protocol):
         state: Any = None,
         mesh: jax.sharding.Mesh | None = None,
     ) -> tuple[CliqueVector, Any]:
-        """
-        Computes marginals from log-space potentials and manages state.
+        """Computes marginals from log-space potentials and manages state.
 
         Args:
             potentials: A CliqueVector representing the log-space potentials

--- a/src/mbi/clique_utils.py
+++ b/src/mbi/clique_utils.py
@@ -13,7 +13,7 @@ Clique: TypeAlias = tuple[str, ...]
 
 
 def powerset(iterable):
-    "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
+    """Powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)."""
     s = list(iterable)
     return itertools.chain.from_iterable(
         itertools.combinations(s, r) for r in range(len(s) + 1)

--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -66,7 +66,7 @@ class Dataset:
         domain: Domain,
         weights: np.ndarray | None = None,
     ):
-        """create a Dataset object
+        """Create a Dataset object.
 
         :param data: a numpy array (n x d) or a dictionary of 1d arrays (length n), keyed by attribute.
         :param domain: a domain object
@@ -126,7 +126,7 @@ class Dataset:
 
     @staticmethod
     def synthetic(domain: Domain, N: int) -> Dataset:
-        """Generate synthetic data conforming to the given domain
+        """Generate synthetic data conforming to the given domain.
 
         :param domain: The domain object
         :param N: the number of individuals
@@ -137,7 +137,7 @@ class Dataset:
 
     @staticmethod
     def load(path: str, domain: str | Domain) -> Dataset:
-        """Load data into a dataset object
+        """Load data into a dataset object.
 
         :param path: path to csv file
         :param domain: path to json file encoding the domain information
@@ -175,7 +175,7 @@ class Dataset:
     def project(
         self, cols: int | str | Sequence[str] | Sequence[int]
     ) -> Factor:
-        """project dataset onto a subset of columns"""
+        """Project dataset onto a subset of columns."""
         if isinstance(cols, (str, int)):
             cols = [cols]
 
@@ -198,7 +198,7 @@ class Dataset:
         return self._n
 
     def datavector(self, flatten: bool = True) -> NDArray:
-        """return the database in vector-of-counts form"""
+        """Return the database in vector-of-counts form."""
         dims = self.domain.shape
         if len(dims) == 0:
             result = self.weights.sum()
@@ -211,8 +211,7 @@ class Dataset:
         return counts if flatten else counts.reshape(dims)
 
     def compress(self, mapping: dict[str, np.ndarray]) -> Dataset:
-        """
-        Compresses the dataset by mapping domain elements to a smaller domain.
+        """Compress the dataset by mapping domain elements to a smaller domain.
 
         Args:
             mapping: A dictionary where keys are attribute names and values are 1D arrays.
@@ -249,8 +248,8 @@ class Dataset:
         return Dataset(new_data, new_domain, self.weights)
 
     def decompress(self, mapping: dict[str, np.ndarray]) -> Dataset:
-        """
-        Decompresses the dataset by reversing the mapping.
+        """Decompress the dataset by reversing the mapping.
+
         Since the mapping is surjective, the reverse mapping is one-to-many.
         We sample uniformly from the possible original values.
 
@@ -332,7 +331,7 @@ class JaxDataset:
 
     @staticmethod
     def synthetic(domain: Domain, records: int) -> JaxDataset:
-        """Generate synthetic data conforming to the given domain
+        """Generate synthetic data conforming to the given domain.
 
         :param domain: The domain object
         :param records: the number of individuals
@@ -346,7 +345,7 @@ class JaxDataset:
         return JaxDataset(data, domain)
 
     def project(self, cols: str | Sequence[str]) -> Factor:
-        """project dataset onto a subset of columns"""
+        """Project dataset onto a subset of columns."""
         if isinstance(cols, (str, int)):
             cols = [cols]
 

--- a/src/mbi/domain.py
+++ b/src/mbi/domain.py
@@ -125,6 +125,7 @@ class Domain:
 
         Args:
           attrs: the attributes to marginalize out.
+
         Returns:
           the marginalized Domain object
         """
@@ -210,6 +211,7 @@ class Domain:
 
         Args:
           attributes: A subset of attributes whose total size should be returned.
+
         Returns:
           the total size of the domain
         """

--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -126,6 +126,7 @@ def _get_subarrays(
       ax_dims: A list of axis dimensions to slice along, or None if no slicing is
         needed.
       index: The index to slice at.
+
     Returns:
       A list of arrays, each of which is a slice of the corresponding input array.
     """

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -34,8 +34,7 @@ from .markov_random_field import MarkovRandomField
 
 
 class Estimator(Protocol):
-    """
-    Defines the callable signature for marginal-based estimators.
+    """Defines the callable signature for marginal-based estimators.
 
     An estimator estimates a discrete distribution, or more generally
     a `Projectable' object from a loss function defined over it's
@@ -58,8 +57,7 @@ class Estimator(Protocol):
         known_total: float | None = None,
         **kwargs: Any,
     ) -> Projectable:
-        """
-        Estimate a Projectable from noisy marginal measurements.
+        """Estimate a Projectable from noisy marginal measurements.
 
         Args:
             domain: The Domain object specifying the attributes and their

--- a/src/mbi/experimental/__init__.py
+++ b/src/mbi/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental MBI modules."""

--- a/src/mbi/experimental/mixture_of_products.py
+++ b/src/mbi/experimental/mixture_of_products.py
@@ -55,6 +55,7 @@ def synthetic_col(counts, total):
 class MixtureOfProducts:
 
     def __init__(self, products, domain, total):
+        """Initialize a MixtureOfProducts model."""
         self.products = products
         self.domain = domain
         self.total = total

--- a/src/mbi/experimental/public_support.py
+++ b/src/mbi/experimental/public_support.py
@@ -1,3 +1,5 @@
+"""Estimation with public data support constraints."""
+
 import jax
 import numpy as np
 from scipy.special import logsumexp

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -1,3 +1,5 @@
+"""Factor representation for discrete probability distributions."""
+
 from __future__ import annotations
 
 import functools

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -29,8 +29,7 @@ _EINSUM_LETTERS = list(string.ascii_lowercase) + list(string.ascii_uppercase)
 
 
 class MarginalOracle(Protocol):
-    """
-    Defines the callable signature for stateless marginal oracle functions.
+    """Defines the callable signature for stateless marginal oracle functions.
 
     A marginal oracle consumes log-space potentials (CliqueVector) of
     a graphical model and returns its marginals (CliqueVector).  The
@@ -57,8 +56,7 @@ class MarginalOracle(Protocol):
         total: float = 1.0,
         mesh: jax.sharding.Mesh | None = None,
     ) -> CliqueVector:
-        """
-        Computes marginals from log-space potentials.
+        """Computes marginals from log-space potentials.
 
         Args:
             potentials: A CliqueVector representing the log-space potentials
@@ -565,7 +563,7 @@ def calculate_many_marginals(
     belief_propagation_oracle: MarginalOracle = message_passing_stable,
     mesh: jax.sharding.Mesh | None = None,
 ) -> CliqueVector:
-    """Calculates marginals for all the projections in the list using
+    """Calculate marginals for all projections using belief propagation.
 
     Implements Algorithm from section 10.3 in Koller and Friedman.
     This method may be faster than calling variable_elimination many times.


### PR DESCRIPTION
## Summary

Enable all previously-commented-out lint checks in GitHub Actions CI, matching JAX Privacy's CI structure.

### Changes to `.github/workflows/main.yml`

**New `lint` job** (runs in parallel with tests):
- **pyink** formatting check (replaces the commented-out yapf check)
- **flake8** (new — selective rules matching JAX Privacy)
- **pydocstyle** (Google convention)
- **pylint** (with trimmed config)
- 15-minute timeout

**Updated `test` job**:
- Same as before (pytest, doctests, pytype)
- Updated GitHub Actions to v4/v5

### Merge Order

> ⚠️ This PR should be merged **last**, after the following PRs land:
> - #107 (pydocstyle config alignment)
> - #108 (flake8 config)
> - #109 (pylintrc trimming)
> - #110 (code quality fixes)
> - #111 (pyink formatting)
>
> Merging this PR before those will cause CI failures.