### PR TITLE
Register MarginalLossFn as JAX pytree

### DIFF
--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -20,6 +20,7 @@ from typing import Any, NamedTuple, Protocol, TypeAlias
 
 import attr
 import jax
+import jax.numpy as jnp
 import networkx as nx
 from scipy.cluster.hierarchy import DisjointSet
 
@@ -303,12 +304,11 @@ class ApproxMirrorDescent:
         )
         return ApproxMirrorDescentState(potentials, mu, messages)
 
-    @functools.partial(jax.jit, static_argnames=["self", "loss_fn"])
+    @functools.partial(jax.jit, static_argnames=["self"])
     def _step(
         self,
         state: ApproxMirrorDescentState,
         total: jax.Array | float,
-        *,
         loss_fn: marginal_loss.MarginalLossFn,
     ) -> ApproxMirrorDescentState:
         """Perform a single mirror descent step."""
@@ -353,7 +353,7 @@ class ApproxMirrorDescent:
         state = self._init(potentials, known_total)
 
         for _ in range(iters):
-            state = self._step(state, known_total, loss_fn=loss_fn)
+            state = self._step(state, known_total, loss_fn)
             callback_fn(state.mu)
 
         # Final oracle call with warm-started messages.
@@ -370,31 +370,43 @@ class ApproxMirrorDescent:
     def precompile(
         self,
         domain: Domain,
-        loss_fn: marginal_loss.MarginalLossFn | list[LinearMeasurement],
+        measurements: list[LinearMeasurement] | None = None,
         *,
-        known_total: float | None = None,
-        potentials: CliqueVector | None = None,
+        extra_cliques: list[tuple[str, ...]] | None = None,
     ) -> None:
         """Warm up the JIT cache for ``estimate``.
 
-        Triggers ahead-of-time compilation of the jitted step function using
-        ``lower().compile()``.  The compiled program is discarded, but it
-        populates the JIT cache so that subsequent calls to ``estimate`` with
-        the same ``loss_fn`` skip compilation entirely.
+        Triggers ahead-of-time compilation of the jitted step function
+        without materializing any concrete arrays.  Because
+        ``MarginalLossFn`` is a JAX pytree, the compiled program depends
+        only on the clique structure and loss type (static metadata), not
+        on measurement values (dynamic leaves).
+
+        You may pass concrete ``measurements`` you already have, plus
+        ``extra_cliques`` for cliques whose measurements are not yet
+        available.  Abstract ``LinearMeasurement`` objects with
+        ``ShapeDtypeStruct`` values are constructed for extra cliques.
 
         Args:
             domain: The domain over which the model is defined.
-            loss_fn: A ``MarginalLossFn`` or a list of ``LinearMeasurement``.
-            known_total: The known or estimated number of records.
-            potentials: Initial potentials.
+            measurements: Optional list of ``LinearMeasurement`` objects.
+            extra_cliques: Optional additional cliques to compile for.
         """
-        loss_fn, known_total, potentials = estimation._initialize(
-            domain, loss_fn, known_total, potentials
-        )
-        state = self._init(potentials, known_total)
+        all_measurements = list(measurements or [])
+        for cl in extra_cliques or []:
+            shape = (domain.project(cl).size(),)
+            abstract_values = jax.ShapeDtypeStruct(shape, jnp.float32)
+            all_measurements.append(LinearMeasurement(abstract_values, cl))
+
+        loss_fn = marginal_loss.from_linear_measurements(all_measurements)
+        potentials = CliqueVector.abstract(domain, loss_fn.cliques)
+
+        # Use eval_shape to get the abstract state pytree without
+        # running any computation.
+        abstract_state = jax.eval_shape(self._init, potentials, 1.0)
 
         # lower().compile() populates the jit cache without executing.
