### PR TITLE
Add JAX-accelerated synthetic data generation

### DIFF
--- a/src/mbi/extensions/__init__.py
+++ b/src/mbi/extensions/__init__.py
@@ -2,3 +2,4 @@
 
 from .mixture_of_products import MixtureOfProducts, MixtureOfProductsEstimator
 from .reweighted_dataset import ReweightedDatasetEstimator
+from .synthetic_data import SyntheticDataGenerator

--- a/src/mbi/extensions/__init__.py
+++ b/src/mbi/extensions/__init__.py
@@ -2,4 +2,4 @@
 
 from .mixture_of_products import MixtureOfProducts, MixtureOfProductsEstimator
 from .reweighted_dataset import ReweightedDatasetEstimator
-from .synthetic_data import SyntheticDataGenerator
+from .synthetic_data import precompile, synthetic_data

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -31,21 +31,19 @@ def precompile(
 ) -> concurrent.futures.Future:
   """Warm the JIT cache for ``synthetic_data`` asynchronously.
 
-  Only requires domain and clique structure — both are available before
-  estimation finishes.  Fire and forget; ``synthetic_data`` benefits from
-  whatever has compiled so far.
+  Only requires domain and clique structure — both available after
+  measurement selection.  Fire and forget; ``synthetic_data`` benefits
+  from whatever has compiled so far.
 
   Args:
     domain: The Domain over which the model is defined.
-    cliques: The cliques of the model (known after workload selection).
+    cliques: The cliques of the model (known after measurement selection).
     rows: Number of records that will be generated.
   """
   rows = max(1, int(rows))
   plan = _build_plan(domain, cliques)
 
   def _compile_all():
