### PR TITLE
fix: code cleanup (remove dead code, simplify, un-ignore experimental)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@
 
 # Files or directories to be skipped. They should be base names, not paths.
 # Add things like virtualenv directories here if needed (e.g., venv, .venv, env)
-ignore=CVS,experimental/public_support.py,experimental/mixture_of_products.py
+ignore=CVS
 
 
 # Pickle collected data for later comparisons.

--- a/src/mbi/domain.py
+++ b/src/mbi/domain.py
@@ -7,6 +7,7 @@ various operations like projection, marginalization, and merging of domains.
 """
 
 import functools
+import math
 from collections.abc import Iterator, Sequence
 from typing import Any
 
@@ -216,7 +217,7 @@ class Domain:
           the total size of the domain
         """
         if attributes is None:
-            return functools.reduce(lambda x, y: x * y, self.shape, 1)
+            return math.prod(self.shape)
         return self.project(attributes).size()
 
     @property

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -16,7 +16,6 @@ support the cliques of the marginal-based loss function can be used here.
 from __future__ import annotations
 
 import functools
-import math
 from collections.abc import Callable
 from typing import Any, NamedTuple, Protocol
 
@@ -251,12 +250,9 @@ def _optimize(loss_and_grad_fn, params, iters=250, callback_fn=lambda _: None):
         linesearch=optax.scale_by_zoom_linesearch(128, max_learning_rate=1),
     )
     state = optimizer.init(params)
-    prev_loss = math.inf
     for _ in range(iters):
-        params, state, loss = update(params, state)
+        params, state, _loss = update(params, state)
         callback_fn(params)
-        # if loss == prev_loss: break
-        prev_loss = loss
     return params
 
 


### PR DESCRIPTION
Minor code cleanup:
- Remove commented-out early stopping code and its associated `prev_loss` variable in `_optimize()`
- Replace `functools.reduce(lambda x, y: x*y, ...)` with `math.prod()` in `Domain.size()`
- Un-ignore `experimental/` in `.pylintrc` (files are now properly linted)