### PR TITLE
Default to float32, remove jax_enable_x64

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -25,11 +25,11 @@ import numpy as np
 import optax
 
 from . import marginal_loss, marginal_oracles
-from ._api import Estimator, PGMEstimator  # noqa: F401
+from ._api import Estimator, PGMEstimator  # noqa: F401  # pylint: disable=unused-import
 from .approximate_oracles import StatefulMarginalOracle
 from .clique_vector import CliqueVector
 from .domain import Domain
-from .factor import Factor, Projectable
+from .factor import Factor, Projectable  # pylint: disable=unused-import
 from .marginal_loss import LinearMeasurement
 from .markov_random_field import MarkovRandomField
 

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable, Sequence
-from typing import Literal, Protocol
+from typing import Literal
 
 import attr
 import chex
@@ -13,8 +13,6 @@ import jax.numpy as jnp
 import numpy as np
 
 from .domain import Domain
-
-jax.config.update("jax_enable_x64", True)
 
 
 @functools.partial(
@@ -75,7 +73,7 @@ class Factor:
 
     @classmethod
     def abstract(cls, domain: Domain) -> Factor:
-        return cls(domain, jax.ShapeDtypeStruct(domain.shape, jnp.float64))
+        return cls(domain, jax.ShapeDtypeStruct(domain.shape, jnp.float32))
 
     # Reshaping operations
     def transpose(self, attrs: Sequence[str]) -> Factor:
@@ -332,7 +330,7 @@ class Factor:
 
 
 # Re-export for backward compatibility; canonical definition is in _api.py.
-from ._api import Projectable  # noqa: E402
+from ._api import Projectable  # noqa: E402  # pylint: disable=wrong-import-position,unused-import
 
 __all__ = [name for name in dir() if not name.startswith("_")] + [
     "Projectable",

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -84,6 +84,7 @@ class MarkovRandomField:
 
         def synthetic_col(counts, total):
             """Generates a synthetic column by sampling or rounding based on counts and total."""
+            counts = np.asarray(counts, dtype=np.float64)
             dtype = np.min_scalar_type(counts.size)
             options = np.arange(counts.size, dtype=dtype)
             if total == 0:

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -166,7 +166,7 @@ class TestCustomDotGeneral(unittest.TestCase):
 
 class TestScanEinsum(unittest.TestCase):
 
-    def assertArraysAllClose(self, arr1, arr2, msg=None, rtol=1e-7, atol=1e-9):
+    def assertArraysAllClose(self, arr1, arr2, msg=None, rtol=1e-5, atol=1e-5):
         self.assertTrue(jnp.allclose(arr1, arr2, rtol=rtol, atol=atol), msg=msg)
 
     def test_no_sequential(self):

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -38,7 +38,7 @@ class TestEstimation(unittest.TestCase):
     def test_total_estimator(self, cliques):
         measurements = fake_measurements(cliques)
         total = estimation.minimum_variance_unbiased_total(measurements)
-        np.testing.assert_allclose(total, 1.0)
+        np.testing.assert_allclose(total, 1.0, rtol=1e-5)
 
     @parameterized.expand(itertools.product(_CLIQUE_SETS))
     def test_mirror_descent(self, cliques):

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -96,7 +96,9 @@ class TestMarginalOracles(unittest.TestCase):
         marginals = oracle(zeros, total)
         for cl in cliques:
             expected = total / _DOMAIN.size(cl)
-            np.testing.assert_allclose(marginals[cl].datavector(), expected)
+            np.testing.assert_allclose(
+                marginals[cl].datavector(), expected, rtol=1e-5
+            )
 
     @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS))
     def test_matches_brute_force(self, oracle, cliques, total=10):
@@ -105,7 +107,7 @@ class TestMarginalOracles(unittest.TestCase):
         mu2 = marginal_oracles.brute_force_marginals(theta, total)
         for cl in cliques:
             np.testing.assert_allclose(
-                mu1[cl].datavector(), mu2[cl].datavector()
+                mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
             )
 
     @parameterized.expand(itertools.product(_CLIQUE_SETS, _ALL_CLIQUES))
@@ -144,7 +146,7 @@ class TestMarginalOracles(unittest.TestCase):
 
         ans2 = ans2.transpose(ans1.domain.attributes)
 
-        np.testing.assert_allclose(ans1.values, ans2.values, atol=1e-12)
+        np.testing.assert_allclose(ans1.values, ans2.values, atol=1e-5)
         self.assertEqual(ans1.domain, ans2.domain)
 
     @parameterized.expand(_STABLE_ORACLES)


### PR DESCRIPTION
## Summary

Switches MBI from float64 to float32 as the default precision.

### Changes

- **`factor.py`**: Remove global `jax.config.update('jax_enable_x64', True)`. Change `Factor.abstract` default dtype from `float64` to `float32`.
- **`markov_random_field.py`**: Cast counts to `float64` before probability normalization in `synthetic_data` — numpy's `np.random.choice` requires probabilities that sum exactly to 1.
- **Test tolerance adjustments**:
  - `test_marginal_oracles.py`: `atol=1e-12` → `atol=1e-5`, default → `rtol=1e-5`
  - `test_einsum.py`: `rtol=1e-7/atol=1e-9` → `rtol=1e-5/atol=1e-5`

### Results

- 744/744 tests pass
- Test suite ~23% faster (4:14 → 3:16)
- Users who need float64 can still set `jax.config.update('jax_enable_x64', True)` themselves