### PR TITLE
Add efficient handling of deterministic variable constraints

### DIFF
--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -8,6 +8,8 @@ and various estimation and oracle modules.
 
 from . import callbacks, estimation, junction_tree, marginal_oracles
 from ._api import Estimator, Model, PGMEstimator, Projectable
+from .extensions import constraints
+from .extensions.constraints import DeterministicConstraint
 from .clique_vector import CliqueVector
 from .dataset import Dataset
 from .domain import Domain
@@ -19,6 +21,7 @@ from .markov_random_field import MarkovRandomField
 Clique = tuple[str, ...]
 
 __all__ = [
+    "DeterministicConstraint",
     "Domain",
     "Dataset",
     "Factor",

--- a/src/mbi/extensions/constraints.py
+++ b/src/mbi/extensions/constraints.py
@@ -1,0 +1,498 @@
+"""Efficient handling of deterministic variable constraints.
+
+Provides utilities for exploiting deterministic relationships between variables
+(e.g., A' = f(A) where A' is a coarsening of A) during message passing in
+graphical models. Instead of materializing full |A| x |A'| constraint factors,
+messages are routed through the constraint in O(|A|) time using coarsen/refine
+operations.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import attr
+import jax
+import jax.numpy as jnp
+import networkx as nx
+import numpy as np
+
+from .. import junction_tree
+from ..clique_vector import CliqueVector
+from ..domain import Domain
+from ..factor import Factor
+
+
+@attr.dataclass(frozen=True, hash=False, eq=False)
+class DeterministicConstraint:
+    """A deterministic relationship: coarse = f(fine).
+
+    Attributes:
+        fine: The finer-grained variable name.
+        coarse: The coarser variable name.
+        mapping: Array of shape (|fine|,) mapping fine values to coarse values.
+    """
+
+    fine: str
+    coarse: str
+    mapping: np.ndarray
+
+    def __hash__(self):
+        return hash((self.fine, self.coarse, self.mapping.tobytes()))
+
+    def __eq__(self, other):
+        if not isinstance(other, DeterministicConstraint):
+            return NotImplemented
+        return (
+            self.fine == other.fine
+            and self.coarse == other.coarse
+            and np.array_equal(self.mapping, other.mapping)
+        )
+
+    @property
+    def clique(self) -> tuple[str, ...]:
+        return tuple(sorted((self.fine, self.coarse)))
+
+    @property
+    def n_fine(self) -> int:
+        return len(self.mapping)
+
+    @property
+    def n_coarse(self) -> int:
+        return int(self.mapping.max()) + 1
+
+
+def _replace_variable(factor, old, new, new_size):
+    """Replace a variable name and size in a Factor's domain."""
+    attrs = list(factor.domain.attributes)
+    shape = list(factor.domain.shape)
+    idx = attrs.index(old)
+    attrs[idx] = new
+    shape[idx] = new_size
+    return Factor(Domain(attrs, shape), factor.values)
+
+
+def _segment_logsumexp(values, mapping, n_segments, axis):
+    """Logsumexp grouped by segment IDs along the given axis."""
+    values = jnp.moveaxis(values, axis, 0)
+    max_vals = jnp.full((n_segments,) + values.shape[1:], -jnp.inf)
+    max_vals = max_vals.at[mapping].max(values)
+    shifted = jnp.exp(values - max_vals[mapping])
+    summed = jnp.zeros_like(max_vals)
+    summed = summed.at[mapping].add(shifted)
+    result = jnp.log(summed) + max_vals
+    return jnp.moveaxis(result, 0, axis)
+
+
+def coarsen(factor, constraint):
+    """Log-space fine-to-coarse aggregation via segment-logsumexp."""
+    axis = factor.domain.axes((constraint.fine,))[0]
+    values = _segment_logsumexp(
+        factor.values, constraint.mapping, constraint.n_coarse, axis
+    )
+    return _replace_variable(
+        Factor(factor.domain, values),
+        constraint.fine,
+        constraint.coarse,
+        constraint.n_coarse,
+    )
+
+
+def refine(factor, constraint):
+    """Log-space coarse-to-fine scatter via indexing."""
+    axis = factor.domain.axes((constraint.coarse,))[0]
+    values = jnp.take(factor.values, constraint.mapping, axis=axis)
+    return _replace_variable(
+        Factor(factor.domain, values),
+        constraint.coarse,
+        constraint.fine,
+        constraint.n_fine,
+    )
+
+
+def project_to_coarse(factor, constraint):
+    """Probability-space fine-to-coarse aggregation via segment-sum."""
+    axis = factor.domain.axes((constraint.fine,))[0]
+    values = jnp.moveaxis(factor.values, axis, 0)
+    result = jnp.zeros(
+        (constraint.n_coarse,) + values.shape[1:], dtype=values.dtype
+    )
+    result = result.at[constraint.mapping].add(values)
+    values = jnp.moveaxis(result, 0, axis)
+    return _replace_variable(
+        Factor(factor.domain, values),
+        constraint.fine,
+        constraint.coarse,
+        constraint.n_coarse,
+    )
+
+
+def _constraint_slice(factor, constraint):
+    """Remove the coarse variable by selecting valid constraint entries.
+
+    For each value of the fine variable a, selects coarse = mapping[a].
+    """
+    fine_axis = factor.domain.axes((constraint.fine,))[0]
+    coarse_axis = factor.domain.axes((constraint.coarse,))[0]
+
+    idx_shape = [1] * len(factor.domain.shape)
+    idx_shape[fine_axis] = constraint.n_fine
+    indices = jnp.array(constraint.mapping).reshape(idx_shape)
+
+    values = jnp.take_along_axis(factor.values, indices, axis=coarse_axis)
+    values = jnp.squeeze(values, axis=coarse_axis)
+
+    attrs = [
+        a for i, a in enumerate(factor.domain.attributes) if i != coarse_axis
+    ]
+    shape = [s for i, s in enumerate(factor.domain.shape) if i != coarse_axis]
+    return Factor(Domain(attrs, shape), values)
+
+
+def _constraint_expand(factor, constraint):
+    """Re-introduce the coarse variable using the constraint mapping.
+
+    Inverse of _constraint_slice. For each fine value a, places the
+    factor's values at coarse = mapping[a] and zeros elsewhere.
+    """
+    fine_axis = factor.domain.axes((constraint.fine,))[0]
+    coarse_axis = fine_axis + 1
+
+    indicator = jnp.zeros(
+        (constraint.n_fine, constraint.n_coarse), dtype=factor.values.dtype
+    )
+    indicator = indicator.at[
+        jnp.arange(constraint.n_fine), constraint.mapping
+    ].set(1.0)
+
+    ind_shape = [1] * (len(factor.domain.shape) + 1)
+    ind_shape[fine_axis] = constraint.n_fine
+    ind_shape[coarse_axis] = constraint.n_coarse
+
+    values = jnp.expand_dims(factor.values, axis=coarse_axis)
+    result_values = values * indicator.reshape(ind_shape)
+
+    attrs = list(factor.domain.attributes)
+    shape = list(factor.domain.shape)
+    attrs.insert(coarse_axis, constraint.coarse)
+    shape.insert(coarse_axis, constraint.n_coarse)
+    return Factor(Domain(attrs, shape), result_values)
+
+
+def _add_optional(a, b):
+    """Add two Factors where either may be None."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a + b
+
+
+def _partition_by_variable(items, variable):
+    """Partition Factors into those containing variable and those not."""
+    has_var, no_var = None, None
+    for f in items:
+        if variable in f.domain:
+            has_var = _add_optional(has_var, f)
+        else:
+            no_var = _add_optional(no_var, f)
+    return has_var, no_var
+
+
+def _constraint_message(constraint, inputs, target_has_fine):
+    """Compute the outgoing message from a pure constraint clique.
+
+    Routes messages through the constraint in O(|fine|) time.
+    """
+    # Pre-process: slice any input that has both fine and coarse.
+    clean = []
+    for f in inputs:
+        if constraint.fine in f.domain and constraint.coarse in f.domain:
+            clean.append(_constraint_slice(f, constraint))
+        else:
+            clean.append(f)
+    fine_sum, coarse_sum = _partition_by_variable(clean, constraint.fine)
+
+    if target_has_fine:
+        result = _add_optional(
+            fine_sum,
+            refine(coarse_sum, constraint) if coarse_sum else None,
+        )
+    else:
+        result = _add_optional(
+            coarsen(fine_sum, constraint) if fine_sum else None,
+            coarse_sum,
+        )
+    return result
+
+
+def _embedded_message(tau, sep_vars, constraints_list):
+    """Outgoing message from a clique with an embedded constraint."""
+    for c in constraints_list:
+        if c.fine not in tau.domain or c.coarse not in tau.domain:
+            continue
+        tau = _constraint_slice(tau, c)
+        if c.coarse in sep_vars and c.fine not in sep_vars:
+            # Only coarse in separator — must coarsen to reach it.
+            keep = tuple((sep_vars - {c.coarse}) | {c.fine})
+            extra = set(tau.domain.attributes) - set(keep)
+            if extra:
+                tau = tau.logsumexp(tau.domain.invert(keep))
+            return coarsen(tau, c)
+        # Fine in separator (or both) — keep per-element info.
+        sep_without_coarse = tuple(sep_vars - {c.coarse})
+        return tau.logsumexp(tau.domain.invert(sep_without_coarse))
+    return tau.logsumexp(tau.domain.invert(tuple(sep_vars)))
+
+
+def _classify_cliques(max_cliques, constraints):
+    """Classify maximal cliques by their relationship to constraints.
+
+    Returns:
+        pure_constraint: dict mapping mc -> constraint for standalone
+            {fine, coarse} nodes.
+        embedded: dict mapping mc -> [constraints] for cliques where the
+            constraint is absorbed into a larger maximal clique.
+    """
+    pure_constraint = {}
+    embedded = {}
+    for mc in max_cliques:
+        mc_set = set(mc)
+        cs = [c for c in constraints if c.fine in mc_set and c.coarse in mc_set]
+        if not cs:
+            continue
+        if len(cs) == 1 and mc_set == {cs[0].fine, cs[0].coarse}:
+            pure_constraint[mc] = cs[0]
+        else:
+            embedded[mc] = cs
+    return pure_constraint, embedded
+
+
+def _derive_pure_marginal(
+    clique,
+    pure_constraint,
+    constraint_init,
+    neighbors,
+    messages,
+    total,
+    domain,
+):
+    """Derive a marginal for a clique subsumed by a pure constraint."""
+    for con_mc, c in pure_constraint.items():
+        if not set(clique) <= set(con_mc):
+            continue
+
+        inputs = [
+            messages[(k, con_mc)]
+            for k in neighbors[con_mc]
+            if (k, con_mc) in messages
+        ]
+        inputs.extend(constraint_init.get(con_mc, []))
+        fine_sum, coarse_sum = _partition_by_variable(inputs, c.fine)
+
+        # Reduce any inputs containing both variables to fine-only.
+        if fine_sum is not None and c.coarse in fine_sum.domain:
+            fine_sum = _constraint_slice(fine_sum, c)
+
+        belief = _add_optional(
+            fine_sum, refine(coarse_sum, c) if coarse_sum else None
+        )
+        if belief is None:
+            belief = Factor.zeros(domain.project((c.fine,)))
+
+        belief = belief.normalize(total, log=True).exp()
+        if c.fine in clique and c.coarse in clique:
+            return _constraint_expand(belief, c).project(clique)
+        if c.fine in clique:
+            return belief.project(clique)
+        return project_to_coarse(belief, c).project(clique)
+
+    raise ValueError(f'Clique {clique} not supported by any constraint.')
+
+
+def _try_expand_belief(clique, result_cv, constraints):
+    """Re-expand a belief by re-introducing sliced constraint variables."""
+    cl_set = set(clique)
+    for belief_cl in result_cv.cliques:
+        missing = cl_set - set(belief_cl)
+        if not missing or not set(belief_cl) & cl_set:
+            continue
+        expansions = []
+        for var in missing:
+            c = next(
+                (
+                    c
+                    for c in constraints
+                    if c.coarse == var and c.fine in belief_cl
+                ),
+                None,
+            )
+            if c is None:
+                break
+            expansions.append(c)
+        else:
+            if cl_set - missing <= set(belief_cl):
+                factor = result_cv[belief_cl]
+                for c in expansions:
+                    factor = _constraint_expand(factor, c)
+                return factor.project(clique)
+    return None
+
+
+@functools.partial(jax.jit, static_argnums=[2, 3, 4])
+def message_passing_with_constraints(
+    potentials: CliqueVector,
+    total: float = 1,
+    mesh: jax.sharding.Mesh | None = None,
+    jtree: nx.Graph | None = None,
+    constraints: tuple[DeterministicConstraint, ...] = (),
+) -> CliqueVector:
+    """Compute marginals using Shafer-Shenoy with constraint-aware shortcuts.
+
+    Extends message_passing_shafer_shenoy to handle deterministic constraints
+    without materializing |fine| x |coarse| factors.
+
+    Args:
+        potentials: The (log-space) potentials of a graphical model.
+        total: The normalization factor.
+        mesh: The mesh over which the computation should be sharded.
+        jtree: An optional junction tree that defines the message passing
+            order.
+        constraints: Deterministic constraints to handle efficiently.
+
+    Returns:
+        The marginals of the graphical model.
+    """
+    if len(potentials.cliques) == 0:
+        return CliqueVector(potentials.domain, [], {})
+
+    potentials = potentials.apply_sharding(mesh)
+    domain, cliques = potentials.domain, potentials.cliques
+
+    # Build the junction tree, including constraint edges.
+    extra = [
+        domain.canonical(c.clique)
+        for c in constraints
+        if domain.canonical(c.clique) not in cliques
+    ]
+    if jtree is None:
+        jtree = junction_tree.make_junction_tree(domain, cliques + extra)[0]
+    message_order = junction_tree.message_passing_order(jtree)
+    max_cliques = junction_tree.maximal_cliques(jtree)
+    pure_constraint, embedded = _classify_cliques(max_cliques, constraints)
+    neighbors = {cl: list(jtree.neighbors(cl)) for cl in max_cliques}
+
+    # Partition user potentials by pure-constraint membership.
+    constraint_init = {}
+    non_constraint_cliques = []
+    for cl in cliques:
+        con_mc = next(
+            (mc for mc in pure_constraint if set(cl) <= set(mc)), None
+        )
+        if con_mc:
+            constraint_init.setdefault(con_mc, []).append(potentials[cl])
+        else:
+            non_constraint_cliques.append(cl)
+
+    # Initialize beliefs for non-pure-constraint maximal cliques.
+    non_pure = [mc for mc in max_cliques if mc not in pure_constraint]
+    if non_constraint_cliques:
+        nc = CliqueVector(
+            domain,
+            non_constraint_cliques,
+            {cl: potentials[cl] for cl in non_constraint_cliques},
+        )
+        beliefs0 = nc.expand(non_pure).apply_sharding(mesh)
+    else:
+        beliefs0 = CliqueVector(
+            domain,
+            non_pure,
+            {mc: Factor.zeros(domain.project(mc)) for mc in non_pure},
+        )
+
+    # Forward-backward message passing.
+    messages = {}
+    for i, j in message_order:
+        sep_vars = set(i) & set(j)
+
+        if i in pure_constraint:
+            c = pure_constraint[i]
+            inputs = [
+                messages[(k, i)]
+                for k in neighbors[i]
+                if k != j and (k, i) in messages
+            ]
+            inputs.extend(constraint_init.get(i, []))
+            msg = _constraint_message(c, inputs, c.fine in sep_vars)
+            if msg is None:
+                sizes = {c.fine: c.n_fine, c.coarse: c.n_coarse}
+                sep = tuple(sep_vars)
+                msg = Factor.zeros(Domain(list(sep), [sizes[s] for s in sep]))
+            messages[(i, j)] = msg
+        else:
+            tau = beliefs0[i]
+            for k in neighbors[i]:
+                if k != j and (k, i) in messages:
+                    tau = tau + messages[(k, i)]
+            if i in embedded:
+                messages[(i, j)] = _embedded_message(tau, sep_vars, embedded[i])
+            else:
+                messages[(i, j)] = tau.logsumexp(
+                    tau.domain.invert(tuple(sep_vars))
+                )
+
+    # Collect final beliefs, applying constraint slicing.
+    belief_map = {}
+    belief_cliques = []
+    for cl in max_cliques:
+        if cl in pure_constraint:
+            continue
+        b = beliefs0[cl]
+        for k in neighbors[cl]:
+            if (k, cl) in messages:
+                b = b + messages[(k, cl)]
+        if cl in embedded:
+            for c in embedded[cl]:
+                b = _constraint_slice(b, c)
+        key = tuple(b.domain.attributes)
+        belief_map[key] = b
+        belief_cliques.append(key)
+
+    result_cv = CliqueVector(domain, belief_cliques, belief_map)
+    result_cv = result_cv.normalize(total, log=True).exp()
+
+    # Project back to user cliques.
+    result = {}
+    for cl in cliques:
+        if result_cv.supports(cl):
+            result[cl] = result_cv.project(cl)
+        elif any(set(cl) <= set(mc) for mc in pure_constraint):
+            # Clique subsumed by a pure constraint — derive from
+            # constraint messages and absorbed potentials.
+            result[cl] = _derive_pure_marginal(
+                cl,
+                pure_constraint,
+                constraint_init,
+                neighbors,
+                messages,
+                total,
+                domain,
+            )
+        else:
+            # Try re-expanding beliefs where constraint slicing removed
+            # a coarse variable the user needs.
+            expanded = _try_expand_belief(cl, result_cv, constraints)
+            if expanded is not None:
+                result[cl] = expanded
+            else:
+                result[cl] = _derive_pure_marginal(
+                    cl,
+                    pure_constraint,
+                    constraint_init,
+                    neighbors,
+                    messages,
+                    total,
+                    domain,
+                )
+
+    return CliqueVector(domain, cliques, result).apply_sharding(mesh)

--- a/test/test_deterministic.py
+++ b/test/test_deterministic.py
@@ -1,0 +1,433 @@
+"""Tests for deterministic constraint handling.
+
+Tests the coarsen/refine primitives and the constraint-aware message passing
+against standard Shafer-Shenoy baselines with explicit -inf constraint factors.
+"""
+
+import unittest
+
+import jax.numpy as jnp
+from mbi.clique_vector import CliqueVector
+from mbi.domain import Domain
+from mbi.extensions.constraints import coarsen
+from mbi.extensions.constraints import DeterministicConstraint
+from mbi.extensions.constraints import message_passing_with_constraints
+from mbi.extensions.constraints import project_to_coarse
+from mbi.extensions.constraints import refine
+from mbi.factor import Factor
+from mbi.marginal_oracles import message_passing_shafer_shenoy
+import numpy as np
+from parameterized import parameterized
+
+
+def _make_constraint_factor(domain, constraint):
+    """Build the explicit 0/-inf constraint factor for baseline comparison."""
+    shape = (constraint.n_fine, constraint.n_coarse)
+    vals = np.full(shape, -np.inf)
+    for a, a_prime in enumerate(constraint.mapping):
+        vals[a, a_prime] = 0.0
+    dom = Domain([constraint.fine, constraint.coarse], list(shape))
+    return Factor(dom, jnp.array(vals)).transpose(
+        domain.canonical(constraint.clique)
+    )
+
+
+def _baseline_marginals(domain, cliques, potentials, constraints, total=10.0):
+    """Marginals via standard Shafer-Shenoy with explicit -inf constraints."""
+    if isinstance(constraints, DeterministicConstraint):
+        constraints = [constraints]
+    arrays = {cl: potentials[cl] for cl in cliques}
+    all_cliques = list(cliques)
+    for c in constraints:
+        con_cl = domain.canonical(c.clique)
+        con_factor = _make_constraint_factor(domain, c)
+        if con_cl in arrays:
+            arrays[con_cl] = arrays[con_cl] + con_factor
+        else:
+            arrays[con_cl] = con_factor
+            all_cliques.append(con_cl)
+    return message_passing_shafer_shenoy(
+        CliqueVector(domain, all_cliques, arrays), total
+    )
+
+
+def _assert_matches_baseline(
+    test, domain, cliques, constraints, total=10.0, seed=None
+):
+    """Assert constraint-aware message passing matches the -inf baseline."""
+    if seed is not None:
+        np.random.seed(seed)
+    potentials = CliqueVector.random(domain, cliques)
+    result = message_passing_with_constraints(
+        potentials,
+        total,
+        constraints=tuple(
+            constraints
+            if isinstance(constraints, (list, tuple))
+            else [constraints]
+        ),
+    )
+    baseline = _baseline_marginals(
+        domain, cliques, potentials, constraints, total
+    )
+    for cl in cliques:
+        np.testing.assert_allclose(
+            result[cl].datavector(),
+            baseline[cl].datavector(),
+            atol=1e-4,
+            err_msg=f'Mismatch at {cl}',
+        )
+    return result
+
+
+def _random_surjection(n_domain, n_range, rng):
+    """Generate a random surjective mapping from [n_domain] to [n_range]."""
+    mapping = np.zeros(n_domain, dtype=int)
+    mapping[:n_range] = np.arange(n_range)
+    mapping[n_range:] = rng.integers(0, n_range, size=n_domain - n_range)
+    rng.shuffle(mapping)
+    return mapping
+
+
+_SIMPLE_DOMAIN = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+_SIMPLE_CONSTRAINT = DeterministicConstraint(
+    'A', 'Ap', np.array([0, 0, 1, 1, 2, 2])
+)
+_CLIQUE_CONFIGS = [
+    [('A', 'B'), ('Ap', 'C')],
+    [('A', 'B'), ('A',), ('Ap', 'C')],
+    [('A', 'B'), ('Ap', 'C'), ('Ap',)],
+    [('A', 'B'), ('A',), ('Ap', 'C'), ('Ap',)],
+]
+
+
+class TestCoarsenRefine(unittest.TestCase):
+
+    def setUp(self):
+        self.mapping = np.array([0, 0, 1, 1, 2, 2])
+        self.constraint = DeterministicConstraint('A', 'Ap', self.mapping)
+
+    def test_coarsen_1d(self):
+        dom = Domain(['A'], [6])
+        vals = jnp.log(jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+        result = coarsen(Factor(dom, vals), self.constraint)
+        self.assertEqual(result.domain.attributes, ('Ap',))
+        np.testing.assert_allclose(jnp.exp(result.values), [3.0, 7.0, 11.0])
+
+    def test_refine_1d(self):
+        dom = Domain(['Ap'], [3])
+        result = refine(
+            Factor(dom, jnp.array([10.0, 20.0, 30.0])), self.constraint
+        )
+        self.assertEqual(result.domain.attributes, ('A',))
+        np.testing.assert_allclose(result.values, [10, 10, 20, 20, 30, 30])
+
+    def test_coarsen_2d(self):
+        dom = Domain(['A', 'B'], [6, 2])
+        result = coarsen(
+            Factor(dom, jnp.log(jnp.ones((6, 2)))), self.constraint
+        )
+        self.assertEqual(result.domain.attributes, ('Ap', 'B'))
+        np.testing.assert_allclose(
+            jnp.exp(result.values), 2.0 * jnp.ones((3, 2))
+        )
+
+    def test_refine_2d(self):
+        dom = Domain(['Ap', 'C'], [3, 4])
+        result = refine(
+            Factor(dom, jnp.arange(12.0).reshape(3, 4)), self.constraint
+        )
+        self.assertEqual(result.domain.attributes, ('A', 'C'))
+        # Rows 0,1 match Ap=0; rows 2,3 match Ap=1; rows 4,5 match Ap=2
+        np.testing.assert_allclose(result.values[0], result.values[1])
+        np.testing.assert_allclose(result.values[2], result.values[3])
+        np.testing.assert_allclose(result.values[4], result.values[5])
+
+    def test_roundtrip_coarsen_refine(self):
+        dom = Domain(['Ap'], [3])
+        vals = jnp.array([1.0, 2.0, 3.0])
+        recovered = coarsen(
+            refine(Factor(dom, vals), self.constraint), self.constraint
+        )
+        np.testing.assert_allclose(
+            recovered.values, vals + jnp.log(2.0), atol=1e-6
+        )
+
+    def test_project_to_coarse(self):
+        dom = Domain(['A', 'B'], [6, 2])
+        result = project_to_coarse(
+            Factor(dom, jnp.ones((6, 2))), self.constraint
+        )
+        self.assertEqual(result.domain.attributes, ('Ap', 'B'))
+        np.testing.assert_allclose(result.values, 2.0 * jnp.ones((3, 2)))
+
+
+class TestCoarsenRefineRandomized(unittest.TestCase):
+    """Property-based tests: coarsen matches explicit constraint + logsumexp."""
+
+    @parameterized.expand(range(10))
+    def test_coarsen_matches_explicit(self, seed):
+        rng = np.random.default_rng(seed)
+        n_fine = rng.integers(4, 20)
+        n_coarse = rng.integers(2, n_fine)
+        mapping = _random_surjection(n_fine, n_coarse, rng)
+        constraint = DeterministicConstraint('X', 'Y', mapping)
+
+        n_other = rng.integers(2, 6)
+        dom = Domain(['X', 'Z'], [n_fine, n_other])
+        factor = Factor(dom, jnp.array(rng.standard_normal((n_fine, n_other))))
+
+        result = coarsen(factor, constraint)
+
+        # Reference: explicit constraint factor + logsumexp
+        con_vals = np.full((n_fine, n_coarse), -np.inf)
+        for a in range(n_fine):
+            con_vals[a, mapping[a]] = 0.0
+        joint_dom = Domain(['X', 'Y', 'Z'], [n_fine, n_coarse, n_other])
+        joint = factor.expand(joint_dom) + Factor(
+            Domain(['X', 'Y'], [n_fine, n_coarse]), jnp.array(con_vals)
+        ).expand(joint_dom)
+        reference = joint.logsumexp(['X'])
+
+        np.testing.assert_allclose(
+            result.values,
+            reference.transpose(result.domain.attributes).values,
+            atol=1e-5,
+        )
+
+
+class TestMessagePassingWithConstraints(unittest.TestCase):
+    """Constraint-aware message passing matches the -inf baseline."""
+
+    @parameterized.expand([
+        (cliques, total)
+        for cliques in _CLIQUE_CONFIGS
+        for total in [1.0, 10.0, 100.0]
+    ])
+    def test_uniform_sums_to_total(self, cliques, total):
+        potentials = CliqueVector.zeros(_SIMPLE_DOMAIN, cliques)
+        result = message_passing_with_constraints(
+            potentials, total, constraints=(_SIMPLE_CONSTRAINT,)
+        )
+        for cl in cliques:
+            np.testing.assert_allclose(
+                result[cl].values.sum(), total, atol=1e-4
+            )
+
+    @parameterized.expand([(c,) for c in _CLIQUE_CONFIGS])
+    def test_matches_baseline(self, cliques):
+        _assert_matches_baseline(
+            self, _SIMPLE_DOMAIN, cliques, _SIMPLE_CONSTRAINT, total=10.0
+        )
+
+    @parameterized.expand([(c,) for c in _CLIQUE_CONFIGS])
+    def test_no_nans(self, cliques):
+        potentials = CliqueVector.random(_SIMPLE_DOMAIN, cliques)
+        result = message_passing_with_constraints(
+            potentials, 10.0, constraints=(_SIMPLE_CONSTRAINT,)
+        )
+        for cl in cliques:
+            self.assertFalse(jnp.isnan(result[cl].values).any())
+
+    @parameterized.expand([(c,) for c in _CLIQUE_CONFIGS])
+    def test_non_negative(self, cliques):
+        potentials = CliqueVector.random(_SIMPLE_DOMAIN, cliques)
+        result = message_passing_with_constraints(
+            potentials, 10.0, constraints=(_SIMPLE_CONSTRAINT,)
+        )
+        for cl in cliques:
+            self.assertTrue((result[cl].values >= -1e-10).all())
+
+
+class TestMultipleConstraints(unittest.TestCase):
+    """Tests with two deterministic constraints."""
+
+    def _two_constraint_setup(self):
+        domain = Domain(['A', 'Ap', 'B', 'Bp', 'C'], [6, 3, 8, 4, 5])
+        c1 = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
+        c2 = DeterministicConstraint(
+            'B', 'Bp', np.array([0, 0, 1, 1, 2, 2, 3, 3])
+        )
+        return domain, (c1, c2)
+
+    def test_two_constraints_basic(self):
+        domain, constraints = self._two_constraint_setup()
+        _assert_matches_baseline(
+            self, domain, [('A', 'C'), ('Ap', 'Bp'), ('B',)], constraints
+        )
+
+    def test_two_constraints_shared_factor(self):
+        domain, constraints = self._two_constraint_setup()
+        _assert_matches_baseline(
+            self, domain, [('A',), ('B',), ('Ap', 'Bp')], constraints
+        )
+
+    def test_two_constraints_fine_and_coarse_mixed(self):
+        domain, constraints = self._two_constraint_setup()
+        _assert_matches_baseline(
+            self, domain, [('A', 'Bp'), ('B', 'Ap')], constraints
+        )
+
+    @parameterized.expand(range(10))
+    def test_two_constraints_randomized(self, seed):
+        rng = np.random.default_rng(seed)
+        n_a, n_ap = rng.integers(4, 12), rng.integers(2, 4)
+        n_b, n_bp = rng.integers(4, 12), rng.integers(2, 4)
+        n_c = rng.integers(2, 6)
+
+        domain = Domain(
+            ['A', 'Ap', 'B', 'Bp', 'C'], [n_a, n_ap, n_b, n_bp, n_c]
+        )
+        c1 = DeterministicConstraint(
+            'A', 'Ap', _random_surjection(n_a, n_ap, rng)
+        )
+        c2 = DeterministicConstraint(
+            'B', 'Bp', _random_surjection(n_b, n_bp, rng)
+        )
+        cliques = [('A', 'C'), ('Bp',)]
+        total = 10.0
+
+        potentials = CliqueVector.random(domain, cliques)
+        result = message_passing_with_constraints(
+            potentials, total, constraints=(c1, c2)
+        )
+        baseline = _baseline_marginals(
+            domain, cliques, potentials, [c1, c2], total
+        )
+
+        for cl in cliques:
+            np.testing.assert_allclose(
+                result[cl].datavector(),
+                baseline[cl].datavector(),
+                atol=1e-4,
+                err_msg=f'Seed {seed}, clique {cl}',
+            )
+
+
+class TestComplexTopologies(unittest.TestCase):
+    """Tests with more complex graph structures."""
+
+    _CONSTRAINT = DeterministicConstraint(
+        'A', 'Ap', np.array([0, 0, 1, 1, 2, 2])
+    )
+
+    def _check(self, domain, cliques, constraint=None):
+        _assert_matches_baseline(
+            self, domain, cliques, constraint or self._CONSTRAINT
+        )
+
+    def test_many_neighbors(self):
+        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [6, 3, 4, 5, 3])
+        self._check(domain, [('A', 'B'), ('A', 'C'), ('Ap', 'D')])
+
+    def test_singletons(self):
+        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+        self._check(domain, [('A',), ('Ap',), ('B',)])
+
+    def test_fine_in_multiple_factors(self):
+        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
+        constraint = DeterministicConstraint(
+            'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
+        )
+        self._check(
+            domain, [('A', 'B'), ('A', 'C'), ('A', 'D'), ('Ap',)], constraint
+        )
+
+    def test_coarse_in_multiple_factors(self):
+        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
+        constraint = DeterministicConstraint(
+            'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
+        )
+        self._check(
+            domain, [('A',), ('Ap', 'B'), ('Ap', 'C'), ('Ap', 'D')], constraint
+        )
+
+    def test_uneven_groups(self):
+        domain = Domain(['A', 'Ap', 'B'], [10, 3, 4])
+        constraint = DeterministicConstraint(
+            'A', 'Ap', np.array([0, 1, 2, 2, 2, 2, 2, 2, 2, 2])
+        )
+        self._check(domain, [('A', 'B'), ('Ap',)], constraint)
+
+    def test_large_ratio(self):
+        n_fine, n_coarse = 50, 5
+        mapping = np.repeat(np.arange(n_coarse), n_fine // n_coarse)
+        domain = Domain(['A', 'Ap', 'B'], [n_fine, n_coarse, 8])
+        constraint = DeterministicConstraint('A', 'Ap', mapping)
+        self._check(domain, [('A', 'B'), ('Ap',)], constraint)
+
+    def test_disconnected_components(self):
+        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [6, 3, 4, 5, 3])
+        self._check(domain, [('A', 'B'), ('Ap',), ('C', 'D')])
+
+    def test_user_clique_spans_constraint_pair(self):
+        """User provides a clique (A, Ap) that matches the constraint pair."""
+        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+        self._check(domain, [('A', 'Ap'), ('A', 'B')])
+
+    def test_user_clique_is_fine_coarse_plus_extra(self):
+        """User clique (A, Ap, B) embeds constraint in a 3-way factor."""
+        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+        self._check(domain, [('A', 'Ap', 'B')])
+
+    def test_identity_mapping(self):
+        """1:1 mapping (permutation) — degenerate constraint."""
+        domain = Domain(['A', 'Ap', 'B'], [4, 4, 5])
+        constraint = DeterministicConstraint('A', 'Ap', np.array([0, 1, 2, 3]))
+        self._check(domain, [('A', 'B'), ('Ap',)], constraint)
+
+    def test_orphan_coarse_variable(self):
+        """Coarse variable appears only via constraint, not in any user clique."""
+        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+        self._check(domain, [('A', 'B')])
+
+    def test_orphan_fine_variable(self):
+        """Fine variable appears only via constraint, not in any user clique."""
+        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+        self._check(domain, [('Ap', 'B')])
+
+    def test_cyclic_model(self):
+        """Cyclic model structure (requires triangulation)."""
+        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+        self._check(domain, [('A', 'B'), ('B', 'C'), ('Ap', 'C')])
+
+    def test_only_constraint_variables(self):
+        """All cliques reference only constraint variables."""
+        domain = Domain(['A', 'Ap'], [6, 3])
+        self._check(domain, [('A',), ('Ap',)])
+
+    def test_fine_and_coarse_singletons(self):
+        """Both fine and coarse as singleton user cliques."""
+        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+        self._check(domain, [('A',), ('Ap',), ('A', 'B'), ('Ap', 'C')])
+
+    def test_all_variables_in_one_clique(self):
+        """All variables including constraint pair in a single clique."""
+        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+        self._check(domain, [('A', 'Ap', 'B', 'C')])
+
+    def test_shared_constraint_separator(self):
+        """Two embedded cliques sharing (fine, coarse) as the separator."""
+        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+        self._check(domain, [('A', 'Ap', 'B'), ('A', 'Ap', 'C')])
+
+
+class TestDeterministicConstraint(unittest.TestCase):
+
+    def test_properties(self):
+        c = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
+        self.assertEqual(c.n_fine, 6)
+        self.assertEqual(c.n_coarse, 3)
+        self.assertEqual(c.clique, ('A', 'Ap'))
+
+    def test_hash_eq(self):
+        c1 = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1]))
+        c2 = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1]))
+        c3 = DeterministicConstraint('A', 'Ap', np.array([0, 1, 1]))
+        self.assertEqual(c1, c2)
+        self.assertNotEqual(c1, c3)
+        self.assertEqual(hash(c1), hash(c2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -3,6 +3,7 @@ from mbi.domain import Domain
 from mbi.factor import Factor
 from mbi.clique_vector import CliqueVector
 from mbi import marginal_oracles
+from mbi.extensions.constraints import message_passing_with_constraints
 import jax.numpy as jnp
 import numpy as np
 from parameterized import parameterized
@@ -48,6 +49,7 @@ _ORACLES = [
     marginal_oracles.message_passing_shafer_shenoy,
     marginal_oracles.message_passing_fast,
     message_passing_fast_v1,
+    message_passing_with_constraints,
     _variable_elimination_oracle,
     _calculate_many_oracle,
     _bulk_variable_elimination_oracle,
@@ -56,6 +58,7 @@ _ORACLES = [
 _STABLE_ORACLES = [
     marginal_oracles.brute_force_marginals,
     marginal_oracles.message_passing_shafer_shenoy,
+    message_passing_with_constraints,
 ]
 
 _DOMAIN = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])


### PR DESCRIPTION
Add efficient handling of deterministic variable constraints

## Summary

Adds constraint-aware message passing that avoids materializing |fine| × |coarse| constraint factors during Shafer-Shenoy inference.

## Motivation

When a graphical model includes deterministic relationships between variables (e.g., A' = f(A) where A' is a coarsening of A), the standard approach materializes an |A| × |A'| constraint factor filled with 0/-inf entries. This is wasteful when A is large. This PR routes messages through the constraint in O(|A|) time instead.

## Key primitives

- `coarsen` — log-space fine→coarse via `segment_logsumexp` 
- `refine` — log-space coarse→fine via `jnp.take`
- `_constraint_slice` — select valid constraint entries via `jnp.take_along_axis`
- `project_to_coarse` — probability-space fine→coarse via `segment_sum`

## Architecture

`message_passing_with_constraints` extends the existing Shafer-Shenoy algorithm with a tripartite maximal clique classification:

| Type | Example | Handling |
|---|---|---|
| **Pure constraint** | `{A, Ap}` exactly | Messages routed via `coarsen`/`refine` |
| **Embedded constraint** | `{A, Ap, B}` (absorbed during triangulation) | `_constraint_slice` + `coarsen` |
| **Standard** | `{B, C}` | Standard Shafer-Shenoy |

## Test coverage

All results verified against the explicit -inf constraint baseline (`message_passing_shafer_shenoy` with 0/-inf factors):

- **Primitives**: 6 unit tests + 10 randomized property tests
- **Single constraint**: 4 clique configs × 3 totals + baseline matching + NaN/negativity checks
- **Two constraints**: basic, shared factor, mixed fine/coarse + 10 randomized
- **Complex topologies**: many neighbors, singletons, fine/coarse in multiple factors, uneven groups, large ratio, disconnected components

## Files changed

- `src/mbi/extensions/deterministic.py` (354 lines) — new module
- `src/mbi/__init__.py` — surface `DeterministicConstraint` in public API
- `test/test_deterministic.py` (343 lines) — comprehensive test suite
