### PR TITLE
Add ReweightedDataset estimator in extensions/

### DIFF
--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -375,7 +375,7 @@ class JaxDataset:
         )
 
         counts = jnp.bincount(
-            linear_indices, weights=self.weights, minlength=length
+            linear_indices, weights=self.weights, length=length
         )
 
         return Factor(domain, counts.reshape(dims))

--- a/src/mbi/extensions/reweighted_dataset.py
+++ b/src/mbi/extensions/reweighted_dataset.py
@@ -30,7 +30,7 @@ class ReweightedDataset:
     """A discrete distribution as a reweighted set of seed records."""
 
     _log_weights: jax.Array
-    _data: tuple[tuple[int, ...], ...] = field(metadata={"static": True})
+    _data: dict[str, jax.Array]
     domain: Domain = field(metadata={"static": True})
     total: float = field(metadata={"static": True})
 
@@ -38,13 +38,10 @@ class ReweightedDataset:
     def from_dataset(cls, dataset: Dataset, total: float | None = None):
         """Initialize from a Dataset with uniform weights."""
         data_dict = dataset.to_dict()
-        data = tuple(
-            tuple(data_dict[col].tolist()) for col in dataset.domain.attrs
-        )
-        n = len(data[0])
+        data = {col: jnp.array(data_dict[col]) for col in dataset.domain.attrs}
+        n = dataset.records
         total = total if total is not None else float(n)
-        log_weights = jnp.zeros(n)
-        return cls(log_weights, data, dataset.domain, total)
+        return cls(jnp.zeros(n), data, dataset.domain, total)
 
     @property
     def weights(self) -> jax.Array:
@@ -54,7 +51,7 @@ class ReweightedDataset:
     @property
     def num_records(self) -> int:
         """Number of seed records."""
-        return len(self._data[0])
+        return next(iter(self._data.values())).shape[0]
 
     def project(self, attrs) -> Factor:
         """Compute the weighted marginal over ``attrs``."""
@@ -62,10 +59,9 @@ class ReweightedDataset:
             attrs = (attrs,)
         attrs = tuple(attrs)
         proj_domain = self.domain.project(attrs)
-        col_indices = [self.domain.attrs.index(a) for a in attrs]
         weights = self.weights
 
-        indices = tuple(jnp.array(self._data[i]) for i in col_indices)
+        indices = tuple(self._data[a] for a in attrs)
         values = jnp.zeros(proj_domain.shape)
         values = values.at[indices].add(weights)
         return Factor(proj_domain, values)
@@ -93,8 +89,8 @@ class ReweightedDataset:
         rng.shuffle(row_indices)
         row_indices = row_indices[:total]
         data = {
-            col: np.array(self._data[i])[row_indices]
-            for i, col in enumerate(self.domain.attrs)
+            col: np.asarray(self._data[col])[row_indices]
+            for col in self.domain.attrs
         }
         return Dataset(data, self.domain)
 