-        self._step.lower(self, state, known_total, loss_fn=loss_fn).compile()
+        self._step.lower(self, abstract_state, 1.0, loss_fn).compile()
 
 
 def mirror_descent(

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -181,7 +181,7 @@ def mirror_descent(
     mu = marginal_oracle(potentials, known_total)
     initial_loss = loss_fn(mu)
 
-    # Use partial to capture non-hashable args (MarginalLossFn has list fields).
+    # Use partial to capture loss_fn and marginal_oracle as closed-over args.
     state = MirrorDescentState(potentials, alpha, initial_loss, mu)
     step = jax.jit(
         functools.partial(

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -2,15 +2,16 @@
 
 This module provides structures and functions for defining and calculating loss
 based on potentially noisy linear measurements of marginal distributions. Key
-components include the `LinearMeasurement` class to represent individual
-measurements and the `MarginalLossFn` class to define loss functions over
-`CliqueVector` objects, enabling the evaluation of model fit against observed
+components include the ``LinearMeasurement`` class to represent individual
+measurements and the ``MarginalLossFn`` class to define loss functions over
+``CliqueVector`` objects, enabling the evaluation of model fit against observed
 or noisy data. Utilities for clique manipulation and feasibility checks are also
 included.
 """
 
 import functools
 from collections.abc import Callable, Sequence
+from typing import Any
 
 import attr
 import chex
@@ -27,7 +28,7 @@ from .factor import Factor
 @functools.partial(
     jax.tree_util.register_dataclass,
     meta_fields=["clique", "stddev", "query"],
-    data_fields=["values"],
+    data_fields=["noisy_measurement"],
 )
 @attr.dataclass(frozen=True)
 class LinearMeasurement:
@@ -47,28 +48,85 @@ class LinearMeasurement:
     query: Callable[[Factor], jax.Array] = Factor.datavector
 
 
-# this class might need to be refactored so that loss_fn consumes measurements
-# that way measurements can be included as an input to the jitted.
-# Or it can be a pytree where the measurements are one node in the PyTree.
+@functools.partial(
+    jax.tree_util.register_dataclass,
+    data_fields=["data"],
+    meta_fields=["cliques", "loss_fn", "lipschitz"],
+)
 @attr.dataclass(frozen=True)
 class MarginalLossFn:
-    """A Loss function over the concatenated vector of marginals.
+    """A loss function over the concatenated vector of marginals.
+
+    Separates the computation (``loss_fn``, static) from the captured data
+    (``data``, dynamic JAX pytree leaves).  This allows ``MarginalLossFn``
+    to be passed through ``jax.jit`` as a regular traced argument rather
+    than a static one, so that different measurement values with the same
+    structure reuse the same compiled program.
 
     Attributes:
-        cliques: A list of cliques (tuples of attribute names) that define the
-            scope of the marginals used in the loss function.
-        loss_fn: A callable that takes a `CliqueVector` (representing the
-            marginals) and returns a numeric loss value.
-        lipschitz: An optional float representing the Lipschitz constant of the
-            gradient of the loss function. This is used for optimization algorithms.
+        cliques: Cliques defining the scope of the marginals.
+        loss_fn: A pure function ``(marginals, data) -> loss``.  This is
+            treated as static metadata for JIT compilation.
+        data: Arbitrary pytree of arrays captured by ``loss_fn``.  This is
+            traced through JIT and can change without recompilation.
+        lipschitz: Optional Lipschitz constant of the gradient.
     """
 
     cliques: Sequence[Clique] = attr.field(converter=tuple)
-    loss_fn: Callable[[CliqueVector], chex.Numeric]
+    loss_fn: Callable[[CliqueVector, Any], chex.Numeric]
+    data: Any = ()
     lipschitz: float | None = None
 
     def __call__(self, marginals: CliqueVector) -> chex.Numeric:
-        return self.loss_fn(marginals)
+        return self.loss_fn(marginals, self.data)
+
+
+def _l2_loss(
+    marginals: CliqueVector,
+    measurements: tuple[LinearMeasurement, ...],
+) -> chex.Numeric:
+    """Weighted L2 loss over linear measurements."""
+    loss = 0.0
+    for M in measurements:
+        mu = marginals.project(M.clique)
+        stddev = jnp.maximum(M.stddev, 1e-12)
+        diff = (M.query(mu) - M.noisy_measurement) / stddev
+        loss += 0.5 * jnp.vdot(diff, diff)
+    return loss
+
+
+def _l1_loss(
+    marginals: CliqueVector,
+    measurements: tuple[LinearMeasurement, ...],
+) -> chex.Numeric:
+    """Weighted L1 loss over linear measurements."""
+    loss = 0.0
+    for M in measurements:
+        mu = marginals.project(M.clique)
+        stddev = jnp.maximum(M.stddev, 1e-12)
+        diff = (M.query(mu) - M.noisy_measurement) / stddev
+        loss += jnp.sum(jnp.abs(diff))
+    return loss
+
+
+def _normalized_l2_loss(
+    marginals: CliqueVector,
+    measurements: tuple[LinearMeasurement, ...],
+) -> chex.Numeric:
+    """Normalized L2 loss over linear measurements."""
+    loss = _l2_loss(marginals, measurements)
+    total = marginals.project(()).datavector(flatten=False)
+    return jnp.sqrt(loss / len(measurements) / total)
+
+
+def _normalized_l1_loss(
+    marginals: CliqueVector,
+    measurements: tuple[LinearMeasurement, ...],
+) -> chex.Numeric:
+    """Normalized L1 loss over linear measurements."""
+    loss = _l1_loss(marginals, measurements)
+    total = marginals.project(()).datavector(flatten=False)
+    return loss / len(measurements) / total
 
 
 def calculate_l2_lipschitz(
@@ -126,31 +184,20 @@ def from_linear_measurements(
         raise ValueError(f"Unknown norm {norm}.")
     cliques = [m.clique for m in measurements]
     maximal_cliques = maximal_subset(cliques)
+    data = tuple(measurements)
 
-    def loss_fn(marginals: CliqueVector) -> chex.Numeric:
-        loss = 0.0
-        for M in measurements:
-            mu = marginals.project(M.clique)
-            # avoid introducing inf/nan from invariants
-            stddev = jnp.maximum(M.stddev, 1e-12)
-            diff = (M.query(mu) - M.noisy_measurement) / stddev
-            if norm == "l2":
-                loss += 0.5 * jnp.vdot(diff, diff)
-            elif norm == "l1":
-                loss += jnp.sum(jnp.abs(diff))
+    if normalize:
+        loss_fn = _normalized_l2_loss if norm == "l2" else _normalized_l1_loss
+    else:
+        loss_fn = _l2_loss if norm == "l2" else _l1_loss
 
-        if normalize:
-            total = marginals.project(()).datavector(flatten=False)
-            loss = loss / len(measurements) / total
-            if norm == "l2":
-                loss = jnp.sqrt(loss)
-        return loss
+    loss = MarginalLossFn(maximal_cliques, loss_fn, data)
 
     if norm == "l2" and not normalize and domain is not None:
-        lipschitz = calculate_l2_lipschitz(domain, maximal_cliques, loss_fn)
-        return MarginalLossFn(maximal_cliques, loss_fn, lipschitz)
+        lipschitz = calculate_l2_lipschitz(domain, maximal_cliques, loss)
+        return MarginalLossFn(maximal_cliques, loss_fn, data, lipschitz)
 
-    return MarginalLossFn(maximal_cliques, loss_fn)
+    return loss
 
 
 def primal_feasibility(mu: CliqueVector) -> chex.Numeric:


### PR DESCRIPTION
Refactors `MarginalLossFn` to separate computation from data using the **fn + data** pattern:

- **`fn`** (static metadata): pure function `(marginals, data) -> loss`
- **`data`** (dynamic pytree leaves): tuple of `LinearMeasurement` objects
- **`cliques`, `lipschitz`**: static metadata forming the JIT cache key

### Why

`MarginalLossFn` was an opaque closure, forcing it to be a static arg in `jax.jit`. Different measurements → different closure → cache miss → recompilation. Now it's a proper JAX pytree:

- Different measurements with the same clique structure reuse the compiled program
- `precompile(domain, cliques)` works with dummy measurements (cache hit guaranteed)
- Custom loss functions supported: `MarginalLossFn(cliques, fn=my_fn, data=my_arrays)`

### Bug fix

Also fixes a latent bug in `LinearMeasurement` pytree registration: `data_fields` was `['values']` but the actual field is `'noisy_measurement'`. This never triggered before because the pytree was never unflattened.

### Changes

| File | Change |
|---|---|
| `marginal_loss.py` | Register `MarginalLossFn` as pytree; move closure logic to module-level pure functions (`_l2_loss`, `_l1_loss`, etc.); fix `LinearMeasurement` data_fields |
| `approximate_oracles.py` | `loss_fn` becomes regular traced arg in `_step` (not static); `precompile` takes `(domain, cliques)` again |
