### PR TITLE
Seed all test randomness for deterministic execution

### DIFF
--- a/test/test_approximate_oracles.py
+++ b/test/test_approximate_oracles.py
@@ -8,6 +8,8 @@ import numpy as np
 from parameterized import parameterized
 import itertools
 
+np.random.seed(0)
+
 
 _ORACLES = [approximate_oracles.convex_generalized_belief_propagation]
 

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -4,6 +4,8 @@ import jax.numpy as jnp
 from mbi.einsum import scan_einsum, custom_dot_general
 import numpy as np
 
+np.random.seed(0)
+
 
 class TestCustomDotGeneral(unittest.TestCase):
 

--- a/test/test_factor.py
+++ b/test/test_factor.py
@@ -4,6 +4,8 @@ from mbi.domain import Domain
 import numpy as np
 import jax.numpy as jnp
 
+np.random.seed(0)
+
 
 class TestFactor(unittest.TestCase):
 

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -10,6 +10,8 @@ from parameterized import parameterized
 import itertools
 import functools
 
+np.random.seed(0)
+
 
 def _variable_elimination_oracle(
     potentials: CliqueVector, total: float = 1


### PR DESCRIPTION
Adds `np.random.seed(0)` to the 4 test files that were missing it:

- `test_marginal_oracles.py`
- `test_einsum.py`
- `test_factor.py`
- `test_approximate_oracles.py`

The other 6 test files with randomness already had seeds. The remaining 5 test files use no randomness at all.

849/849 tests pass. All lint checks green.