@@ -139,29 +135,36 @@ def estimate(
     model = ReweightedDataset.from_dataset(seed_data, known_total)
     cliques = loss_fn.cliques
 
-    def model_loss(model: ReweightedDataset) -> float:
-        arrays = {cl: model.project(cl) for cl in cliques}
+    # Optimize only _log_weights.  model._data (JAX arrays) is closed over
+    # and passed as implicit arguments to JIT, not baked as HLO constants.
+    def params_loss(log_weights: jax.Array) -> float:
+        m = ReweightedDataset(log_weights, model._data, domain, known_total)
+        arrays = {cl: m.project(cl) for cl in cliques}
         mu = CliqueVector(domain, cliques, arrays)
         return loss_fn(mu)
 
-    model_loss_and_grad = jax.jit(jax.value_and_grad(model_loss))
-    opt_state = optimizer.init(model)
+    params_loss_and_grad = jax.jit(jax.value_and_grad(params_loss))
+    log_weights = model._log_weights
+    opt_state = optimizer.init(log_weights)
 
     def step(carry, _):
-        model, opt_state = carry
-        loss, grad = model_loss_and_grad(model)
-        updates, opt_state = optimizer.update(grad, opt_state, model)
-        model = optax.apply_updates(model, updates)
-        return (model, opt_state), loss
+        log_weights, opt_state = carry
+        loss, grad = params_loss_and_grad(log_weights)
+        updates, opt_state = optimizer.update(grad, opt_state, log_weights)
+        log_weights = optax.apply_updates(log_weights, updates)
+        return (log_weights, opt_state), loss
 
     scan_block = jax.jit(
         lambda carry: jax.lax.scan(step, carry, None, length=callback_every)
     )
 
+    def make_model(log_weights):
+        return ReweightedDataset(log_weights, model._data, domain, known_total)
+
     num_blocks = -(-iters // callback_every)  # ceil division
     for _ in range(num_blocks):
-        (model, opt_state), _ = scan_block((model, opt_state))
+        (log_weights, opt_state), _ = scan_block((log_weights, opt_state))
         if callback_fn is not None:
-            callback_fn(model)
+            callback_fn(make_model(log_weights))
 
-    return model
+    return make_model(log_weights)

--- a/src/mbi/extensions/reweighted_dataset.py
+++ b/src/mbi/extensions/reweighted_dataset.py
@@ -9,7 +9,6 @@ with softmax normalization to guarantee non-negativity.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
 
 import jax
 import jax.numpy as jnp
@@ -20,75 +19,40 @@ from .. import estimation, marginal_loss
 from ..clique_vector import CliqueVector
 from ..dataset import Dataset, JaxDataset
 from ..domain import Domain
-from ..factor import Factor
 from ..marginal_loss import LinearMeasurement
 
 
-@jax.tree_util.register_dataclass
-@dataclass
-class ReweightedDataset:
-    """A discrete distribution as a reweighted set of seed records."""
+def synthetic_data(model: JaxDataset, rows: int | None = None) -> Dataset:
+    """Generate synthetic data via randomized rounding of weights.
 
-    _log_weights: jax.Array
-    _data: JaxDataset = field(metadata={"static": True})
-    domain: Domain = field(metadata={"static": True})
-    total: float = field(metadata={"static": True})
+    Args:
+        model: A JaxDataset with weights representing the distribution.
+        rows: Number of rows to generate.  Defaults to the sum of weights.
 
-    @classmethod
-    def from_dataset(cls, dataset: Dataset, total: float | None = None):
-        """Initialize from a Dataset with uniform weights."""
-        n = dataset.records
-        total = total if total is not None else float(n)
-        data_dict = dataset.to_dict()
-        jax_data = JaxDataset(
-            {col: jnp.array(data_dict[col]) for col in dataset.domain.attrs},
-            dataset.domain,
-        )
-        return cls(jnp.zeros(n), jax_data, dataset.domain, total)
-
-    @property
-    def weights(self) -> jax.Array:
-        """Non-negative weights summing to total (softmax of log-weights)."""
-        return jax.nn.softmax(self._log_weights) * self.total
-
-    @property
-    def num_records(self) -> int:
-        """Number of seed records."""
-        return self._data.records
-
-    def _weighted_data(self) -> JaxDataset:
-        """Return a JaxDataset with current softmax weights applied."""
-        return JaxDataset(self._data.data, self.domain, self.weights)
-
-    def project(self, attrs) -> Factor:
-        """Compute the weighted marginal over ``attrs``."""
-        return self._weighted_data().project(attrs)
-
-    def supports(self, attrs) -> bool:
-        """Any subset of domain attributes is supported."""
-        return self._data.supports(attrs)
-
-    def synthetic_data(self, rows=None) -> Dataset:
-        """Generate synthetic data via randomized rounding of weights."""
-        total = max(1, int(rows or self.total))
-        rng = np.random.default_rng()
-        weights = np.asarray(self.weights)
-        counts = weights * total / weights.sum()
-        frac, integ = np.modf(counts)
-        integ = integ.astype(int)
-        extra = total - integ.sum()
-        if extra > 0:
-            p = frac / frac.sum()
-            idx = rng.choice(len(counts), extra, replace=False, p=p)
-            integ[idx] += 1
-        row_indices = np.repeat(np.arange(len(counts)), integ)
-        rng.shuffle(row_indices)
-        row_indices = row_indices[:total]
-        data = {
-            col: np.asarray(self._data.data[col])[row_indices]
-            for col in self.domain.attrs
-        }
-        return Dataset(data, self.domain)
+    Returns:
+        A Dataset with integer-valued rows.
+    """
+    weights = np.asarray(
+        model.weights if model.weights is not None else np.ones(model.records)
+    )
+    total = max(1, int(rows or weights.sum()))
+    rng = np.random.default_rng()
+    counts = weights * total / weights.sum()
+    frac, integ = np.modf(counts)
+    integ = integ.astype(int)
+    extra = total - integ.sum()
+    if extra > 0:
+        p = frac / frac.sum()
+        idx = rng.choice(len(counts), extra, replace=False, p=p)
+        integ[idx] += 1
+    row_indices = np.repeat(np.arange(len(counts)), integ)
+    rng.shuffle(row_indices)
+    row_indices = row_indices[:total]
+    data = {
+        col: np.asarray(model.data[col])[row_indices]
+        for col in model.domain.attrs
+    }
+    return Dataset(data, model.domain)
 
 
 def estimate(
@@ -100,9 +64,9 @@ def estimate(
     iters: int = 2500,
     learning_rate: float = 0.1,
     optimizer: optax.GradientTransformation | None = None,
-    callback_fn: Callable[[ReweightedDataset], None] | None = None,
+    callback_fn: Callable[[JaxDataset], None] | None = None,
     callback_every: int = 100,
-) -> ReweightedDataset:
+) -> JaxDataset:
     """Estimate a distribution by reweighting seed records.
 
     Args:
@@ -115,11 +79,11 @@ def estimate(
         learning_rate: Learning rate for the optimizer.
         optimizer: An optax optimizer.  Defaults to ``optax.adam``.
         callback_fn: Called every ``callback_every`` iterations with the
-            current model.
+            current JaxDataset.
         callback_every: Controls callback frequency and ``lax.scan`` chunk size.
 
     Returns:
-        A ReweightedDataset fitted to the measurements.
+        A JaxDataset with learned weights fitted to the measurements.
     """
     loss_fn, known_total, _ = estimation._initialize(
         domain, loss_fn, known_total, None
@@ -128,22 +92,21 @@ def estimate(
     if optimizer is None:
         optimizer = optax.adam(learning_rate)
 
-    model = ReweightedDataset.from_dataset(seed_data, known_total)
+    data_dict = seed_data.to_dict()
+    jax_data = {col: jnp.array(data_dict[col]) for col in domain.attrs}
+    log_weights = jnp.zeros(seed_data.records)
     cliques = loss_fn.cliques
 
-    # Precompute a JaxDataset with the seed data.  Its JAX arrays are closed
-    # over in params_loss and passed as implicit arguments to JIT.
-    jax_data = model._data
-
+    # jax_data values (JAX arrays) are closed over and passed as implicit
+    # arguments to JIT — not baked as HLO constants.
     def params_loss(log_weights: jax.Array) -> float:
         weights = jax.nn.softmax(log_weights) * known_total
-        weighted = JaxDataset(jax_data.data, domain, weights)
+        weighted = JaxDataset(jax_data, domain, weights)
         arrays = {cl: weighted.project(cl) for cl in cliques}
         mu = CliqueVector(domain, cliques, arrays)
         return loss_fn(mu)
 
     params_loss_and_grad = jax.jit(jax.value_and_grad(params_loss))
-    log_weights = model._log_weights
     opt_state = optimizer.init(log_weights)
 
     def step(carry, _):
@@ -158,7 +121,8 @@ def estimate(
     )
 
     def make_model(log_weights):
-        return ReweightedDataset(log_weights, model._data, domain, known_total)
+        weights = jax.nn.softmax(log_weights) * known_total
+        return JaxDataset(jax_data, domain, weights)
 
     num_blocks = -(-iters // callback_every)  # ceil division
     for _ in range(num_blocks):

--- a/src/mbi/extensions/reweighted_dataset.py
+++ b/src/mbi/extensions/reweighted_dataset.py
@@ -1,0 +1,167 @@
+"""Reweighted dataset estimation for discrete distributions.
+
+Inspired by PMW^Pub (https://arxiv.org/abs/2102.08598).  Given a seed set of
+records, the distribution is represented by learning a weight for each record
+to minimize the marginal loss.  The weights are parameterized in log-space
+with softmax normalization to guarantee non-negativity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+from .. import estimation, marginal_loss
+from ..clique_vector import CliqueVector
+from ..dataset import Dataset
+from ..domain import Domain
+from ..factor import Factor
+from ..marginal_loss import LinearMeasurement
+
+
+@jax.tree_util.register_dataclass
+@dataclass
+class ReweightedDataset:
+    """A discrete distribution as a reweighted set of seed records."""
+
+    _log_weights: jax.Array
+    _data: tuple[tuple[int, ...], ...] = field(metadata={"static": True})
+    domain: Domain = field(metadata={"static": True})
+    total: float = field(metadata={"static": True})
+
+    @classmethod
+    def from_dataset(cls, dataset: Dataset, total: float | None = None):
+        """Initialize from a Dataset with uniform weights."""
+        data_dict = dataset.to_dict()
+        data = tuple(
+            tuple(data_dict[col].tolist()) for col in dataset.domain.attrs
+        )
+        n = len(data[0])
+        total = total if total is not None else float(n)
+        log_weights = jnp.zeros(n)
+        return cls(log_weights, data, dataset.domain, total)
+
+    @property
+    def weights(self) -> jax.Array:
+        """Non-negative weights summing to total (softmax of log-weights)."""
+        return jax.nn.softmax(self._log_weights) * self.total
+
+    @property
+    def num_records(self) -> int:
+        """Number of seed records."""
+        return len(self._data[0])
+
+    def project(self, attrs) -> Factor:
+        """Compute the weighted marginal over ``attrs``."""
+        if isinstance(attrs, str):
+            attrs = (attrs,)
+        attrs = tuple(attrs)
+        proj_domain = self.domain.project(attrs)
+        col_indices = [self.domain.attrs.index(a) for a in attrs]
+        weights = self.weights
+
+        indices = tuple(jnp.array(self._data[i]) for i in col_indices)
+        values = jnp.zeros(proj_domain.shape)
+        values = values.at[indices].add(weights)
+        return Factor(proj_domain, values)
+
+    def supports(self, attrs) -> bool:
+        """Any subset of domain attributes is supported."""
+        if isinstance(attrs, str):
+            attrs = (attrs,)
+        return all(a in self.domain.attrs for a in attrs)
+
+    def synthetic_data(self, rows=None) -> Dataset:
+        """Generate synthetic data via randomized rounding of weights."""
+        total = max(1, int(rows or self.total))
+        rng = np.random.default_rng()
+        weights = np.asarray(self.weights)
+        counts = weights * total / weights.sum()
+        frac, integ = np.modf(counts)
+        integ = integ.astype(int)
+        extra = total - integ.sum()
+        if extra > 0:
+            p = frac / frac.sum()
+            idx = rng.choice(len(counts), extra, replace=False, p=p)
+            integ[idx] += 1
+        row_indices = np.repeat(np.arange(len(counts)), integ)
+        rng.shuffle(row_indices)
+        row_indices = row_indices[:total]
+        data = {
+            col: np.array(self._data[i])[row_indices]
+            for i, col in enumerate(self.domain.attrs)
+        }
+        return Dataset(data, self.domain)
+
+
+def estimate(
+    domain: Domain,
+    loss_fn: marginal_loss.MarginalLossFn | list[LinearMeasurement],
+    seed_data: Dataset,
+    *,
+    known_total: float | None = None,
+    iters: int = 2500,
+    learning_rate: float = 0.1,
+    optimizer: optax.GradientTransformation | None = None,
+    callback_fn: Callable[[ReweightedDataset], None] | None = None,
+    callback_every: int = 100,
+) -> ReweightedDataset:
+    """Estimate a distribution by reweighting seed records.
+
+    Args:
+        domain: The discrete domain over which the distribution is defined.
+        loss_fn: A MarginalLossFn or list of LinearMeasurement objects.
+        seed_data: A Dataset of seed records to reweight.
+        known_total: Known or estimated number of records.  If None and
+            ``loss_fn`` is a list, estimated automatically.
+        iters: Number of optimization iterations.
+        learning_rate: Learning rate for the optimizer.
+        optimizer: An optax optimizer.  Defaults to ``optax.adam``.
+        callback_fn: Called every ``callback_every`` iterations with the
+            current model.
+        callback_every: Controls callback frequency and ``lax.scan`` chunk size.
+
+    Returns:
+        A ReweightedDataset fitted to the measurements.
+    """
+    loss_fn, known_total, _ = estimation._initialize(
+        domain, loss_fn, known_total, None
+    )
+
+    if optimizer is None:
+        optimizer = optax.adam(learning_rate)
+
+    model = ReweightedDataset.from_dataset(seed_data, known_total)
+    cliques = loss_fn.cliques
+
+    def model_loss(model: ReweightedDataset) -> float:
+        arrays = {cl: model.project(cl) for cl in cliques}
+        mu = CliqueVector(domain, cliques, arrays)
+        return loss_fn(mu)
+
+    model_loss_and_grad = jax.jit(jax.value_and_grad(model_loss))
+    opt_state = optimizer.init(model)
+
+    def step(carry, _):
+        model, opt_state = carry
+        loss, grad = model_loss_and_grad(model)
+        updates, opt_state = optimizer.update(grad, opt_state, model)
+        model = optax.apply_updates(model, updates)
+        return (model, opt_state), loss
+
+    scan_block = jax.jit(
+        lambda carry: jax.lax.scan(step, carry, None, length=callback_every)
+    )
+
+    num_blocks = -(-iters // callback_every)  # ceil division
+    for _ in range(num_blocks):
+        (model, opt_state), _ = scan_block((model, opt_state))
+        if callback_fn is not None:
+            callback_fn(model)
+
+    return model

--- a/src/mbi/extensions/reweighted_dataset.py
+++ b/src/mbi/extensions/reweighted_dataset.py
@@ -18,7 +18,7 @@ import optax
 
 from .. import estimation, marginal_loss
 from ..clique_vector import CliqueVector
-from ..dataset import Dataset
+from ..dataset import Dataset, JaxDataset
 from ..domain import Domain
 from ..factor import Factor
 from ..marginal_loss import LinearMeasurement
@@ -30,18 +30,21 @@ class ReweightedDataset:
     """A discrete distribution as a reweighted set of seed records."""
 
     _log_weights: jax.Array
-    _data: dict[str, jax.Array]
+    _data: JaxDataset = field(metadata={"static": True})
     domain: Domain = field(metadata={"static": True})
     total: float = field(metadata={"static": True})
 
     @classmethod
     def from_dataset(cls, dataset: Dataset, total: float | None = None):
         """Initialize from a Dataset with uniform weights."""
-        data_dict = dataset.to_dict()
-        data = {col: jnp.array(data_dict[col]) for col in dataset.domain.attrs}
         n = dataset.records
         total = total if total is not None else float(n)
-        return cls(jnp.zeros(n), data, dataset.domain, total)
+        data_dict = dataset.to_dict()
+        jax_data = JaxDataset(
+            {col: jnp.array(data_dict[col]) for col in dataset.domain.attrs},
+            dataset.domain,
+        )
+        return cls(jnp.zeros(n), jax_data, dataset.domain, total)
 
     @property
     def weights(self) -> jax.Array:
@@ -51,26 +54,19 @@ class ReweightedDataset:
     @property
     def num_records(self) -> int:
         """Number of seed records."""
-        return next(iter(self._data.values())).shape[0]
+        return self._data.records
+
+    def _weighted_data(self) -> JaxDataset:
+        """Return a JaxDataset with current softmax weights applied."""
+        return JaxDataset(self._data.data, self.domain, self.weights)
 
     def project(self, attrs) -> Factor:
         """Compute the weighted marginal over ``attrs``."""
-        if isinstance(attrs, str):
-            attrs = (attrs,)
-        attrs = tuple(attrs)
-        proj_domain = self.domain.project(attrs)
-        weights = self.weights
-
-        indices = tuple(self._data[a] for a in attrs)
-        values = jnp.zeros(proj_domain.shape)
-        values = values.at[indices].add(weights)
-        return Factor(proj_domain, values)
+        return self._weighted_data().project(attrs)
 
     def supports(self, attrs) -> bool:
         """Any subset of domain attributes is supported."""
-        if isinstance(attrs, str):
-            attrs = (attrs,)
-        return all(a in self.domain.attrs for a in attrs)
+        return self._data.supports(attrs)
 
     def synthetic_data(self, rows=None) -> Dataset:
         """Generate synthetic data via randomized rounding of weights."""
@@ -89,7 +85,7 @@ class ReweightedDataset:
         rng.shuffle(row_indices)
         row_indices = row_indices[:total]
         data = {
-            col: np.asarray(self._data[col])[row_indices]
+            col: np.asarray(self._data.data[col])[row_indices]
             for col in self.domain.attrs
         }
         return Dataset(data, self.domain)
@@ -135,11 +131,14 @@ def estimate(
     model = ReweightedDataset.from_dataset(seed_data, known_total)
     cliques = loss_fn.cliques
 
-    # Optimize only _log_weights.  model._data (JAX arrays) is closed over
-    # and passed as implicit arguments to JIT, not baked as HLO constants.
+    # Precompute a JaxDataset with the seed data.  Its JAX arrays are closed
+    # over in params_loss and passed as implicit arguments to JIT.
+    jax_data = model._data
+
     def params_loss(log_weights: jax.Array) -> float:
-        m = ReweightedDataset(log_weights, model._data, domain, known_total)
-        arrays = {cl: m.project(cl) for cl in cliques}
+        weights = jax.nn.softmax(log_weights) * known_total
+        weighted = JaxDataset(jax_data.data, domain, weights)
+        arrays = {cl: weighted.project(cl) for cl in cliques}
         mu = CliqueVector(domain, cliques, arrays)
         return loss_fn(mu)
 

--- a/test/test_reweighted_dataset.py
+++ b/test/test_reweighted_dataset.py
@@ -2,14 +2,15 @@
 
 import unittest
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from parameterized import parameterized
 
 from mbi import Domain, marginal_loss
 from mbi.clique_vector import CliqueVector
-from mbi.dataset import Dataset
-from mbi.extensions.reweighted_dataset import ReweightedDataset, estimate
+from mbi.dataset import Dataset, JaxDataset
+from mbi.extensions.reweighted_dataset import estimate, synthetic_data
 from mbi.factor import Factor
 
 np.random.seed(42)  # Avoid flaky tests
@@ -42,17 +43,22 @@ def _fake_measurements(domain, cliques):
     return measurements, P
 
 
-class TestReweightedDatasetClass(unittest.TestCase):
-    """Tests for the ReweightedDataset data structure."""
+class TestJaxDatasetBasics(unittest.TestCase):
+    """Tests for JaxDataset used as the reweighted model."""
 
     def setUp(self):
         self.domain = Domain(["x", "y"], [3, 4])
         data = {"x": np.array([0, 1, 2, 0, 1]), "y": np.array([0, 1, 2, 3, 0])}
         self.dataset = Dataset(data, self.domain)
-        self.model = ReweightedDataset.from_dataset(self.dataset, total=100.0)
+        weights = jax.nn.softmax(jnp.zeros(5)) * 100.0
+        self.model = JaxDataset(
+            {col: jnp.array(data[col]) for col in self.domain.attrs},
+            self.domain,
+            weights,
+        )
 
     def test_num_records(self):
-        self.assertEqual(self.model.num_records, 5)
+        self.assertEqual(self.model.records, 5)
 
     def test_weights_sum_to_total(self):
         np.testing.assert_allclose(
@@ -91,16 +97,16 @@ class TestReweightedDatasetClass(unittest.TestCase):
         self.assertFalse(self.model.supports("z"))
 
     def test_synthetic_data(self):
-        data = self.model.synthetic_data(rows=500)
+        data = synthetic_data(self.model, rows=500)
         self.assertEqual(data.records, 500)
         self.assertEqual(data.domain, self.model.domain)
 
     def test_synthetic_data_default_rows(self):
-        data = self.model.synthetic_data()
+        data = synthetic_data(self.model)
         self.assertEqual(data.records, 100)
 
     def test_synthetic_data_values_in_range(self):
-        data = self.model.synthetic_data(rows=200)
+        data = synthetic_data(self.model, rows=200)
         data_dict = data.to_dict()
         for col in self.model.domain.attrs:
             col_data = data_dict[col]
@@ -116,10 +122,7 @@ class TestReweightedDatasetClass(unittest.TestCase):
         )
 
 
-import jax  # noqa: E402 (needed for pytree test above)
-
-
-class TestReweightedDatasetEstimation(unittest.TestCase):
+class TestEstimation(unittest.TestCase):
     """Tests for the reweighted_dataset.estimate function."""
 
     @parameterized.expand([(cliques,) for cliques in _CLIQUE_SETS])
@@ -185,8 +188,8 @@ class TestReweightedDatasetEstimation(unittest.TestCase):
             actual = model.project(M.clique).datavector()
             np.testing.assert_allclose(actual, expected, atol=5e-2)
 
-    def test_projectable_protocol(self):
-        """ReweightedDataset should satisfy the Projectable protocol."""
+    def test_returns_jax_dataset(self):
+        """estimate() should return a JaxDataset."""
         cliques = [("a", "b"), ("c", "d")]
         measurements, _ = _fake_measurements(_DOMAIN, cliques)
         seed_data = _make_seed_data(_DOMAIN)
@@ -197,10 +200,9 @@ class TestReweightedDatasetEstimation(unittest.TestCase):
             iters=50,
         )
 
-        self.assertTrue(hasattr(model, "domain"))
-        self.assertTrue(hasattr(model, "project"))
-        self.assertTrue(hasattr(model, "supports"))
+        self.assertIsInstance(model, JaxDataset)
         self.assertEqual(model.domain, _DOMAIN)
+        self.assertTrue(model.supports(("a", "b")))
 
     def test_synthetic_data_from_estimation(self):
         """Synthetic data should be generatable from an estimated model."""
@@ -214,7 +216,7 @@ class TestReweightedDatasetEstimation(unittest.TestCase):
             iters=100,
         )
 
-        data = model.synthetic_data(rows=1000)
+        data = synthetic_data(model, rows=1000)
         self.assertEqual(data.records, 1000)
         self.assertEqual(data.domain, _DOMAIN)
 
@@ -253,10 +255,10 @@ class TestReweightedDatasetEstimation(unittest.TestCase):
             iters=100,
             optimizer=optax.sgd(0.01),
         )
-        self.assertIsInstance(model, ReweightedDataset)
+        self.assertIsInstance(model, JaxDataset)
 
 
-class TestReweightedDatasetNonNegativity(unittest.TestCase):
+class TestNonNegativity(unittest.TestCase):
     """Test that the softmax parameterization guarantees non-negativity."""
 
     def test_marginals_nonnegative(self):
@@ -293,7 +295,7 @@ class TestReweightedDatasetNonNegativity(unittest.TestCase):
         for cl in cliques:
             marg = model.project(cl)
             np.testing.assert_allclose(
-                float(marg.sum()), model.total, atol=1e-5
+                float(marg.sum()), float(model.weights.sum()), atol=1e-5
             )
 
 

--- a/test/test_reweighted_dataset.py
+++ b/test/test_reweighted_dataset.py
@@ -1,0 +1,301 @@
+"""Tests for mbi.extensions.reweighted_dataset."""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+from parameterized import parameterized
+
+from mbi import Domain, marginal_loss
+from mbi.clique_vector import CliqueVector
+from mbi.dataset import Dataset
+from mbi.extensions.reweighted_dataset import ReweightedDataset, estimate
+from mbi.factor import Factor
+
+np.random.seed(42)  # Avoid flaky tests
+
+
+_DOMAIN = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
+
+_CLIQUE_SETS = [
+    [("a", "b"), ("b", "c"), ("c", "d")],  # tree
+    [("a",), ("a", "b"), ("b", "c"), ("a", "c"), ("b", "d")],  # cyclic/dense
+    [("a", "b"), ("d", "a")],  # missing c
+    [("d",)],  # singleton
+]
+
+
+def _make_seed_data(domain, n=5000):
+    """Create a random Dataset over the domain."""
+    data = {col: np.random.randint(0, domain[col], n) for col in domain.attrs}
+    return Dataset(data, domain)
+
+
+def _fake_measurements(domain, cliques):
+    """Create noise-free measurements from a random distribution."""
+    P = Factor.random(domain)
+    P = P / P.sum()
+    measurements = []
+    for cl in cliques:
+        y = P.project(cl).datavector()
+        measurements.append(marginal_loss.LinearMeasurement(y, cl))
+    return measurements, P
+
+
+class TestReweightedDatasetClass(unittest.TestCase):
+    """Tests for the ReweightedDataset data structure."""
+
+    def setUp(self):
+        self.domain = Domain(["x", "y"], [3, 4])
+        data = {"x": np.array([0, 1, 2, 0, 1]), "y": np.array([0, 1, 2, 3, 0])}
+        self.dataset = Dataset(data, self.domain)
+        self.model = ReweightedDataset.from_dataset(self.dataset, total=100.0)
+
+    def test_num_records(self):
+        self.assertEqual(self.model.num_records, 5)
+
+    def test_weights_sum_to_total(self):
+        np.testing.assert_allclose(
+            float(self.model.weights.sum()), 100.0, atol=1e-5
+        )
+
+    def test_uniform_weights(self):
+        """Initial weights should be uniform."""
+        weights = np.asarray(self.model.weights)
+        np.testing.assert_allclose(weights, 20.0, atol=1e-5)
+
+    def test_project_single_attr(self):
+        marg = self.model.project("x")
+        self.assertEqual(marg.domain, self.model.domain.project(("x",)))
+        np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
+
+    def test_project_multiple_attrs(self):
+        marg = self.model.project(("x", "y"))
+        self.assertEqual(marg.domain.shape, (3, 4))
+        np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
+
+    def test_project_consistency(self):
+        """Marginal of the joint should equal the direct marginal."""
+        joint = self.model.project(("x", "y"))
+        marg_x_from_joint = joint.project("x")
+        marg_x_direct = self.model.project("x")
+        np.testing.assert_allclose(
+            marg_x_from_joint.datavector(),
+            marg_x_direct.datavector(),
+            atol=1e-6,
+        )
+
+    def test_supports(self):
+        self.assertTrue(self.model.supports("x"))
+        self.assertTrue(self.model.supports(("x", "y")))
+        self.assertFalse(self.model.supports("z"))
+
+    def test_synthetic_data(self):
+        data = self.model.synthetic_data(rows=500)
+        self.assertEqual(data.records, 500)
+        self.assertEqual(data.domain, self.model.domain)
+
+    def test_synthetic_data_default_rows(self):
+        data = self.model.synthetic_data()
+        self.assertEqual(data.records, 100)
+
+    def test_synthetic_data_values_in_range(self):
+        data = self.model.synthetic_data(rows=200)
+        data_dict = data.to_dict()
+        for col in self.model.domain.attrs:
+            col_data = data_dict[col]
+            self.assertTrue(np.all(col_data >= 0))
+            self.assertTrue(np.all(col_data < self.model.domain[col]))
+
+    def test_pytree_roundtrip(self):
+        """Model should survive JAX pytree flatten/unflatten."""
+        leaves, treedef = jax.tree_util.tree_flatten(self.model)
+        reconstructed = jax.tree_util.tree_unflatten(treedef, leaves)
+        np.testing.assert_allclose(
+            np.asarray(reconstructed.weights), np.asarray(self.model.weights)
+        )
+
+
+import jax  # noqa: E402 (needed for pytree test above)
+
+
+class TestReweightedDatasetEstimation(unittest.TestCase):
+    """Tests for the reweighted_dataset.estimate function."""
+
+    @parameterized.expand([(cliques,) for cliques in _CLIQUE_SETS])
+    def test_noiseless_recovery(self, cliques):
+        """With noise-free measurements, the model should fit them closely."""
+        measurements, P = _fake_measurements(_DOMAIN, cliques)
+        seed_data = _make_seed_data(_DOMAIN, n=5000)
+        model = estimate(
+            _DOMAIN,
+            measurements,
+            seed_data,
+            iters=500,
+            learning_rate=0.1,
+        )
+
+        for M in measurements:
+            expected = M.noisy_measurement
+            actual = model.project(M.clique).datavector()
+            np.testing.assert_allclose(actual, expected, atol=5e-2)
+
+    def test_l1_loss(self):
+        """Test that L1 loss works without crashing and converges."""
+        cliques = [("a", "b"), ("b", "c")]
+        measurements, P = _fake_measurements(_DOMAIN, cliques)
+        loss_fn = marginal_loss.from_linear_measurements(
+            measurements, norm="l1"
+        )
+        seed_data = _make_seed_data(_DOMAIN)
+
+        model = estimate(
+            _DOMAIN,
+            loss_fn,
+            seed_data,
+            known_total=1.0,
+            iters=500,
+            learning_rate=0.01,
+        )
+
+        for M in measurements:
+            expected = M.noisy_measurement
+            actual = model.project(M.clique).datavector()
+            np.testing.assert_allclose(actual, expected, atol=0.1)
+
+    def test_l2_loss(self):
+        """Test explicit L2 loss construction."""
+        cliques = [("a", "b"), ("b", "c")]
+        measurements, P = _fake_measurements(_DOMAIN, cliques)
+        loss_fn = marginal_loss.from_linear_measurements(
+            measurements, norm="l2"
+        )
+        seed_data = _make_seed_data(_DOMAIN)
+
+        model = estimate(
+            _DOMAIN,
+            loss_fn,
+            seed_data,
+            known_total=1.0,
+            iters=500,
+        )
+
+        for M in measurements:
+            expected = M.noisy_measurement
+            actual = model.project(M.clique).datavector()
+            np.testing.assert_allclose(actual, expected, atol=5e-2)
+
+    def test_projectable_protocol(self):
+        """ReweightedDataset should satisfy the Projectable protocol."""
+        cliques = [("a", "b"), ("c", "d")]
+        measurements, _ = _fake_measurements(_DOMAIN, cliques)
+        seed_data = _make_seed_data(_DOMAIN)
+        model = estimate(
+            _DOMAIN,
+            measurements,
+            seed_data,
+            iters=50,
+        )
+
+        self.assertTrue(hasattr(model, "domain"))
+        self.assertTrue(hasattr(model, "project"))
+        self.assertTrue(hasattr(model, "supports"))
+        self.assertEqual(model.domain, _DOMAIN)
+
+    def test_synthetic_data_from_estimation(self):
+        """Synthetic data should be generatable from an estimated model."""
+        cliques = [("a", "b"), ("b", "c")]
+        measurements, _ = _fake_measurements(_DOMAIN, cliques)
+        seed_data = _make_seed_data(_DOMAIN)
+        model = estimate(
+            _DOMAIN,
+            measurements,
+            seed_data,
+            iters=100,
+        )
+
+        data = model.synthetic_data(rows=1000)
+        self.assertEqual(data.records, 1000)
+        self.assertEqual(data.domain, _DOMAIN)
+
+    def test_callback(self):
+        """Callback should be called once per scan block."""
+        cliques = [("a", "b")]
+        measurements, _ = _fake_measurements(_DOMAIN, cliques)
+        seed_data = _make_seed_data(_DOMAIN)
+
+        callback_count = [0]
+
+        def callback(model):
+            callback_count[0] += 1
+
+        estimate(
+            _DOMAIN,
+            measurements,
+            seed_data,
+            iters=100,
+            callback_fn=callback,
+            callback_every=25,
+        )
+        self.assertEqual(callback_count[0], 4)
+
+    def test_custom_optimizer(self):
+        """Should accept a custom optax optimizer."""
+        import optax
+
+        cliques = [("a", "b"), ("b", "c")]
+        measurements, _ = _fake_measurements(_DOMAIN, cliques)
+        seed_data = _make_seed_data(_DOMAIN)
+        model = estimate(
+            _DOMAIN,
+            measurements,
+            seed_data,
+            iters=100,
+            optimizer=optax.sgd(0.01),
+        )
+        self.assertIsInstance(model, ReweightedDataset)
+
+
+class TestReweightedDatasetNonNegativity(unittest.TestCase):
+    """Test that the softmax parameterization guarantees non-negativity."""
+
+    def test_marginals_nonnegative(self):
+        """All marginals should be non-negative."""
+        cliques = [("a", "b"), ("b", "c"), ("c", "d")]
+        measurements, _ = _fake_measurements(_DOMAIN, cliques)
+        seed_data = _make_seed_data(_DOMAIN)
+        model = estimate(
+            _DOMAIN,
+            measurements,
+            seed_data,
+            iters=100,
+        )
+
+        for cl in cliques:
+            marg = model.project(cl)
+            self.assertTrue(
+                jnp.all(marg.values >= 0),
+                f"Negative values in marginal for clique {cl}",
+            )
+
+    def test_marginals_sum_to_total(self):
+        """Each marginal should sum to total."""
+        cliques = [("a", "b"), ("b", "c")]
+        measurements, _ = _fake_measurements(_DOMAIN, cliques)
+        seed_data = _make_seed_data(_DOMAIN)
+        model = estimate(
+            _DOMAIN,
+            measurements,
+            seed_data,
+            iters=100,
+        )
+
+        for cl in cliques:
+            marg = model.project(cl)
+            np.testing.assert_allclose(
+                float(marg.sum()), model.total, atol=1e-5
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Given a seed set of records, learns non-negative weights to minimize the marginal loss. Inspired by PMW$^{Pub}$ ([arxiv.org/abs/2102.08598](https://arxiv.org/abs/2102.08598)).

## What's included

- **`extensions/reweighted_dataset.py`**: `ReweightedDataset` class + `estimate()` function.
- **`test/test_reweighted_dataset.py`**: 23 tests, all passing.

## Design

- **JAX-registered dataclass pytree**: `_log_weights` (dynamic), `_data`/`domain`/`total` (static).
- **Softmax parameterization**: weights = `softmax(log_weights) * total`, guarantees non-negativity.
- **`Projectable` protocol**: `project()`, `supports()`.
- **`optax` + `lax.scan`** optimization loop with callbacks.
- **Randomized rounding** for `synthetic_data()`.
- Data stored as `tuple[tuple[int, ...], ...]` for JAX hashability.

## Usage

```python
from mbi.extensions import reweighted_dataset

model = reweighted_dataset.estimate(domain, measurements, seed_data)
marginal = model.project(('age', 'income'))
synth = model.synthetic_data(rows=10000)
```
