### PR TITLE
Fix DualAveraging divergence on scaled simplex

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -414,6 +414,7 @@ class DualAveraging(Estimator):
         beta = state.gamma * (t + 1) ** 1.5 / 2
         u = (1 - c) * state.w + c * state.v
         loss, g = jax.value_and_grad(loss_fn)(u)
+        g = g / known_total
         gbar = (1 - c) * state.gbar + c * g
         theta = -t * (t + 1) / (4 * state.lipschitz + beta) * gbar
         v = marginal_oracle(theta, known_total)


### PR DESCRIPTION
## Summary

Normalize the gradient by `known_total` in `DualAveraging._step` to prevent softmax saturation when optimizing over the N-scaled simplex.

## Root Cause

The step coefficient `θ = t(t+1)/(4L) × ḡ` grows as `O(t²/L) × ḡ`. Without gradient normalization, `ḡ` accumulates O(1/σ²)-magnitude gradients, causing `|θ|` to reach thousands or millions — far beyond the softmax numerical range (~20). The marginal oracle then returns degenerate distributions and the algorithm diverges.

## Fix

Add `g = g / known_total` to normalize the gradient before accumulation, making `θ = O(t²/(L·N))` which stays bounded. This is consistent with the entropy DGF on Δ_N having strong convexity `σ_h = 1/N` w.r.t. ℓ₁.

**Note:** PR #138 removed `/ known_total` from both `L` and `g` simultaneously. Since they cancel algebraically (`L/N` in the denominator × `g/N` = `L` in denominator × `g/1`), DA behavior was unchanged. This fix intentionally breaks the cancellation by normalizing only `g`, not `L`, making the potentials N× smaller.

## Results (loss after 1000 iterations, 5 attrs × 4 levels, 10 two-way marginals)

| N | σ | DA (before) | **DA (fixed)** | MD (reference) |
|---|---|-------------|----------------|----------------|
| 1K | 1 | 367 ❌ | **31.0** ✅ | 31.0 |
| 1K | 10 | 33.8 | **31.0** ✅ | 31.0 |
| 1K | 100 | 37.3 | **38.3** ✅ | 38.5 |
| 1K | 1000 | 6135 ❌ | **59.6** ✅ | 61.0 |
| 10K | 1 | 24155 ❌ | **22.1** ✅ | 22.1 |
| 10K | 10 | 301 ❌ | **22.1** ✅ | 22.1 |
| 10K | 100 | 25.0 | **22.1** ✅ | 22.1 |
| 10K | 1000 | 33.9 | **35.9** ✅ | 40.0 |
| 100K | 1 | 7.1M ❌ | **33.1** ✅ | 33.0 |
| 100K | 10 | 68797 ❌ | **33.1** ✅ | 33.1 |
| 100K | 100 | 766 ❌ | **33.1** ✅ | 33.1 |
| 100K | 1000 | 39.4 | **33.1** ✅ | 33.1 |

All existing tests pass.