-    # Run dummy message passing to get Factor inputs with correct
-    # pytree structure for per-column compilation.
     dummy_potentials = _make_dummy_potentials(domain, cliques)
     _, dummy_messages = marginal_oracles.message_passing_implicit(
         dummy_potentials, 1.0, jtree=plan.jtree, return_messages=True,
@@ -120,13 +118,9 @@ def synthetic_data(
   )
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers.
-# ---------------------------------------------------------------------------
-
-
 @dataclasses.dataclass(frozen=True)
 class _ColumnPlan:
+  """Per-column metadata for generation."""
   col: str
   query: tuple[str, ...]
   parents: tuple[str, ...]
@@ -136,13 +130,15 @@ class _ColumnPlan:
 
 @dataclasses.dataclass(frozen=True)
 class _GenerationPlan:
+  """Junction-tree analysis needed by both precompile and generate."""
   order: tuple[str, ...]
   columns: dict[str, _ColumnPlan]
   jtree: Any  # nx.Graph
   maximal_cliques: list[tuple[str, ...]]
 
 
-def _build_plan(domain: Domain, cliques) -> _GenerationPlan:
+def _build_plan(domain, cliques):
+  """Analyse the junction tree and build per-column generation metadata."""
   clique_sets = [set(cl) for cl in cliques]
   jtree, elimination_order = junction_tree.make_junction_tree(
       domain, clique_sets,
@@ -175,6 +171,7 @@ def _build_plan(domain: Domain, cliques) -> _GenerationPlan:
 
 
 def _make_dummy_potentials(domain, cliques):
+  """Build zero-valued potentials with the right pytree structure."""
   arrays = {}
   for cl in cliques:
     shape = tuple(domain[attr] for attr in cl)
@@ -183,6 +180,7 @@ def _make_dummy_potentials(domain, cliques):
 
 
 def _build_lookups(plan, potentials, messages, domain):
+  """Group potentials and messages by maximal clique."""
   mapping = clique_mapping(
       plan.maximal_cliques, potentials.cliques, domain=domain,
   )
@@ -198,6 +196,7 @@ def _build_lookups(plan, potentials, messages, domain):
 
 
 def _gather_inputs(cp, domain, pot_map, msg_map):
+  """Collect Factor inputs for a column's marginal computation."""
   inputs = list(pot_map[cp.maximal_clique]) + list(
       msg_map[cp.maximal_clique]
   )
@@ -209,10 +208,8 @@ def _gather_inputs(cp, domain, pot_map, msg_map):
 
 
 @jax.jit(static_argnames=['query', 'parent_sizes', 'total'])
-def _generate_column(rng_key, inputs, parent_arrays, *, query, parent_sizes,
-                     total):
+def _generate_column(prng, inputs, parent_arrays, *, query, parent_sizes, total):
   """Fused per-column program: marginal computation + Gumbel rounding."""
-  # Marginal computation (einsum_materialized, inlined).
   combined = functools.reduce(lambda a, b: a + b, inputs)
   query_domain = combined.domain.project(query)
   elim_attrs = combined.domain.marginalize(query_domain).attributes
@@ -220,21 +217,19 @@ def _generate_column(rng_key, inputs, parent_arrays, *, query, parent_sizes,
   result = result.normalize(total, log=True).exp()
   marg = result.datavector(flatten=False)
 
-  # Parent indexing.
   if parent_arrays:
     marg_2d = marg.reshape(-1, marg.shape[-1])
-    parent_idx = _ravel_multi_index_jax(parent_arrays, parent_sizes)
+    parent_idx = _ravel_multi_index(parent_arrays, parent_sizes)
   else:
     marg_2d = marg[jnp.newaxis, :]
     parent_idx = jnp.zeros(total, dtype=jnp.int32)
 
-  # Gumbel rounding.
-  return _gumbel_round(rng_key, marg_2d, parent_idx, total)
+  return _gumbel_round(prng, marg_2d, parent_idx, total)
 
 
-def _gumbel_round(rng_key, marg_2d, flat_parent_idx, total):
-  """Gumbel rounding (called inside JIT, not separately decorated)."""
-  rng1, rng2 = jax.random.split(rng_key)
+def _gumbel_round(prng, marg_2d, flat_parent_idx, total):
+  """Assign each record a value matching expected marginals."""
+  rng1, rng2 = jax.random.split(prng)
 
   domain_size = marg_2d.shape[-1]
   parent_product = marg_2d.shape[0]
@@ -282,12 +277,11 @@ def _gumbel_round(rng_key, marg_2d, flat_parent_idx, total):
   all_values = all_values[shuffle_perm]
 
   sort_order = jnp.argsort(flat_parent_idx)
-  result = jnp.empty(total, dtype=jnp.int32)
-  result = result.at[sort_order].set(all_values)
-  return result
+  return jnp.empty(total, dtype=jnp.int32).at[sort_order].set(all_values)
 
 
-def _ravel_multi_index_jax(arrays, sizes):
+def _ravel_multi_index(arrays, sizes):
+  """Compute flat indices from a tuple of per-dimension index arrays."""
   result = arrays[0].astype(jnp.int32)
   for arr, size in zip(arrays[1:], sizes[1:]):
     result = result * size + arr.astype(jnp.int32)
@@ -295,6 +289,7 @@ def _ravel_multi_index_jax(arrays, sizes):
 
 
 def _find_maxclique(query_vars, maximal_cliques):
+  """Return the first maximal clique that contains all query variables."""
   for mc in maximal_cliques:
     if query_vars.issubset(set(mc)):
       return mc

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -1,37 +1,10 @@
-"""Fused JAX synthetic data generation with async precompilation.
-
-This module provides ``SyntheticDataGenerator``, a class that generates
-synthetic data from a ``MarkovRandomField`` using JAX-accelerated column
-generation.  All per-column operations (marginal computation, Gumbel
-rounding / categorical sampling) stay on the GPU, eliminating the
-GPU↔CPU synchronization barriers of the baseline NumPy path.
-
-The class mirrors the ``Estimator.precompile()`` pattern: callers can
-fire off ``precompile()`` as soon as the clique structure is known
-(before estimation finishes) and overlap JIT compilation with mirror
-descent iterations.
-
-Typical usage::
-
-    generator = SyntheticDataGenerator(method='round')
-
-    # Fire-and-forget: compilation runs in the background.
-    generator.precompile(domain, cliques, rows=10_000_000)
-
-    # ... run mirror descent (compilation overlaps) ...
-    model = estimator.estimate(domain, measurements)
-
-    # No need to block — generate() benefits from whatever has compiled
-    # so far, and naturally pipelines with any remaining compilation.
-    data = generator.generate(model, rows=10_000_000)
-"""
+"""JAX-accelerated synthetic data generation with async precompilation."""
 
 from __future__ import annotations
 
 import collections
 import concurrent.futures
 import dataclasses
-import functools
 import logging
 from typing import Any
 
@@ -47,19 +20,11 @@ from ..domain import Domain
 from ..factor import Factor
 from ..markov_random_field import MarkovRandomField
 
-# Shared thread pool for background JIT compilation.
 _COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=4)
-
-
-# ---------------------------------------------------------------------------
-# Generation plan: a static description of *how* to generate each column.
-# ---------------------------------------------------------------------------
 
 
 @dataclasses.dataclass(frozen=True)
 class _ColumnPlan:
-  """Describes how to generate a single column."""
-
   col: str
   has_parents: bool
   query: tuple[str, ...]
@@ -71,18 +36,11 @@ class _ColumnPlan:
 
 @dataclasses.dataclass(frozen=True)
 class _GenerationPlan:
-  """Full generation plan for all columns."""
-
   order: tuple[str, ...]
   columns: dict[str, _ColumnPlan]
-  jtree: Any  # nx.Graph — kept for message passing
+  jtree: Any  # nx.Graph
   maximal_cliques: list[tuple[str, ...]]
   elimination_order: tuple[str, ...]
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
 
 
 class SyntheticDataGenerator:
@@ -102,11 +60,6 @@ class SyntheticDataGenerator:
     )
     self.method = method
     self._plan: _GenerationPlan | None = None
-    self._msg_fn = None
-
-  # ------------------------------------------------------------------
-  # Precompilation
-  # ------------------------------------------------------------------
 
   def precompile(
       self,
@@ -128,16 +81,15 @@ class SyntheticDataGenerator:
     rows = max(1, int(rows))
     plan = _build_plan(domain, cliques)
     self._plan = plan
-    self._msg_fn = _make_message_passing_fn(plan.jtree)
 
     futures: list[concurrent.futures.Future] = []
 
-    # 1. Precompile message passing (1 XLA program).
+    # Precompile message passing (1 XLA program).
     futures.append(_COMPILE_POOL.submit(
-        _precompile_message_passing, self._msg_fn, domain, plan,
+        _precompile_message_passing, domain, plan,
     ))
 
-    # 2. Precompile per-column generation functions (N XLA programs).
+    # Precompile per-column generation functions (N XLA programs).
     for cp in plan.columns.values():
       futures.append(_COMPILE_POOL.submit(
           _precompile_column, cp, rows, self.method,
@@ -145,16 +97,11 @@ class SyntheticDataGenerator:
 
     # NOTE: JAX's JIT cache doesn't coalesce in-flight compilations, so
     # if generate() races a background thread it may compile redundantly.
-    # In practice this only affects the first 1-2 columns.
     def _await_all() -> None:
       for f in futures:
         f.result()
 
     return _COMPILE_POOL.submit(_await_all)
-
-  # ------------------------------------------------------------------
-  # Generation
-  # ------------------------------------------------------------------
 
   def generate(
       self,
@@ -180,20 +127,19 @@ class SyntheticDataGenerator:
     domain = model.domain
     cliques = [set(cl) for cl in model.cliques]
 
-    # Use cached plan or build a new one.
     if self._plan is not None:
       plan = self._plan
     else:
       plan = _build_plan(domain, cliques)
       self._plan = plan
 
-    # Phase 1: Compute junction tree messages (single JIT'd program).
-    if self._msg_fn is None:
-      self._msg_fn = _make_message_passing_fn(plan.jtree)
+    # Phase 1: message passing (JIT'd via annotation on the function).
     expanded_potentials = model.potentials.expand(list(plan.jtree.nodes))
-    _, messages = self._msg_fn(expanded_potentials, 1.0)
+    _, messages = marginal_oracles.message_passing_implicit(
+        expanded_potentials, 1.0, jtree=plan.jtree, return_messages=True,
+    )
 
-    # Build per-maximal-clique potential lookup.
+    # Build per-maximal-clique lookups.
     mapping = clique_mapping(
         plan.maximal_cliques, model.cliques, domain=domain,
     )
@@ -203,14 +149,13 @@ class SyntheticDataGenerator:
     for cl in model.cliques:
       potential_mapping[mapping[cl]].append(model.potentials[cl])
 
-    # Build per-maximal-clique message lookup.
     message_lookup: dict[tuple, list[Factor]] = (
         collections.defaultdict(list)
     )
     for (i, j), msg in messages.items():
       message_lookup[j].append(msg)
 
-    # Phase 2: Generate columns (all on GPU).
+    # Phase 2: generate columns (all on device).
     rng = jax.random.PRNGKey(seed)
     data_jax: dict[str, jax.Array] = {}
 
@@ -218,7 +163,6 @@ class SyntheticDataGenerator:
       rng, col_rng = jax.random.split(rng)
       cp = plan.columns[col]
 
-      # Compute marginal on GPU.
       marg_jax = _compute_marginal_jax(
           cp.maximal_clique, cp.query, domain,
           potential_mapping, message_lookup, rows,
@@ -240,14 +184,8 @@ class SyntheticDataGenerator:
             'Col %d/%d: %s done', step + 1, len(plan.order), col,
         )
 
-    # Bulk transfer to CPU.
     data = {col: np.asarray(arr) for col, arr in data_jax.items()}
     return Dataset(data, domain)
-
-
-# ---------------------------------------------------------------------------
-# Plan construction (pure graph analysis, no JAX)
-# ---------------------------------------------------------------------------
 
 
 def _build_plan(domain: Domain, cliques: list[Clique]) -> _GenerationPlan:
@@ -289,25 +227,8 @@ def _build_plan(domain: Domain, cliques: list[Clique]) -> _GenerationPlan:
   )
 
 
-# ---------------------------------------------------------------------------
-# Precompilation helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_message_passing_fn(jtree):
-  """JIT-compile message passing with the junction tree baked into the closure."""
-
-  @jax.jit
-  def fn(potentials, total):
-    return marginal_oracles.message_passing_implicit(
-        potentials, total, jtree=jtree, return_messages=True,
-    )
-
-  return fn
-
-
-def _precompile_message_passing(msg_fn, domain, plan):
-  """Warm the JIT cache for the message passing program."""
+def _precompile_message_passing(domain, plan):
+  """Trace and compile the message passing program without executing it."""
   dummy_arrays = {}
   for cl in plan.jtree.nodes:
     shape = tuple(domain[attr] for attr in cl)
@@ -315,36 +236,38 @@ def _precompile_message_passing(msg_fn, domain, plan):
   dummy_potentials = CliqueVector(
       domain, list(plan.jtree.nodes), dummy_arrays,
   )
-  msg_fn(dummy_potentials, 1.0)
+  marginal_oracles.message_passing_implicit.lower(
+      dummy_potentials, 1.0, jtree=plan.jtree, return_messages=True,
+  ).compile()
 
 
 def _precompile_column(cp: _ColumnPlan, rows: int, method: str) -> None:
-  """Warm the JIT cache for one column's generation function."""
+  """Trace and compile one column's generation function without executing it."""
   dummy_rng = jax.random.PRNGKey(0)
   if not cp.has_parents:
     dummy_marg = jnp.ones(cp.domain_size, dtype=jnp.float32)
-    _dispatch_no_parents(dummy_rng, dummy_marg, rows, method)
+    fn = _sample_no_parents if method == 'sample' else _round_no_parents
+    fn.lower(dummy_rng, dummy_marg, total=rows).compile()
   else:
     shape = cp.parent_sizes + (cp.domain_size,)
     dummy_marg = jnp.ones(shape, dtype=jnp.float32)
     dummy_parents = tuple(
         jnp.zeros(rows, dtype=jnp.int32) for _ in cp.parent_sizes
     )
-    _dispatch_with_parents(
-        dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes,
-        rows, method,
-    )
-
-
-# ---------------------------------------------------------------------------
-# JIT-compiled generation functions
-# ---------------------------------------------------------------------------
+    if method == 'sample':
+      _sample_with_parents.lower(
+          dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes,
+      ).compile()
+    else:
+      _round_with_parents.lower(
+          dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes, total=rows,
+      ).compile()
 
 
 def _dispatch_no_parents(rng_key, marg_counts, total, method):
   if method == 'sample':
-    return _sample_no_parents(rng_key, marg_counts, total)
-  return _round_no_parents(rng_key, marg_counts, total)
+    return _sample_no_parents(rng_key, marg_counts, total=total)
+  return _round_no_parents(rng_key, marg_counts, total=total)
 
 
 def _dispatch_with_parents(
@@ -353,20 +276,20 @@ def _dispatch_with_parents(
   if method == 'sample':
     return _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes)
   return _round_with_parents(
-      rng_key, marg_counts, parent_data, parent_sizes, total,
+      rng_key, marg_counts, parent_data, parent_sizes, total=total,
   )
 
 
-@functools.partial(jax.jit, static_argnums=(2,))
-def _sample_no_parents(rng_key, marg_counts, total):
+@jax.jit(static_argnames=['total'])
+def _sample_no_parents(rng_key, marg_counts, *, total):
   probs = marg_counts / marg_counts.sum()
   return jax.random.choice(
       rng_key, marg_counts.shape[0], shape=(total,), p=probs,
   ).astype(jnp.int32)
 
 
-@functools.partial(jax.jit, static_argnums=(2,))
-def _round_no_parents(rng_key, marg_counts, total):
+@jax.jit(static_argnames=['total'])
+def _round_no_parents(rng_key, marg_counts, *, total):
   """Gumbel rounding for the no-parents case."""
   domain_size = marg_counts.shape[0]
   counts = marg_counts * (total / marg_counts.sum())
@@ -406,9 +329,9 @@ def _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes):
   ).astype(jnp.int32)
 
 
-@functools.partial(jax.jit, static_argnums=(4,))
+@jax.jit(static_argnames=['total'])
 def _round_with_parents(
-    rng_key, marg_counts, parent_data, parent_sizes, total,
+    rng_key, marg_counts, parent_data, parent_sizes, *, total,
 ):
   """Gumbel rounding conditioned on parents."""
   rng1, rng2 = jax.random.split(rng_key)
@@ -464,11 +387,6 @@ def _round_with_parents(
   result = jnp.empty(total, dtype=jnp.int32)
   result = result.at[sort_order].set(all_values)
   return result
-
-
-# ---------------------------------------------------------------------------
-# Marginal computation and utility functions
-# ---------------------------------------------------------------------------
 
 
 def _compute_marginal_jax(

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -78,7 +78,7 @@ class SyntheticDataGenerator:
     # NOTE: JAX's JIT cache doesn't coalesce in-flight compilations, so
     # if generate() races the background thread it may compile redundantly.
     def _compile_all():
-      _precompile_message_passing(domain, plan)
+      _precompile_message_passing(domain, cliques, plan)
       for cp in plan.columns.values():
         _precompile_column(cp, rows)
 
@@ -115,9 +115,8 @@ class SyntheticDataGenerator:
       self._plan = plan
 
     # Phase 1: message passing (JIT'd via annotation on the function).
-    expanded_potentials = model.potentials.expand(list(plan.jtree.nodes))
     _, messages = marginal_oracles.message_passing_implicit(
-        expanded_potentials, 1.0, jtree=plan.jtree, return_messages=True,
+        model.potentials, 1.0, jtree=plan.jtree, return_messages=True,
     )
 
     # Build per-maximal-clique lookups.
@@ -208,15 +207,13 @@ def _build_plan(domain: Domain, cliques: list[Clique]) -> _GenerationPlan:
   )
 
 
-def _precompile_message_passing(domain, plan):
+def _precompile_message_passing(domain, cliques, plan):
   """Trace and compile the message passing program without executing it."""
   dummy_arrays = {}
-  for cl in plan.jtree.nodes:
+  for cl in cliques:
     shape = tuple(domain[attr] for attr in cl)
     dummy_arrays[cl] = jnp.zeros(shape, dtype=jnp.float32)
-  dummy_potentials = CliqueVector(
-      domain, list(plan.jtree.nodes), dummy_arrays,
-  )
+  dummy_potentials = CliqueVector(domain, list(cliques), dummy_arrays)
   marginal_oracles.message_passing_implicit.lower(
       dummy_potentials, 1.0, jtree=plan.jtree, return_messages=True,
   ).compile()

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -335,7 +335,7 @@ def _compute_marginal_jax(
     if not any(attr in inp.domain.attributes for inp in inputs):
       inputs.append(Factor.zeros(domain.project([attr])))
 
-  result = marginal_oracles.einsum_fused(inputs, query_domain)
+  result = marginal_oracles.einsum_materialized(inputs, query_domain)
   result = result.normalize(total, log=True).exp()
   return result.datavector(flatten=False)
 

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -15,13 +15,14 @@ Typical usage::
 
     generator = SyntheticDataGenerator(method='round')
 
-    # precompile can start before estimation — only needs domain + cliques.
-    compile_future = generator.precompile(domain, cliques, rows=10_000_000)
+    # Fire-and-forget: compilation runs in the background.
+    generator.precompile(domain, cliques, rows=10_000_000)
 
-    # ... run mirror descent ...
+    # ... run mirror descent (compilation overlaps) ...
     model = estimator.estimate(domain, measurements)
 
-    compile_future.result()               # block until compilation finishes
+    # No need to block — generate() benefits from whatever has compiled
+    # so far, and naturally pipelines with any remaining compilation.
     data = generator.generate(model, rows=10_000_000)
 """
 
@@ -120,10 +121,10 @@ class SyntheticDataGenerator:
     """Warm up the JIT cache for ``generate`` asynchronously.
 
     Only requires the domain and clique structure — both are available
-    before estimation finishes.  Returns a ``Future`` that resolves
-    when all per-column JIT compilations have completed.  Callers may
-    ignore the return value (fire-and-forget) or call
-    ``future.result()`` to block.
+    before estimation finishes.  Compilation runs in background threads
+    and pipelines naturally with ``generate()``: each JIT'd function
+    either hits the warm cache or blocks until its compilation finishes,
+    so there is no need to wait on the returned ``Future``.
 
     Args:
       domain: The Domain over which the model is defined.
@@ -131,7 +132,10 @@ class SyntheticDataGenerator:
       rows: Number of records that will be generated.
 
     Returns:
-      A ``Future`` that resolves to ``None`` when compilation is done.
+      A ``Future`` that resolves to ``None`` when all compilations are
+      done.  Callers may ignore this (fire-and-forget) or wait on it
+      if they want a hard guarantee that ``generate()`` will have zero
+      compilation overhead.
     """
     rows = max(1, int(rows))
     plan = _build_plan(domain, cliques)
@@ -151,6 +155,9 @@ class SyntheticDataGenerator:
           _precompile_column, cp, rows, self.method,
       ))
 
+    # NOTE: JAX's JIT cache doesn't coalesce in-flight compilations, so
+    # if generate() races a background thread it may compile redundantly.
+    # In practice this only affects the first 1-2 columns.
     def _await_all() -> None:
       for f in futures:
         f.result()

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -34,39 +34,49 @@ def precompile(
     cliques: list[Clique],
     rows: int,
 ) -> concurrent.futures.Future:
-  """Warm the JIT cache for ``synthetic_data`` asynchronously.
+    """Warm the JIT cache for ``synthetic_data`` asynchronously.
 
-  Only requires domain and clique structure — both available after
-  measurement selection.  Fire and forget; ``synthetic_data`` benefits
-  from whatever has compiled so far.
+    Only requires domain and clique structure — both available after
+    measurement selection.  Fire and forget; ``synthetic_data`` benefits
+    from whatever has compiled so far.
 
-  Args:
-    domain: The Domain over which the model is defined.
-    cliques: The cliques of the model (known after measurement selection).
-    rows: Number of records that will be generated.
-  """
-  rows = max(1, int(rows))
-  plan = _build_plan(domain, cliques)
+    Args:
+      domain: The Domain over which the model is defined.
+      cliques: The cliques of the model (known after measurement selection).
+      rows: Number of records that will be generated.
+    """
+    rows = max(1, int(rows))
+    plan = _build_plan(domain, cliques)
 
-  def _compile_all():
-    dummy_potentials = _make_dummy_potentials(domain, cliques)
-    _, dummy_messages = marginal_oracles.message_passing_implicit(
-        dummy_potentials, 1.0, jtree=plan.jtree, return_messages=True,
-    )
-    pot_map, msg_map = _build_lookups(
-        plan, dummy_potentials, dummy_messages, domain,
-    )
-    for cp in plan.columns.values():
-      inputs = _gather_inputs(cp, domain, pot_map, msg_map)
-      dummy_parents = tuple(
-          jnp.zeros(rows, dtype=jnp.int32) for _ in cp.parents
-      )
-      _generate_column.lower(
-          jax.random.PRNGKey(0), inputs, dummy_parents,
-          query=cp.query, parent_sizes=cp.parent_sizes, total=rows,
-      ).compile()
+    def _compile_all():
+        dummy_potentials = _make_dummy_potentials(domain, cliques)
+        _, dummy_messages = marginal_oracles.message_passing_implicit(
+            dummy_potentials,
+            1.0,
+            jtree=plan.jtree,
+            return_messages=True,
+        )
+        pot_map, msg_map = _build_lookups(
+            plan,
+            dummy_potentials,
+            dummy_messages,
+            domain,
+        )
+        for cp in plan.columns.values():
+            inputs = _gather_inputs(cp, domain, pot_map, msg_map)
+            dummy_parents = tuple(
+                jnp.zeros(rows, dtype=jnp.int32) for _ in cp.parents
+            )
+            _generate_column.lower(
+                jax.random.PRNGKey(0),
+                inputs,
+                dummy_parents,
+                query=cp.query,
+                parent_sizes=cp.parent_sizes,
+                total=rows,
+            ).compile()
 
-  return _COMPILE_POOL.submit(_compile_all)
+    return _COMPILE_POOL.submit(_compile_all)
 
 
 def synthetic_data(
@@ -74,228 +84,250 @@ def synthetic_data(
     rows: int,
     seed: int = 0,
 ) -> Dataset:
-  """Generate synthetic data from a fitted model using Gumbel rounding.
+    """Generate synthetic data from a fitted model using Gumbel rounding.
 
-  Output marginals match the model within ±2 counts per cell.  If
-  ``precompile`` was called earlier with matching domain, cliques, and
-  ``rows``, the JIT cache will be warm and this call is fast.
+    Output marginals match the model within ±2 counts per cell.  If
+    ``precompile`` was called earlier with matching domain, cliques, and
+    ``rows``, the JIT cache will be warm and this call is fast.
 
-  Args:
-    model: A fitted ``MarkovRandomField``.
-    rows: Number of records to generate.
-    seed: Random seed for the JAX PRNG.
+    Args:
+      model: A fitted ``MarkovRandomField``.
+      rows: Number of records to generate.
+      seed: Random seed for the JAX PRNG.
 
-  Returns:
-    A ``Dataset`` whose marginals closely match the model.
-  """
-  rows = max(1, int(rows))
-  domain = model.domain
-  plan = _build_plan(domain, model.cliques)
+    Returns:
+      A ``Dataset`` whose marginals closely match the model.
+    """
+    rows = max(1, int(rows))
+    domain = model.domain
+    plan = _build_plan(domain, model.cliques)
 
-  # Clique ordering in model.potentials must match the cliques passed to
-  # precompile() for the JIT cache to hit (cliques are pytree metadata).
-  _, messages = marginal_oracles.message_passing_implicit(
-      model.potentials, 1.0, jtree=plan.jtree, return_messages=True,
-  )
-  pot_map, msg_map = _build_lookups(
-      plan, model.potentials, messages, domain,
-  )
-
-  rng = jax.random.PRNGKey(seed)
-  data: dict[str, jax.Array] = {}
-
-  for step, col in enumerate(plan.order):
-    rng, col_rng = jax.random.split(rng)
-    cp = plan.columns[col]
-
-    inputs = _gather_inputs(cp, domain, pot_map, msg_map)
-    parent_arrays = tuple(data[p] for p in cp.parents)
-    data[col] = _generate_column(
-        col_rng, inputs, parent_arrays,
-        query=cp.query, parent_sizes=cp.parent_sizes, total=rows,
+    # Clique ordering in model.potentials must match the cliques passed to
+    # precompile() for the JIT cache to hit (cliques are pytree metadata).
+    _, messages = marginal_oracles.message_passing_implicit(
+        model.potentials,
+        1.0,
+        jtree=plan.jtree,
+        return_messages=True,
+    )
+    pot_map, msg_map = _build_lookups(
+        plan,
+        model.potentials,
+        messages,
+        domain,
     )
 
-    if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
-      logging.info('Col %d/%d: %s done', step + 1, len(plan.order), col)
+    rng = jax.random.PRNGKey(seed)
+    data: dict[str, jax.Array] = {}
 
-  return Dataset(
-      {col: np.asarray(arr) for col, arr in data.items()}, domain,
-  )
+    for step, col in enumerate(plan.order):
+        rng, col_rng = jax.random.split(rng)
+        cp = plan.columns[col]
+
+        inputs = _gather_inputs(cp, domain, pot_map, msg_map)
+        parent_arrays = tuple(data[p] for p in cp.parents)
+        data[col] = _generate_column(
+            col_rng,
+            inputs,
+            parent_arrays,
+            query=cp.query,
+            parent_sizes=cp.parent_sizes,
+            total=rows,
+        )
+
+        if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
+            logging.info('Col %d/%d: %s done', step + 1, len(plan.order), col)
+
+    return Dataset(
+        {col: np.asarray(arr) for col, arr in data.items()},
+        domain,
+    )
 
 
 @dataclasses.dataclass(frozen=True)
 class _ColumnPlan:
-  """Per-column metadata for generation."""
-  col: str
-  query: tuple[str, ...]
-  parents: tuple[str, ...]
-  maximal_clique: tuple[str, ...]
-  parent_sizes: tuple[int, ...]
+    """Per-column metadata for generation."""
+
+    col: str
+    query: tuple[str, ...]
+    parents: tuple[str, ...]
+    maximal_clique: tuple[str, ...]
+    parent_sizes: tuple[int, ...]
 
 
 @dataclasses.dataclass(frozen=True)
 class _GenerationPlan:
-  """Junction-tree analysis needed by both precompile and generate."""
-  order: tuple[str, ...]
-  columns: dict[str, _ColumnPlan]
-  jtree: Any  # nx.Graph
-  maximal_cliques: list[tuple[str, ...]]
+    """Junction-tree analysis needed by both precompile and generate."""
+
+    order: tuple[str, ...]
+    columns: dict[str, _ColumnPlan]
+    jtree: Any  # nx.Graph
+    maximal_cliques: list[tuple[str, ...]]
 
 
 def _build_plan(domain, cliques):
-  """Analyse the junction tree and build per-column generation metadata."""
-  clique_sets = [set(cl) for cl in cliques]
-  jtree, elimination_order = junction_tree.make_junction_tree(
-      domain, clique_sets,
-  )
-  maximal_cliques = junction_tree.maximal_cliques(jtree)
-  order = tuple(reversed(elimination_order))
-
-  columns: dict[str, _ColumnPlan] = {}
-  used: set[str] = set()
-  for col in order:
-    relevant = [cl for cl in clique_sets if col in cl]
-    parents = tuple(sorted(used.intersection(set().union(*relevant))))
-    used.add(col)
-
-    query = parents + (col,) if parents else (col,)
-    mc = _find_maxclique(set(query), maximal_cliques)
-
-    columns[col] = _ColumnPlan(
-        col=col,
-        query=query,
-        parents=parents,
-        maximal_clique=mc,
-        parent_sizes=tuple(domain[p] for p in parents),
+    """Analyse the junction tree and build per-column generation metadata."""
+    clique_sets = [set(cl) for cl in cliques]
+    jtree, elimination_order = junction_tree.make_junction_tree(
+        domain,
+        clique_sets,
     )
+    maximal_cliques = junction_tree.maximal_cliques(jtree)
+    order = tuple(reversed(elimination_order))
 
-  return _GenerationPlan(
-      order=order, columns=columns,
-      jtree=jtree, maximal_cliques=maximal_cliques,
-  )
+    columns: dict[str, _ColumnPlan] = {}
+    used: set[str] = set()
+    for col in order:
+        relevant = [cl for cl in clique_sets if col in cl]
+        parents = tuple(sorted(used.intersection(set().union(*relevant))))
+        used.add(col)
+
+        query = parents + (col,) if parents else (col,)
+        mc = _find_maxclique(set(query), maximal_cliques)
+
+        columns[col] = _ColumnPlan(
+            col=col,
+            query=query,
+            parents=parents,
+            maximal_clique=mc,
+            parent_sizes=tuple(domain[p] for p in parents),
+        )
+
+    return _GenerationPlan(
+        order=order,
+        columns=columns,
+        jtree=jtree,
+        maximal_cliques=maximal_cliques,
+    )
 
 
 def _make_dummy_potentials(domain, cliques):
-  """Build zero-valued potentials with the right pytree structure."""
-  arrays = {}
-  for cl in cliques:
-    shape = tuple(domain[attr] for attr in cl)
-    arrays[cl] = jnp.zeros(shape, dtype=jnp.float32)
-  return CliqueVector(domain, list(cliques), arrays)
+    """Build zero-valued potentials with the right pytree structure."""
+    arrays = {}
+    for cl in cliques:
+        shape = tuple(domain[attr] for attr in cl)
+        arrays[cl] = jnp.zeros(shape, dtype=jnp.float32)
+    return CliqueVector(domain, list(cliques), arrays)
 
 
 def _build_lookups(plan, potentials, messages, domain):
-  """Group potentials and messages by maximal clique."""
-  mapping = clique_mapping(
-      plan.maximal_cliques, potentials.cliques, domain=domain,
-  )
-  pot_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
-  for cl in potentials.cliques:
-    pot_map[mapping[cl]].append(potentials[cl])
+    """Group potentials and messages by maximal clique."""
+    mapping = clique_mapping(
+        plan.maximal_cliques,
+        potentials.cliques,
+        domain=domain,
+    )
+    pot_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+    for cl in potentials.cliques:
+        pot_map[mapping[cl]].append(potentials[cl])
 
-  msg_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
-  for (i, j), msg in messages.items():
-    msg_map[j].append(msg)
+    msg_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+    for (i, j), msg in messages.items():
+        msg_map[j].append(msg)
 
-  return pot_map, msg_map
+    return pot_map, msg_map
 
 
 def _gather_inputs(cp, domain, pot_map, msg_map):
-  """Collect Factor inputs for a column's marginal computation."""
-  inputs = list(pot_map[cp.maximal_clique]) + list(
-      msg_map[cp.maximal_clique]
-  )
-  query_domain = domain.project(cp.query)
-  for attr in query_domain.attributes:
-    if not any(attr in inp.domain.attributes for inp in inputs):
-      inputs.append(Factor.zeros(domain.project([attr])))
-  return inputs
+    """Collect Factor inputs for a column's marginal computation."""
+    inputs = list(pot_map[cp.maximal_clique]) + list(msg_map[cp.maximal_clique])
+    query_domain = domain.project(cp.query)
+    for attr in query_domain.attributes:
+        if not any(attr in inp.domain.attributes for inp in inputs):
+            inputs.append(Factor.zeros(domain.project([attr])))
+    return inputs
 
 
 @jax.jit(static_argnames=['query', 'parent_sizes', 'total'])
-def _generate_column(prng, inputs, parent_arrays, *, query, parent_sizes, total):
-  """Fused per-column program: marginal computation + Gumbel rounding."""
-  combined = functools.reduce(lambda a, b: a + b, inputs)
-  query_domain = combined.domain.project(query)
-  elim_attrs = combined.domain.marginalize(query_domain).attributes
-  result = combined.logsumexp(elim_attrs).transpose(query_domain.attributes)
-  result = result.normalize(total, log=True).exp()
-  marg = result.datavector(flatten=False)
+def _generate_column(
+    prng, inputs, parent_arrays, *, query, parent_sizes, total
+):
+    """Fused per-column program: marginal computation + Gumbel rounding."""
+    combined = functools.reduce(lambda a, b: a + b, inputs)
+    query_domain = combined.domain.project(query)
+    elim_attrs = combined.domain.marginalize(query_domain).attributes
+    result = combined.logsumexp(elim_attrs).transpose(query_domain.attributes)
+    result = result.normalize(total, log=True).exp()
+    marg = result.datavector(flatten=False)
 
-  if parent_arrays:
-    marg_2d = marg.reshape(-1, marg.shape[-1])
-    parent_idx = _ravel_multi_index(parent_arrays, parent_sizes)
-  else:
-    marg_2d = marg[jnp.newaxis, :]
-    parent_idx = jnp.zeros(total, dtype=jnp.int32)
+    if parent_arrays:
+        marg_2d = marg.reshape(-1, marg.shape[-1])
+        parent_idx = _ravel_multi_index(parent_arrays, parent_sizes)
+    else:
+        marg_2d = marg[jnp.newaxis, :]
+        parent_idx = jnp.zeros(total, dtype=jnp.int32)
 
-  return _gumbel_round(prng, marg_2d, parent_idx, total)
+    return _gumbel_round(prng, marg_2d, parent_idx, total)
 
 
 def _gumbel_round(prng, marg_2d, flat_parent_idx, total):
-  """Assign each record a value matching expected marginals."""
-  rng1, rng2 = jax.random.split(prng)
+    """Assign each record a value matching expected marginals."""
+    rng1, rng2 = jax.random.split(prng)
 
-  domain_size = marg_2d.shape[-1]
-  parent_product = marg_2d.shape[0]
+    domain_size = marg_2d.shape[-1]
+    parent_product = marg_2d.shape[0]
 
-  marg_parents = marg_2d.sum(axis=-1, keepdims=True)
-  cond_probs = jnp.where(marg_parents != 0, marg_2d / marg_parents, 0.0)
+    marg_parents = marg_2d.sum(axis=-1, keepdims=True)
+    cond_probs = jnp.where(marg_parents != 0, marg_2d / marg_parents, 0.0)
 
-  counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
+    counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
 
-  expected = counts_per_parent[:, None] * cond_probs
-  integ = jnp.floor(expected).astype(jnp.int32)
-  frac = expected - jnp.floor(expected)
-  extra = counts_per_parent - integ.sum(axis=1)
+    expected = counts_per_parent[:, None] * cond_probs
+    integ = jnp.floor(expected).astype(jnp.int32)
+    frac = expected - jnp.floor(expected)
+    extra = counts_per_parent - integ.sum(axis=1)
 
-  u = jax.random.uniform(rng1, (parent_product, domain_size))
-  scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
-  scores = jnp.where(frac == 0, -jnp.inf, scores)
+    u = jax.random.uniform(rng1, (parent_product, domain_size))
+    scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
+    scores = jnp.where(frac == 0, -jnp.inf, scores)
 
-  ranked = jnp.argsort(-scores, axis=1)
-  positions = jnp.broadcast_to(
-      jnp.arange(domain_size)[None, :], (parent_product, domain_size),
-  )
-  roundup_mask = (positions < extra[:, None]).astype(jnp.int32)
-  row_indices = jnp.broadcast_to(
-      jnp.arange(parent_product)[:, None], ranked.shape,
-  )
-  roundup = jnp.zeros((parent_product, domain_size), dtype=jnp.int32)
-  roundup = roundup.at[row_indices, ranked].set(roundup_mask)
-  integ = jnp.maximum(integ + roundup, 0)
+    ranked = jnp.argsort(-scores, axis=1)
+    positions = jnp.broadcast_to(
+        jnp.arange(domain_size)[None, :],
+        (parent_product, domain_size),
+    )
+    roundup_mask = (positions < extra[:, None]).astype(jnp.int32)
+    row_indices = jnp.broadcast_to(
+        jnp.arange(parent_product)[:, None],
+        ranked.shape,
+    )
+    roundup = jnp.zeros((parent_product, domain_size), dtype=jnp.int32)
+    roundup = roundup.at[row_indices, ranked].set(roundup_mask)
+    integ = jnp.maximum(integ + roundup, 0)
 
-  value_options = jnp.arange(domain_size, dtype=jnp.int32)
-  value_options_tiled = jnp.tile(value_options, parent_product)
-  all_values = jnp.repeat(
-      value_options_tiled, integ.ravel(), total_repeat_length=total,
-  )
+    value_options = jnp.arange(domain_size, dtype=jnp.int32)
+    value_options_tiled = jnp.tile(value_options, parent_product)
+    all_values = jnp.repeat(
+        value_options_tiled,
+        integ.ravel(),
+        total_repeat_length=total,
+    )
 
-  group_ids = jnp.repeat(
-      jnp.arange(parent_product, dtype=jnp.float32),
-      counts_per_parent,
-      total_repeat_length=total,
-  )
-  shuffle_keys = jax.random.uniform(rng2, (total,))
-  composite = group_ids + shuffle_keys
-  shuffle_perm = jnp.argsort(composite)
-  all_values = all_values[shuffle_perm]
+    group_ids = jnp.repeat(
+        jnp.arange(parent_product, dtype=jnp.float32),
+        counts_per_parent,
+        total_repeat_length=total,
+    )
+    shuffle_keys = jax.random.uniform(rng2, (total,))
+    composite = group_ids + shuffle_keys
+    shuffle_perm = jnp.argsort(composite)
+    all_values = all_values[shuffle_perm]
 
-  sort_order = jnp.argsort(flat_parent_idx)
-  return jnp.empty(total, dtype=jnp.int32).at[sort_order].set(all_values)
+    sort_order = jnp.argsort(flat_parent_idx)
+    return jnp.empty(total, dtype=jnp.int32).at[sort_order].set(all_values)
 
 
 def _ravel_multi_index(arrays, sizes):
-  """Compute flat indices from a tuple of per-dimension index arrays."""
-  result = arrays[0].astype(jnp.int32)
-  for arr, size in zip(arrays[1:], sizes[1:]):
-    result = result * size + arr.astype(jnp.int32)
-  return result
+    """Compute flat indices from a tuple of per-dimension index arrays."""
+    result = arrays[0].astype(jnp.int32)
+    for arr, size in zip(arrays[1:], sizes[1:]):
+        result = result * size + arr.astype(jnp.int32)
+    return result
 
 
 def _find_maxclique(query_vars, maximal_cliques):
-  """Return the first maximal clique that contains all query variables."""
-  for mc in maximal_cliques:
-    if query_vars.issubset(set(mc)):
-      return mc
-  assert False, f'No maximal clique contains {query_vars}'
+    """Return the first maximal clique that contains all query variables."""
+    for mc in maximal_cliques:
+        if query_vars.issubset(set(mc)):
+            return mc
+    assert False, f'No maximal clique contains {query_vars}'

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -335,7 +335,7 @@ def _compute_marginal_jax(
     if not any(attr in inp.domain.attributes for inp in inputs):
       inputs.append(Factor.zeros(domain.project([attr])))
 
-  result = marginal_oracles.einsum_semistable(inputs, query_domain)
+  result = marginal_oracles.einsum_fused(inputs, query_domain)
   result = result.normalize(total, log=True).exp()
   return result.datavector(flatten=False)
 

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -88,12 +88,8 @@ class _GenerationPlan:
 class SyntheticDataGenerator:
   """Generates synthetic data from a MarkovRandomField using JAX.
 
-  The generator separates the concerns of *planning* (junction tree
-  analysis, JIT compilation) from *execution* (message passing,
-  per-column generation).  The planning phase only depends on the
-  ``Domain`` and clique structure, both of which are known before
-  estimation finishes.  This allows JIT compilation to run in the
-  background while mirror descent is still iterating.
+  Precompilation only requires domain and clique structure, so it can
+  overlap with estimation.
 
   Args:
     method: ``'round'`` for randomized rounding (default) or ``'sample'``
@@ -120,22 +116,14 @@ class SyntheticDataGenerator:
   ) -> concurrent.futures.Future:
     """Warm up the JIT cache for ``generate`` asynchronously.
 
-    Only requires the domain and clique structure — both are available
-    before estimation finishes.  Compilation runs in background threads
-    and pipelines naturally with ``generate()``: each JIT'd function
-    either hits the warm cache or blocks until its compilation finishes,
-    so there is no need to wait on the returned ``Future``.
+    Only requires domain and clique structure.  Compilation pipelines
+    naturally with ``generate()`` via the JIT cache, so there is no
+    need to wait on the returned ``Future``.
 
     Args:
       domain: The Domain over which the model is defined.
       cliques: The cliques of the model (known after workload selection).
       rows: Number of records that will be generated.
-
-    Returns:
-      A ``Future`` that resolves to ``None`` when all compilations are
-      done.  Callers may ignore this (fire-and-forget) or wait on it
-      if they want a hard guarantee that ``generate()`` will have zero
-      compilation overhead.
     """
     rows = max(1, int(rows))
     plan = _build_plan(domain, cliques)
@@ -262,10 +250,7 @@ class SyntheticDataGenerator:
 # ---------------------------------------------------------------------------
 
 
-def _build_plan(
-    domain: Domain,
-    cliques: list[Clique],
-) -> _GenerationPlan:
+def _build_plan(domain: Domain, cliques: list[Clique]) -> _GenerationPlan:
   """Analyse the junction tree and build the per-column generation plan."""
   clique_sets = [set(cl) for cl in cliques]
   jtree, elimination_order = junction_tree.make_junction_tree(
@@ -310,12 +295,7 @@ def _build_plan(
 
 
 def _make_message_passing_fn(jtree):
-  """Create a JIT'd message passing function for a specific junction tree.
-
-  The junction tree is captured in the closure, so all graph-structural
-  operations (message ordering, clique mapping, neighbor lookups) are
-  evaluated at trace time and compiled into a single XLA program.
-  """
+  """JIT-compile message passing with the junction tree baked into the closure."""
 
   @jax.jit
   def fn(potentials, total):
@@ -337,12 +317,9 @@ def _precompile_message_passing(msg_fn, domain, plan):
   )
   msg_fn(dummy_potentials, 1.0)
 
-def _precompile_column(
-    cp: _ColumnPlan,
-    rows: int,
-    method: str,
-) -> None:
-  """Trace and compile the JIT'd generation function for one column."""
+
+def _precompile_column(cp: _ColumnPlan, rows: int, method: str) -> None:
+  """Warm the JIT cache for one column's generation function."""
   dummy_rng = jax.random.PRNGKey(0)
   if not cp.has_parents:
     dummy_marg = jnp.ones(cp.domain_size, dtype=jnp.float32)
@@ -365,7 +342,6 @@ def _precompile_column(
 
 
 def _dispatch_no_parents(rng_key, marg_counts, total, method):
-  """Route to the appropriate JIT'd no-parents function."""
   if method == 'sample':
     return _sample_no_parents(rng_key, marg_counts, total)
   return _round_no_parents(rng_key, marg_counts, total)
@@ -374,7 +350,6 @@ def _dispatch_no_parents(rng_key, marg_counts, total, method):
 def _dispatch_with_parents(
     rng_key, marg_counts, parent_data, parent_sizes, total, method,
 ):
-  """Route to the appropriate JIT'd with-parents function."""
   if method == 'sample':
     return _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes)
   return _round_with_parents(
@@ -384,7 +359,6 @@ def _dispatch_with_parents(
 
 @functools.partial(jax.jit, static_argnums=(2,))
 def _sample_no_parents(rng_key, marg_counts, total):
-  """Sample method for no-parents case."""
   probs = marg_counts / marg_counts.sum()
   return jax.random.choice(
       rng_key, marg_counts.shape[0], shape=(total,), p=probs,
@@ -393,7 +367,7 @@ def _sample_no_parents(rng_key, marg_counts, total):
 
 @functools.partial(jax.jit, static_argnums=(2,))
 def _round_no_parents(rng_key, marg_counts, total):
-  """Gumbel rounding for no-parents case."""
+  """Gumbel rounding for the no-parents case."""
   domain_size = marg_counts.shape[0]
   counts = marg_counts * (total / marg_counts.sum())
   integ = jnp.floor(counts).astype(jnp.int32)
@@ -419,7 +393,6 @@ def _round_no_parents(rng_key, marg_counts, total):
 
 @jax.jit
 def _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes):
-  """Per-record categorical sampling conditioned on parents."""
   marg_parents = marg_counts.sum(axis=-1, keepdims=True)
   cond_probs = jnp.where(marg_parents != 0, marg_counts / marg_parents, 0.0)
   domain_size = marg_counts.shape[-1]
@@ -437,7 +410,7 @@ def _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes):
 def _round_with_parents(
     rng_key, marg_counts, parent_data, parent_sizes, total,
 ):
-  """Gumbel rounding conditioned on parents, vectorized on GPU."""
+  """Gumbel rounding conditioned on parents."""
   rng1, rng2 = jax.random.split(rng_key)
 
   domain_size = marg_counts.shape[-1]
@@ -501,7 +474,7 @@ def _round_with_parents(
 def _compute_marginal_jax(
     maximal_clique, query, domain, potential_mapping, message_lookup, total,
 ):
-  """Compute marginal as a JAX array, staying on device."""
+  """Compute a query marginal on device from cached messages and potentials."""
   inputs = list(potential_mapping[maximal_clique]) + list(
       message_lookup[maximal_clique]
   )
@@ -517,7 +490,6 @@ def _compute_marginal_jax(
 
 
 def _ravel_multi_index_jax(arrays, sizes):
-  """JAX version of np.ravel_multi_index."""
   result = arrays[0].astype(jnp.int32)
   for arr, size in zip(arrays[1:], sizes[1:]):
     result = result * size + arr.astype(jnp.int32)
@@ -525,7 +497,6 @@ def _ravel_multi_index_jax(arrays, sizes):
 
 
 def _find_maxclique(query_vars, maximal_cliques):
-  """Find a maximal clique containing all query variables."""
   for mc in maximal_cliques:
     if query_vars.issubset(set(mc)):
       return mc

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -149,13 +149,16 @@ class SyntheticDataGenerator:
           potential_mapping, message_lookup, rows,
       )
 
-      if not cp.has_parents:
-        data_jax[col] = _round_no_parents(col_rng, marg_jax, total=rows)
-      else:
+      if cp.has_parents:
         parent_data = tuple(data_jax[p] for p in cp.parents)
-        data_jax[col] = _round_with_parents(
-            col_rng, marg_jax, parent_data, cp.parent_sizes, total=rows,
-        )
+        parent_idx = _ravel_multi_index_jax(parent_data, cp.parent_sizes)
+      else:
+        parent_idx = jnp.zeros(rows, dtype=jnp.int32)
+        marg_jax = marg_jax[None, :]
+
+      data_jax[col] = _gumbel_round(
+          col_rng, marg_jax, parent_idx, total=rows,
+      )
 
       if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
         logging.info(
@@ -222,64 +225,28 @@ def _precompile_message_passing(domain, plan):
 def _precompile_column(cp: _ColumnPlan, rows: int) -> None:
   """Trace and compile one column's generation function without executing it."""
   dummy_rng = jax.random.PRNGKey(0)
-  if not cp.has_parents:
-    dummy_marg = jnp.ones(cp.domain_size, dtype=jnp.float32)
-    _round_no_parents.lower(dummy_rng, dummy_marg, total=rows).compile()
-  else:
-    shape = cp.parent_sizes + (cp.domain_size,)
-    dummy_marg = jnp.ones(shape, dtype=jnp.float32)
-    dummy_parents = tuple(
-        jnp.zeros(rows, dtype=jnp.int32) for _ in cp.parent_sizes
-    )
-    _round_with_parents.lower(
-        dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes, total=rows,
-    ).compile()
-
-
-@jax.jit(static_argnames=['total'])
-def _round_no_parents(rng_key, marg_counts, *, total):
-  """Gumbel rounding for the no-parents case."""
-  domain_size = marg_counts.shape[0]
-  counts = marg_counts * (total / marg_counts.sum())
-  integ = jnp.floor(counts).astype(jnp.int32)
-  frac = counts - jnp.floor(counts)
-  extra = total - integ.sum()
-
-  rng1, rng2 = jax.random.split(rng_key)
-  u = jax.random.uniform(rng1, (domain_size,))
-  scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
-  scores = jnp.where(frac == 0, -jnp.inf, scores)
-
-  ranked = jnp.argsort(-scores)
-  roundup = jnp.where(jnp.arange(domain_size) < extra, 1, 0)
-  integ = integ.at[ranked].add(roundup)
-
-  vals = jnp.repeat(
-      jnp.arange(domain_size, dtype=jnp.int32), integ,
-      total_repeat_length=total,
+  parent_product = 1 if not cp.has_parents else (
+      int(np.prod(cp.parent_sizes))
   )
-  perm = jax.random.permutation(rng2, total)
-  return vals[perm]
+  dummy_marg = jnp.ones((parent_product, cp.domain_size), dtype=jnp.float32)
+  dummy_idx = jnp.zeros(rows, dtype=jnp.int32)
+  _gumbel_round.lower(dummy_rng, dummy_marg, dummy_idx, total=rows).compile()
 
 
 @jax.jit(static_argnames=['total'])
-def _round_with_parents(
-    rng_key, marg_counts, parent_data, parent_sizes, *, total,
-):
-  """Gumbel rounding conditioned on parents."""
+def _gumbel_round(rng_key, marg_counts_2d, flat_parent_idx, *, total):
+  """Gumbel rounding: assign each record a value matching expected marginals."""
   rng1, rng2 = jax.random.split(rng_key)
 
-  domain_size = marg_counts.shape[-1]
-  parent_product = marg_counts.size // domain_size
+  domain_size = marg_counts_2d.shape[-1]
+  parent_product = marg_counts_2d.shape[0]
 
-  marg_parents = marg_counts.sum(axis=-1, keepdims=True)
-  cond_probs = jnp.where(marg_parents != 0, marg_counts / marg_parents, 0.0)
-  cond_probs_2d = cond_probs.reshape(parent_product, domain_size)
+  marg_parents = marg_counts_2d.sum(axis=-1, keepdims=True)
+  cond_probs = jnp.where(marg_parents != 0, marg_counts_2d / marg_parents, 0.0)
 
-  flat_parent_idx = _ravel_multi_index_jax(parent_data, parent_sizes)
   counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
 
-  expected = counts_per_parent[:, None] * cond_probs_2d
+  expected = counts_per_parent[:, None] * cond_probs
   integ = jnp.floor(expected).astype(jnp.int32)
   frac = expected - jnp.floor(expected)
   extra = counts_per_parent - integ.sum(axis=1)

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -46,19 +46,12 @@ class _GenerationPlan:
 class SyntheticDataGenerator:
   """Generates synthetic data from a MarkovRandomField using JAX.
 
-  Precompilation only requires domain and clique structure, so it can
-  overlap with estimation.
-
-  Args:
-    method: ``'round'`` for randomized rounding (default) or ``'sample'``
-      for i.i.d. categorical sampling.
+  Uses Gumbel rounding so output marginals match the model within
+  ±2 counts per cell.  Precompilation only requires domain and clique
+  structure, so it can overlap with estimation.
   """
 
-  def __init__(self, method: str = 'round'):
-    assert method in ('round', 'sample'), (
-        f"method must be 'round' or 'sample', got {method!r}"
-    )
-    self.method = method
+  def __init__(self):
     self._plan: _GenerationPlan | None = None
 
   def precompile(
@@ -87,7 +80,7 @@ class SyntheticDataGenerator:
     def _compile_all():
       _precompile_message_passing(domain, plan)
       for cp in plan.columns.values():
-        _precompile_column(cp, rows, self.method)
+        _precompile_column(cp, rows)
 
     return _COMPILE_POOL.submit(_compile_all)
 
@@ -157,14 +150,11 @@ class SyntheticDataGenerator:
       )
 
       if not cp.has_parents:
-        data_jax[col] = _dispatch_no_parents(
-            col_rng, marg_jax, rows, self.method,
-        )
+        data_jax[col] = _round_no_parents(col_rng, marg_jax, total=rows)
       else:
         parent_data = tuple(data_jax[p] for p in cp.parents)
-        data_jax[col] = _dispatch_with_parents(
-            col_rng, marg_jax, parent_data, cp.parent_sizes,
-            rows, self.method,
+        data_jax[col] = _round_with_parents(
+            col_rng, marg_jax, parent_data, cp.parent_sizes, total=rows,
         )
 
       if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
@@ -229,51 +219,21 @@ def _precompile_message_passing(domain, plan):
   ).compile()
 
 
-def _precompile_column(cp: _ColumnPlan, rows: int, method: str) -> None:
+def _precompile_column(cp: _ColumnPlan, rows: int) -> None:
   """Trace and compile one column's generation function without executing it."""
   dummy_rng = jax.random.PRNGKey(0)
   if not cp.has_parents:
     dummy_marg = jnp.ones(cp.domain_size, dtype=jnp.float32)
-    fn = _sample_no_parents if method == 'sample' else _round_no_parents
-    fn.lower(dummy_rng, dummy_marg, total=rows).compile()
+    _round_no_parents.lower(dummy_rng, dummy_marg, total=rows).compile()
   else:
     shape = cp.parent_sizes + (cp.domain_size,)
     dummy_marg = jnp.ones(shape, dtype=jnp.float32)
     dummy_parents = tuple(
         jnp.zeros(rows, dtype=jnp.int32) for _ in cp.parent_sizes
     )
-    if method == 'sample':
-      _sample_with_parents.lower(
-          dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes,
-      ).compile()
-    else:
-      _round_with_parents.lower(
-          dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes, total=rows,
-      ).compile()
-
-
-def _dispatch_no_parents(rng_key, marg_counts, total, method):
-  if method == 'sample':
-    return _sample_no_parents(rng_key, marg_counts, total=total)
-  return _round_no_parents(rng_key, marg_counts, total=total)
-
-
-def _dispatch_with_parents(
-    rng_key, marg_counts, parent_data, parent_sizes, total, method,
-):
-  if method == 'sample':
-    return _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes)
-  return _round_with_parents(
-      rng_key, marg_counts, parent_data, parent_sizes, total=total,
-  )
-
-
-@jax.jit(static_argnames=['total'])
-def _sample_no_parents(rng_key, marg_counts, *, total):
-  probs = marg_counts / marg_counts.sum()
-  return jax.random.choice(
-      rng_key, marg_counts.shape[0], shape=(total,), p=probs,
-  ).astype(jnp.int32)
+    _round_with_parents.lower(
+        dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes, total=rows,
+    ).compile()
 
 
 @jax.jit(static_argnames=['total'])
@@ -300,21 +260,6 @@ def _round_no_parents(rng_key, marg_counts, *, total):
   )
   perm = jax.random.permutation(rng2, total)
   return vals[perm]
-
-
-@jax.jit
-def _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes):
-  marg_parents = marg_counts.sum(axis=-1, keepdims=True)
-  cond_probs = jnp.where(marg_parents != 0, marg_counts / marg_parents, 0.0)
-  domain_size = marg_counts.shape[-1]
-  parent_product = cond_probs.size // domain_size
-  cond_probs_2d = cond_probs.reshape(parent_product, domain_size)
-
-  flat_parent_idx = _ravel_multi_index_jax(parent_data, parent_sizes)
-  per_record_probs = cond_probs_2d[flat_parent_idx]
-  return jax.random.categorical(
-      rng_key, jnp.log(per_record_probs + 1e-30),
-  ).astype(jnp.int32)
 
 
 @jax.jit(static_argnames=['total'])

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -115,6 +115,8 @@ class SyntheticDataGenerator:
       self._plan = plan
 
     # Phase 1: message passing (JIT'd via annotation on the function).
+    # Clique ordering in model.potentials must match the cliques passed to
+    # precompile() for the JIT cache to hit (cliques are pytree metadata).
     _, messages = marginal_oracles.message_passing_implicit(
         model.potentials, 1.0, jtree=plan.jtree, return_messages=True,
     )

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import collections
 import concurrent.futures
 import dataclasses
+import functools
 import logging
 from typing import Any
 
@@ -23,14 +24,113 @@ from ..markov_random_field import MarkovRandomField
 _COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
 
+def precompile(
+    domain: Domain,
+    cliques: list[Clique],
+    rows: int,
+) -> concurrent.futures.Future:
+  """Warm the JIT cache for ``synthetic_data`` asynchronously.
+
+  Only requires domain and clique structure — both are available before
+  estimation finishes.  Fire and forget; ``synthetic_data`` benefits from
+  whatever has compiled so far.
+
+  Args:
+    domain: The Domain over which the model is defined.
+    cliques: The cliques of the model (known after workload selection).
+    rows: Number of records that will be generated.
+  """
+  rows = max(1, int(rows))
+  plan = _build_plan(domain, cliques)
+
+  def _compile_all():
+    # Run dummy message passing to get Factor inputs with correct
+    # pytree structure for per-column compilation.
+    dummy_potentials = _make_dummy_potentials(domain, cliques)
+    _, dummy_messages = marginal_oracles.message_passing_implicit(
+        dummy_potentials, 1.0, jtree=plan.jtree, return_messages=True,
+    )
+    pot_map, msg_map = _build_lookups(
+        plan, dummy_potentials, dummy_messages, domain,
+    )
+    for cp in plan.columns.values():
+      inputs = _gather_inputs(cp, domain, pot_map, msg_map)
+      dummy_parents = tuple(
+          jnp.zeros(rows, dtype=jnp.int32) for _ in cp.parents
+      )
+      _generate_column.lower(
+          jax.random.PRNGKey(0), inputs, dummy_parents,
+          query=cp.query, parent_sizes=cp.parent_sizes, total=rows,
+      ).compile()
+
+  return _COMPILE_POOL.submit(_compile_all)
+
+
+def synthetic_data(
+    model: MarkovRandomField,
+    rows: int,
+    seed: int = 0,
+) -> Dataset:
+  """Generate synthetic data from a fitted model using Gumbel rounding.
+
+  Output marginals match the model within ±2 counts per cell.  If
+  ``precompile`` was called earlier with matching domain, cliques, and
+  ``rows``, the JIT cache will be warm and this call is fast.
+
+  Args:
+    model: A fitted ``MarkovRandomField``.
+    rows: Number of records to generate.
+    seed: Random seed for the JAX PRNG.
+
+  Returns:
+    A ``Dataset`` whose marginals closely match the model.
+  """
+  rows = max(1, int(rows))
+  domain = model.domain
+  plan = _build_plan(domain, model.cliques)
+
+  # Clique ordering in model.potentials must match the cliques passed to
+  # precompile() for the JIT cache to hit (cliques are pytree metadata).
+  _, messages = marginal_oracles.message_passing_implicit(
+      model.potentials, 1.0, jtree=plan.jtree, return_messages=True,
+  )
+  pot_map, msg_map = _build_lookups(
+      plan, model.potentials, messages, domain,
+  )
+
+  rng = jax.random.PRNGKey(seed)
+  data: dict[str, jax.Array] = {}
+
+  for step, col in enumerate(plan.order):
+    rng, col_rng = jax.random.split(rng)
+    cp = plan.columns[col]
+
+    inputs = _gather_inputs(cp, domain, pot_map, msg_map)
+    parent_arrays = tuple(data[p] for p in cp.parents)
+    data[col] = _generate_column(
+        col_rng, inputs, parent_arrays,
+        query=cp.query, parent_sizes=cp.parent_sizes, total=rows,
+    )
+
+    if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
+      logging.info('Col %d/%d: %s done', step + 1, len(plan.order), col)
+
+  return Dataset(
+      {col: np.asarray(arr) for col, arr in data.items()}, domain,
+  )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers.
+# ---------------------------------------------------------------------------
+
+
 @dataclasses.dataclass(frozen=True)
 class _ColumnPlan:
   col: str
-  has_parents: bool
   query: tuple[str, ...]
   parents: tuple[str, ...]
   maximal_clique: tuple[str, ...]
-  domain_size: int
   parent_sizes: tuple[int, ...]
 
 
@@ -40,138 +140,9 @@ class _GenerationPlan:
   columns: dict[str, _ColumnPlan]
   jtree: Any  # nx.Graph
   maximal_cliques: list[tuple[str, ...]]
-  elimination_order: tuple[str, ...]
 
 
-class SyntheticDataGenerator:
-  """Generates synthetic data from a MarkovRandomField using JAX.
-
-  Uses Gumbel rounding so output marginals match the model within
-  ±2 counts per cell.  Precompilation only requires domain and clique
-  structure, so it can overlap with estimation.
-  """
-
-  def __init__(self):
-    self._plan: _GenerationPlan | None = None
-
-  def precompile(
-      self,
-      domain: Domain,
-      cliques: list[Clique],
-      rows: int,
-  ) -> concurrent.futures.Future:
-    """Warm up the JIT cache for ``generate`` asynchronously.
-
-    Only requires domain and clique structure.  Compilation pipelines
-    naturally with ``generate()`` via the JIT cache, so there is no
-    need to wait on the returned ``Future``.
-
-    Args:
-      domain: The Domain over which the model is defined.
-      cliques: The cliques of the model (known after workload selection).
-      rows: Number of records that will be generated.
-    """
-    rows = max(1, int(rows))
-    plan = _build_plan(domain, cliques)
-    self._plan = plan
-
-    # NOTE: JAX's JIT cache doesn't coalesce in-flight compilations, so
-    # if generate() races the background thread it may compile redundantly.
-    def _compile_all():
-      _precompile_message_passing(domain, cliques, plan)
-      for cp in plan.columns.values():
-        _precompile_column(cp, rows)
-
-    return _COMPILE_POOL.submit(_compile_all)
-
-  def generate(
-      self,
-      model: MarkovRandomField,
-      rows: int,
-      *,
-      seed: int = 0,
-  ) -> Dataset:
-    """Generate synthetic data from a fitted model.
-
-    If ``precompile`` was called earlier with the same domain, cliques,
-    and ``rows``, the JIT cache will be warm and this call is fast.
-
-    Args:
-      model: A fitted ``MarkovRandomField``.
-      rows: Number of records to generate.
-      seed: Random seed for the JAX PRNG.
-
-    Returns:
-      A ``Dataset`` whose marginals closely match the model.
-    """
-    rows = max(1, int(rows))
-    domain = model.domain
-    cliques = [set(cl) for cl in model.cliques]
-
-    if self._plan is not None:
-      plan = self._plan
-    else:
-      plan = _build_plan(domain, cliques)
-      self._plan = plan
-
-    # Phase 1: message passing (JIT'd via annotation on the function).
-    # Clique ordering in model.potentials must match the cliques passed to
-    # precompile() for the JIT cache to hit (cliques are pytree metadata).
-    _, messages = marginal_oracles.message_passing_implicit(
-        model.potentials, 1.0, jtree=plan.jtree, return_messages=True,
-    )
-
-    # Build per-maximal-clique lookups.
-    mapping = clique_mapping(
-        plan.maximal_cliques, model.cliques, domain=domain,
-    )
-    potential_mapping: dict[tuple, list[Factor]] = (
-        collections.defaultdict(list)
-    )
-    for cl in model.cliques:
-      potential_mapping[mapping[cl]].append(model.potentials[cl])
-
-    message_lookup: dict[tuple, list[Factor]] = (
-        collections.defaultdict(list)
-    )
-    for (i, j), msg in messages.items():
-      message_lookup[j].append(msg)
-
-    # Phase 2: generate columns (all on device).
-    rng = jax.random.PRNGKey(seed)
-    data_jax: dict[str, jax.Array] = {}
-
-    for step, col in enumerate(plan.order):
-      rng, col_rng = jax.random.split(rng)
-      cp = plan.columns[col]
-
-      marg_jax = _compute_marginal_jax(
-          cp.maximal_clique, cp.query, domain,
-          potential_mapping, message_lookup, rows,
-      )
-
-      if cp.has_parents:
-        parent_data = tuple(data_jax[p] for p in cp.parents)
-        parent_idx = _ravel_multi_index_jax(parent_data, cp.parent_sizes)
-      else:
-        parent_idx = jnp.zeros(rows, dtype=jnp.int32)
-        marg_jax = marg_jax[None, :]
-
-      data_jax[col] = _gumbel_round(
-          col_rng, marg_jax, parent_idx, total=rows,
-      )
-
-      if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
-        logging.info(
-            'Col %d/%d: %s done', step + 1, len(plan.order), col,
-        )
-
-    data = {col: np.asarray(arr) for col, arr in data_jax.items()}
-    return Dataset(data, domain)
-
-
-def _build_plan(domain: Domain, cliques: list[Clique]) -> _GenerationPlan:
-  """Analyse the junction tree and build the per-column generation plan."""
+def _build_plan(domain: Domain, cliques) -> _GenerationPlan:
   clique_sets = [set(cl) for cl in cliques]
   jtree, elimination_order = junction_tree.make_junction_tree(
       domain, clique_sets,
@@ -187,61 +158,89 @@ def _build_plan(domain: Domain, cliques: list[Clique]) -> _GenerationPlan:
     used.add(col)
 
     query = parents + (col,) if parents else (col,)
-    query_set = set(query)
-    mc = _find_maxclique(query_set, maximal_cliques)
+    mc = _find_maxclique(set(query), maximal_cliques)
 
     columns[col] = _ColumnPlan(
         col=col,
-        has_parents=bool(parents),
         query=query,
         parents=parents,
         maximal_clique=mc,
-        domain_size=domain[col],
         parent_sizes=tuple(domain[p] for p in parents),
     )
 
   return _GenerationPlan(
-      order=order,
-      columns=columns,
-      jtree=jtree,
-      maximal_cliques=maximal_cliques,
-      elimination_order=tuple(elimination_order),
+      order=order, columns=columns,
+      jtree=jtree, maximal_cliques=maximal_cliques,
   )
 
 
-def _precompile_message_passing(domain, cliques, plan):
-  """Trace and compile the message passing program without executing it."""
-  dummy_arrays = {}
+def _make_dummy_potentials(domain, cliques):
+  arrays = {}
   for cl in cliques:
     shape = tuple(domain[attr] for attr in cl)
-    dummy_arrays[cl] = jnp.zeros(shape, dtype=jnp.float32)
-  dummy_potentials = CliqueVector(domain, list(cliques), dummy_arrays)
-  marginal_oracles.message_passing_implicit.lower(
-      dummy_potentials, 1.0, jtree=plan.jtree, return_messages=True,
-  ).compile()
+    arrays[cl] = jnp.zeros(shape, dtype=jnp.float32)
+  return CliqueVector(domain, list(cliques), arrays)
 
 
-def _precompile_column(cp: _ColumnPlan, rows: int) -> None:
-  """Trace and compile one column's generation function without executing it."""
-  dummy_rng = jax.random.PRNGKey(0)
-  parent_product = 1 if not cp.has_parents else (
-      int(np.prod(cp.parent_sizes))
+def _build_lookups(plan, potentials, messages, domain):
+  mapping = clique_mapping(
+      plan.maximal_cliques, potentials.cliques, domain=domain,
   )
-  dummy_marg = jnp.ones((parent_product, cp.domain_size), dtype=jnp.float32)
-  dummy_idx = jnp.zeros(rows, dtype=jnp.int32)
-  _gumbel_round.lower(dummy_rng, dummy_marg, dummy_idx, total=rows).compile()
+  pot_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+  for cl in potentials.cliques:
+    pot_map[mapping[cl]].append(potentials[cl])
+
+  msg_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+  for (i, j), msg in messages.items():
+    msg_map[j].append(msg)
+
+  return pot_map, msg_map
 
 
-@jax.jit(static_argnames=['total'])
-def _gumbel_round(rng_key, marg_counts_2d, flat_parent_idx, *, total):
-  """Gumbel rounding: assign each record a value matching expected marginals."""
+def _gather_inputs(cp, domain, pot_map, msg_map):
+  inputs = list(pot_map[cp.maximal_clique]) + list(
+      msg_map[cp.maximal_clique]
+  )
+  query_domain = domain.project(cp.query)
+  for attr in query_domain.attributes:
+    if not any(attr in inp.domain.attributes for inp in inputs):
+      inputs.append(Factor.zeros(domain.project([attr])))
+  return inputs
+
+
+@jax.jit(static_argnames=['query', 'parent_sizes', 'total'])
+def _generate_column(rng_key, inputs, parent_arrays, *, query, parent_sizes,
+                     total):
+  """Fused per-column program: marginal computation + Gumbel rounding."""
+  # Marginal computation (einsum_materialized, inlined).
+  combined = functools.reduce(lambda a, b: a + b, inputs)
+  query_domain = combined.domain.project(query)
+  elim_attrs = combined.domain.marginalize(query_domain).attributes
+  result = combined.logsumexp(elim_attrs).transpose(query_domain.attributes)
+  result = result.normalize(total, log=True).exp()
+  marg = result.datavector(flatten=False)
+
+  # Parent indexing.
+  if parent_arrays:
+    marg_2d = marg.reshape(-1, marg.shape[-1])
+    parent_idx = _ravel_multi_index_jax(parent_arrays, parent_sizes)
+  else:
+    marg_2d = marg[jnp.newaxis, :]
+    parent_idx = jnp.zeros(total, dtype=jnp.int32)
+
+  # Gumbel rounding.
+  return _gumbel_round(rng_key, marg_2d, parent_idx, total)
+
+
+def _gumbel_round(rng_key, marg_2d, flat_parent_idx, total):
+  """Gumbel rounding (called inside JIT, not separately decorated)."""
   rng1, rng2 = jax.random.split(rng_key)
 
-  domain_size = marg_counts_2d.shape[-1]
-  parent_product = marg_counts_2d.shape[0]
+  domain_size = marg_2d.shape[-1]
+  parent_product = marg_2d.shape[0]
 
-  marg_parents = marg_counts_2d.sum(axis=-1, keepdims=True)
-  cond_probs = jnp.where(marg_parents != 0, marg_counts_2d / marg_parents, 0.0)
+  marg_parents = marg_2d.sum(axis=-1, keepdims=True)
+  cond_probs = jnp.where(marg_parents != 0, marg_2d / marg_parents, 0.0)
 
   counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
 
@@ -286,24 +285,6 @@ def _gumbel_round(rng_key, marg_counts_2d, flat_parent_idx, *, total):
   result = jnp.empty(total, dtype=jnp.int32)
   result = result.at[sort_order].set(all_values)
   return result
-
-
-def _compute_marginal_jax(
-    maximal_clique, query, domain, potential_mapping, message_lookup, total,
-):
-  """Compute a query marginal on device from cached messages and potentials."""
-  inputs = list(potential_mapping[maximal_clique]) + list(
-      message_lookup[maximal_clique]
-  )
-  query_domain = domain.project(query)
-
-  for attr in query_domain.attributes:
-    if not any(attr in inp.domain.attributes for inp in inputs):
-      inputs.append(Factor.zeros(domain.project([attr])))
-
-  result = marginal_oracles.einsum_materialized(inputs, query_domain)
-  result = result.normalize(total, log=True).exp()
-  return result.datavector(flatten=False)
 
 
 def _ravel_multi_index_jax(arrays, sizes):

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -20,7 +20,7 @@ from ..domain import Domain
 from ..factor import Factor
 from ..markov_random_field import MarkovRandomField
 
-_COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+_COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -82,26 +82,14 @@ class SyntheticDataGenerator:
     plan = _build_plan(domain, cliques)
     self._plan = plan
 
-    futures: list[concurrent.futures.Future] = []
-
-    # Precompile message passing (1 XLA program).
-    futures.append(_COMPILE_POOL.submit(
-        _precompile_message_passing, domain, plan,
-    ))
-
-    # Precompile per-column generation functions (N XLA programs).
-    for cp in plan.columns.values():
-      futures.append(_COMPILE_POOL.submit(
-          _precompile_column, cp, rows, self.method,
-      ))
-
     # NOTE: JAX's JIT cache doesn't coalesce in-flight compilations, so
-    # if generate() races a background thread it may compile redundantly.
-    def _await_all() -> None:
-      for f in futures:
-        f.result()
+    # if generate() races the background thread it may compile redundantly.
+    def _compile_all():
+      _precompile_message_passing(domain, plan)
+      for cp in plan.columns.values():
+        _precompile_column(cp, rows, self.method)
 
-    return _COMPILE_POOL.submit(_await_all)
+    return _COMPILE_POOL.submit(_compile_all)
 
   def generate(
       self,

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -1,0 +1,525 @@
+"""Fused JAX synthetic data generation with async precompilation.
+
+This module provides ``SyntheticDataGenerator``, a class that generates
+synthetic data from a ``MarkovRandomField`` using JAX-accelerated column
+generation.  All per-column operations (marginal computation, Gumbel
+rounding / categorical sampling) stay on the GPU, eliminating the
+GPU↔CPU synchronization barriers of the baseline NumPy path.
+
+The class mirrors the ``Estimator.precompile()`` pattern: callers can
+fire off ``precompile()`` as soon as the clique structure is known
+(before estimation finishes) and overlap JIT compilation with mirror
+descent iterations.
+
+Typical usage::
+
+    generator = SyntheticDataGenerator(method='round')
+
+    # precompile can start before estimation — only needs domain + cliques.
+    compile_future = generator.precompile(domain, cliques, rows=10_000_000)
+
+    # ... run mirror descent ...
+    model = estimator.estimate(domain, measurements)
+
+    compile_future.result()               # block until compilation finishes
+    data = generator.generate(model, rows=10_000_000)
+"""
+
+from __future__ import annotations
+
+import collections
+import concurrent.futures
+import dataclasses
+import functools
+import logging
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .. import junction_tree, marginal_oracles
+from ..clique_utils import Clique, clique_mapping
+from ..clique_vector import CliqueVector
+from ..dataset import Dataset
+from ..domain import Domain
+from ..factor import Factor
+from ..markov_random_field import MarkovRandomField
+
+# Shared thread pool for background JIT compilation.
+_COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+
+# ---------------------------------------------------------------------------
+# Generation plan: a static description of *how* to generate each column.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class _ColumnPlan:
+  """Describes how to generate a single column."""
+
+  col: str
+  has_parents: bool
+  query: tuple[str, ...]
+  parents: tuple[str, ...]
+  maximal_clique: tuple[str, ...]
+  domain_size: int
+  parent_sizes: tuple[int, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class _GenerationPlan:
+  """Full generation plan for all columns."""
+
+  order: tuple[str, ...]
+  columns: dict[str, _ColumnPlan]
+  jtree: Any  # nx.Graph — kept for message passing
+  maximal_cliques: list[tuple[str, ...]]
+  elimination_order: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class SyntheticDataGenerator:
+  """Generates synthetic data from a MarkovRandomField using JAX.
+
+  The generator separates the concerns of *planning* (junction tree
+  analysis, JIT compilation) from *execution* (message passing,
+  per-column generation).  The planning phase only depends on the
+  ``Domain`` and clique structure, both of which are known before
+  estimation finishes.  This allows JIT compilation to run in the
+  background while mirror descent is still iterating.
+
+  Args:
+    method: ``'round'`` for randomized rounding (default) or ``'sample'``
+      for i.i.d. categorical sampling.
+  """
+
+  def __init__(self, method: str = 'round'):
+    assert method in ('round', 'sample'), (
+        f"method must be 'round' or 'sample', got {method!r}"
+    )
+    self.method = method
+    self._plan: _GenerationPlan | None = None
+    self._msg_fn = None
+
+  # ------------------------------------------------------------------
+  # Precompilation
+  # ------------------------------------------------------------------
+
+  def precompile(
+      self,
+      domain: Domain,
+      cliques: list[Clique],
+      rows: int,
+  ) -> concurrent.futures.Future:
+    """Warm up the JIT cache for ``generate`` asynchronously.
+
+    Only requires the domain and clique structure — both are available
+    before estimation finishes.  Returns a ``Future`` that resolves
+    when all per-column JIT compilations have completed.  Callers may
+    ignore the return value (fire-and-forget) or call
+    ``future.result()`` to block.
+
+    Args:
+      domain: The Domain over which the model is defined.
+      cliques: The cliques of the model (known after workload selection).
+      rows: Number of records that will be generated.
+
+    Returns:
+      A ``Future`` that resolves to ``None`` when compilation is done.
+    """
+    rows = max(1, int(rows))
+    plan = _build_plan(domain, cliques)
+    self._plan = plan
+    self._msg_fn = _make_message_passing_fn(plan.jtree)
+
+    futures: list[concurrent.futures.Future] = []
+
+    # 1. Precompile message passing (1 XLA program).
+    futures.append(_COMPILE_POOL.submit(
+        _precompile_message_passing, self._msg_fn, domain, plan,
+    ))
+
+    # 2. Precompile per-column generation functions (N XLA programs).
+    for cp in plan.columns.values():
+      futures.append(_COMPILE_POOL.submit(
+          _precompile_column, cp, rows, self.method,
+      ))
+
+    def _await_all() -> None:
+      for f in futures:
+        f.result()
+
+    return _COMPILE_POOL.submit(_await_all)
+
+  # ------------------------------------------------------------------
+  # Generation
+  # ------------------------------------------------------------------
+
+  def generate(
+      self,
+      model: MarkovRandomField,
+      rows: int,
+      *,
+      seed: int = 0,
+  ) -> Dataset:
+    """Generate synthetic data from a fitted model.
+
+    If ``precompile`` was called earlier with the same domain, cliques,
+    and ``rows``, the JIT cache will be warm and this call is fast.
+
+    Args:
+      model: A fitted ``MarkovRandomField``.
+      rows: Number of records to generate.
+      seed: Random seed for the JAX PRNG.
+
+    Returns:
+      A ``Dataset`` whose marginals closely match the model.
+    """
+    rows = max(1, int(rows))
+    domain = model.domain
+    cliques = [set(cl) for cl in model.cliques]
+
+    # Use cached plan or build a new one.
+    if self._plan is not None:
+      plan = self._plan
+    else:
+      plan = _build_plan(domain, cliques)
+      self._plan = plan
+
+    # Phase 1: Compute junction tree messages (single JIT'd program).
+    if self._msg_fn is None:
+      self._msg_fn = _make_message_passing_fn(plan.jtree)
+    expanded_potentials = model.potentials.expand(list(plan.jtree.nodes))
+    _, messages = self._msg_fn(expanded_potentials, 1.0)
+
+    # Build per-maximal-clique potential lookup.
+    mapping = clique_mapping(
+        plan.maximal_cliques, model.cliques, domain=domain,
+    )
+    potential_mapping: dict[tuple, list[Factor]] = (
+        collections.defaultdict(list)
+    )
+    for cl in model.cliques:
+      potential_mapping[mapping[cl]].append(model.potentials[cl])
+
+    # Build per-maximal-clique message lookup.
+    message_lookup: dict[tuple, list[Factor]] = (
+        collections.defaultdict(list)
+    )
+    for (i, j), msg in messages.items():
+      message_lookup[j].append(msg)
+
+    # Phase 2: Generate columns (all on GPU).
+    rng = jax.random.PRNGKey(seed)
+    data_jax: dict[str, jax.Array] = {}
+
+    for step, col in enumerate(plan.order):
+      rng, col_rng = jax.random.split(rng)
+      cp = plan.columns[col]
+
+      # Compute marginal on GPU.
+      marg_jax = _compute_marginal_jax(
+          cp.maximal_clique, cp.query, domain,
+          potential_mapping, message_lookup, rows,
+      )
+
+      if not cp.has_parents:
+        data_jax[col] = _dispatch_no_parents(
+            col_rng, marg_jax, rows, self.method,
+        )
+      else:
+        parent_data = tuple(data_jax[p] for p in cp.parents)
+        data_jax[col] = _dispatch_with_parents(
+            col_rng, marg_jax, parent_data, cp.parent_sizes,
+            rows, self.method,
+        )
+
+      if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
+        logging.info(
+            'Col %d/%d: %s done', step + 1, len(plan.order), col,
+        )
+
+    # Bulk transfer to CPU.
+    data = {col: np.asarray(arr) for col, arr in data_jax.items()}
+    return Dataset(data, domain)
+
+
+# ---------------------------------------------------------------------------
+# Plan construction (pure graph analysis, no JAX)
+# ---------------------------------------------------------------------------
+
+
+def _build_plan(
+    domain: Domain,
+    cliques: list[Clique],
+) -> _GenerationPlan:
+  """Analyse the junction tree and build the per-column generation plan."""
+  clique_sets = [set(cl) for cl in cliques]
+  jtree, elimination_order = junction_tree.make_junction_tree(
+      domain, clique_sets,
+  )
+  maximal_cliques = junction_tree.maximal_cliques(jtree)
+  order = tuple(reversed(elimination_order))
+
+  columns: dict[str, _ColumnPlan] = {}
+  used: set[str] = set()
+  for col in order:
+    relevant = [cl for cl in clique_sets if col in cl]
+    parents = tuple(sorted(used.intersection(set().union(*relevant))))
+    used.add(col)
+
+    query = parents + (col,) if parents else (col,)
+    query_set = set(query)
+    mc = _find_maxclique(query_set, maximal_cliques)
+
+    columns[col] = _ColumnPlan(
+        col=col,
+        has_parents=bool(parents),
+        query=query,
+        parents=parents,
+        maximal_clique=mc,
+        domain_size=domain[col],
+        parent_sizes=tuple(domain[p] for p in parents),
+    )
+
+  return _GenerationPlan(
+      order=order,
+      columns=columns,
+      jtree=jtree,
+      maximal_cliques=maximal_cliques,
+      elimination_order=tuple(elimination_order),
+  )
+
+
+# ---------------------------------------------------------------------------
+# Precompilation helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message_passing_fn(jtree):
+  """Create a JIT'd message passing function for a specific junction tree.
+
+  The junction tree is captured in the closure, so all graph-structural
+  operations (message ordering, clique mapping, neighbor lookups) are
+  evaluated at trace time and compiled into a single XLA program.
+  """
+
+  @jax.jit
+  def fn(potentials, total):
+    return marginal_oracles.message_passing_implicit(
+        potentials, total, jtree=jtree, return_messages=True,
+    )
+
+  return fn
+
+
+def _precompile_message_passing(msg_fn, domain, plan):
+  """Warm the JIT cache for the message passing program."""
+  dummy_arrays = {}
+  for cl in plan.jtree.nodes:
+    shape = tuple(domain[attr] for attr in cl)
+    dummy_arrays[cl] = jnp.zeros(shape, dtype=jnp.float32)
+  dummy_potentials = CliqueVector(
+      domain, list(plan.jtree.nodes), dummy_arrays,
+  )
+  msg_fn(dummy_potentials, 1.0)
+
+def _precompile_column(
+    cp: _ColumnPlan,
+    rows: int,
+    method: str,
+) -> None:
+  """Trace and compile the JIT'd generation function for one column."""
+  dummy_rng = jax.random.PRNGKey(0)
+  if not cp.has_parents:
+    dummy_marg = jnp.ones(cp.domain_size, dtype=jnp.float32)
+    _dispatch_no_parents(dummy_rng, dummy_marg, rows, method)
+  else:
+    shape = cp.parent_sizes + (cp.domain_size,)
+    dummy_marg = jnp.ones(shape, dtype=jnp.float32)
+    dummy_parents = tuple(
+        jnp.zeros(rows, dtype=jnp.int32) for _ in cp.parent_sizes
+    )
+    _dispatch_with_parents(
+        dummy_rng, dummy_marg, dummy_parents, cp.parent_sizes,
+        rows, method,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JIT-compiled generation functions
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_no_parents(rng_key, marg_counts, total, method):
+  """Route to the appropriate JIT'd no-parents function."""
+  if method == 'sample':
+    return _sample_no_parents(rng_key, marg_counts, total)
+  return _round_no_parents(rng_key, marg_counts, total)
+
+
+def _dispatch_with_parents(
+    rng_key, marg_counts, parent_data, parent_sizes, total, method,
+):
+  """Route to the appropriate JIT'd with-parents function."""
+  if method == 'sample':
+    return _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes)
+  return _round_with_parents(
+      rng_key, marg_counts, parent_data, parent_sizes, total,
+  )
+
+
+@functools.partial(jax.jit, static_argnums=(2,))
+def _sample_no_parents(rng_key, marg_counts, total):
+  """Sample method for no-parents case."""
+  probs = marg_counts / marg_counts.sum()
+  return jax.random.choice(
+      rng_key, marg_counts.shape[0], shape=(total,), p=probs,
+  ).astype(jnp.int32)
+
+
+@functools.partial(jax.jit, static_argnums=(2,))
+def _round_no_parents(rng_key, marg_counts, total):
+  """Gumbel rounding for no-parents case."""
+  domain_size = marg_counts.shape[0]
+  counts = marg_counts * (total / marg_counts.sum())
+  integ = jnp.floor(counts).astype(jnp.int32)
+  frac = counts - jnp.floor(counts)
+  extra = total - integ.sum()
+
+  rng1, rng2 = jax.random.split(rng_key)
+  u = jax.random.uniform(rng1, (domain_size,))
+  scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
+  scores = jnp.where(frac == 0, -jnp.inf, scores)
+
+  ranked = jnp.argsort(-scores)
+  roundup = jnp.where(jnp.arange(domain_size) < extra, 1, 0)
+  integ = integ.at[ranked].add(roundup)
+
+  vals = jnp.repeat(
+      jnp.arange(domain_size, dtype=jnp.int32), integ,
+      total_repeat_length=total,
+  )
+  perm = jax.random.permutation(rng2, total)
+  return vals[perm]
+
+
+@jax.jit
+def _sample_with_parents(rng_key, marg_counts, parent_data, parent_sizes):
+  """Per-record categorical sampling conditioned on parents."""
+  marg_parents = marg_counts.sum(axis=-1, keepdims=True)
+  cond_probs = jnp.where(marg_parents != 0, marg_counts / marg_parents, 0.0)
+  domain_size = marg_counts.shape[-1]
+  parent_product = cond_probs.size // domain_size
+  cond_probs_2d = cond_probs.reshape(parent_product, domain_size)
+
+  flat_parent_idx = _ravel_multi_index_jax(parent_data, parent_sizes)
+  per_record_probs = cond_probs_2d[flat_parent_idx]
+  return jax.random.categorical(
+      rng_key, jnp.log(per_record_probs + 1e-30),
+  ).astype(jnp.int32)
+
+
+@functools.partial(jax.jit, static_argnums=(4,))
+def _round_with_parents(
+    rng_key, marg_counts, parent_data, parent_sizes, total,
+):
+  """Gumbel rounding conditioned on parents, vectorized on GPU."""
+  rng1, rng2 = jax.random.split(rng_key)
+
+  domain_size = marg_counts.shape[-1]
+  parent_product = marg_counts.size // domain_size
+
+  marg_parents = marg_counts.sum(axis=-1, keepdims=True)
+  cond_probs = jnp.where(marg_parents != 0, marg_counts / marg_parents, 0.0)
+  cond_probs_2d = cond_probs.reshape(parent_product, domain_size)
+
+  flat_parent_idx = _ravel_multi_index_jax(parent_data, parent_sizes)
+  counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
+
+  expected = counts_per_parent[:, None] * cond_probs_2d
+  integ = jnp.floor(expected).astype(jnp.int32)
+  frac = expected - jnp.floor(expected)
+  extra = counts_per_parent - integ.sum(axis=1)
+
+  u = jax.random.uniform(rng1, (parent_product, domain_size))
+  scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
+  scores = jnp.where(frac == 0, -jnp.inf, scores)
+
+  ranked = jnp.argsort(-scores, axis=1)
+  positions = jnp.broadcast_to(
+      jnp.arange(domain_size)[None, :], (parent_product, domain_size),
+  )
+  roundup_mask = (positions < extra[:, None]).astype(jnp.int32)
+  row_indices = jnp.broadcast_to(
+      jnp.arange(parent_product)[:, None], ranked.shape,
+  )
+  roundup = jnp.zeros((parent_product, domain_size), dtype=jnp.int32)
+  roundup = roundup.at[row_indices, ranked].set(roundup_mask)
+  integ = jnp.maximum(integ + roundup, 0)
+
+  value_options = jnp.arange(domain_size, dtype=jnp.int32)
+  value_options_tiled = jnp.tile(value_options, parent_product)
+  all_values = jnp.repeat(
+      value_options_tiled, integ.ravel(), total_repeat_length=total,
+  )
+
+  group_ids = jnp.repeat(
+      jnp.arange(parent_product, dtype=jnp.float32),
+      counts_per_parent,
+      total_repeat_length=total,
+  )
+  shuffle_keys = jax.random.uniform(rng2, (total,))
+  composite = group_ids + shuffle_keys
+  shuffle_perm = jnp.argsort(composite)
+  all_values = all_values[shuffle_perm]
+
+  sort_order = jnp.argsort(flat_parent_idx)
+  result = jnp.empty(total, dtype=jnp.int32)
+  result = result.at[sort_order].set(all_values)
+  return result
+
+
+# ---------------------------------------------------------------------------
+# Marginal computation and utility functions
+# ---------------------------------------------------------------------------
+
+
+def _compute_marginal_jax(
+    maximal_clique, query, domain, potential_mapping, message_lookup, total,
+):
+  """Compute marginal as a JAX array, staying on device."""
+  inputs = list(potential_mapping[maximal_clique]) + list(
+      message_lookup[maximal_clique]
+  )
+  query_domain = domain.project(query)
+
+  for attr in query_domain.attributes:
+    if not any(attr in inp.domain.attributes for inp in inputs):
+      inputs.append(Factor.zeros(domain.project([attr])))
+
+  result = marginal_oracles.einsum_semistable(inputs, query_domain)
+  result = result.normalize(total, log=True).exp()
+  return result.datavector(flatten=False)
+
+
+def _ravel_multi_index_jax(arrays, sizes):
+  """JAX version of np.ravel_multi_index."""
+  result = arrays[0].astype(jnp.int32)
+  for arr, size in zip(arrays[1:], sizes[1:]):
+    result = result * size + arr.astype(jnp.int32)
+  return result
+
+
+def _find_maxclique(query_vars, maximal_cliques):
+  """Find a maximal clique containing all query variables."""
+  for mc in maximal_cliques:
+    if query_vars.issubset(set(mc)):
+      return mc
+  assert False, f'No maximal clique contains {query_vars}'

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -24,6 +24,11 @@ from ..markov_random_field import MarkovRandomField
 _COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
 
+# precompile() and synthetic_data() are coupled: both must build the same
+# _GenerationPlan and call _generate_column with matching static args for
+# the JIT cache to hit.  Keep their signatures and internal logic in sync.
+
+
 def precompile(
     domain: Domain,
     cliques: list[Clique],

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -189,7 +189,7 @@ def einsum_fused(
     return sum_product(log_factors, dom, einsum_fn=_custom_einsum)
 
 
-@jax.jit(static_argnames=['jtree', 'return_messages'])
+@jax.jit(static_argnames=["jtree", "return_messages"])
 def message_passing_hugin(
     potentials: CliqueVector,
     total: float = 1.0,
@@ -238,7 +238,7 @@ def message_passing_hugin(
     return (marginals, messages) if return_messages else marginals
 
 
-@jax.jit(static_argnames=['jtree', 'return_messages'])
+@jax.jit(static_argnames=["jtree", "return_messages"])
 def message_passing_shafer_shenoy(
     potentials: CliqueVector,
     total: float = 1.0,
@@ -298,7 +298,7 @@ def message_passing_shafer_shenoy(
     return (marginals, messages) if return_messages else marginals
 
 
-@jax.jit(static_argnames=['jtree', 'contraction', 'return_messages'])
+@jax.jit(static_argnames=["jtree", "contraction", "return_messages"])
 def message_passing_implicit(
     potentials: CliqueVector,
     total: float = 1.0,

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -189,6 +189,7 @@ def einsum_fused(
     return sum_product(log_factors, dom, einsum_fn=_custom_einsum)
 
 
+@jax.jit(static_argnames=['jtree', 'return_messages'])
 def message_passing_hugin(
     potentials: CliqueVector,
     total: float = 1.0,
@@ -237,6 +238,7 @@ def message_passing_hugin(
     return (marginals, messages) if return_messages else marginals
 
 
+@jax.jit(static_argnames=['jtree', 'return_messages'])
 def message_passing_shafer_shenoy(
     potentials: CliqueVector,
     total: float = 1.0,
@@ -296,6 +298,7 @@ def message_passing_shafer_shenoy(
     return (marginals, messages) if return_messages else marginals
 
 
+@jax.jit(static_argnames=['jtree', 'contraction', 'return_messages'])
 def message_passing_implicit(
     potentials: CliqueVector,
     total: float = 1.0,


### PR DESCRIPTION
Two standalone functions for fast synthetic data generation from MarkovRandomField models:

- `synthetic_data(model, rows, seed)`: Generate synthetic data using Gumbel rounding. Output marginals match the model within ±2 counts per cell.

- `precompile(domain, cliques, rows)`: Optionally warm the JIT cache asynchronously. Only requires domain and clique structure (available after measurement selection), so compilation can overlap with estimation.

### Key design choices

- No class, no shared state. Connection between precompile and synthetic_data is JAX's global JIT cache.
- Single `_generate_column` function with `static_argnames` for JIT cache matching.
- Fused XLA programs: each column compiles marginal computation, parent indexing, and Gumbel rounding into one program.
- `einsum_materialized` for numerically stable marginal computation.
- Passes `model.potentials` directly to `message_passing_implicit` (no `expand()`).