### PR TITLE
Fix UAM divergence on scaled simplex via unit simplex scaling

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -944,13 +944,23 @@ def universal_accelerated_method(
     )
     marginal_oracle = functools.partial(marginal_oracle, mesh=mesh)
 
+    # Operate on the unit simplex internally to avoid softmax saturation.
+    # The loss on the unit simplex is f_scaled(p) = f(N * p), so its Hessian
+    # is N^2 times larger.  The dual projection maps potentials to the unit
+    # simplex (known_total=1) instead of the N-scaled simplex.
+    def scaled_loss(p):
+        return loss_fn(known_total * p)
+
+    L = loss_fn.lipschitz or 1.0
+    initial_stepsize = 1.0 / (known_total * L)
+
     carry, cond_fun, body_fun = _universal_accelerated_method_step_init(
-        fun=loss_fn,
+        fun=scaled_loss,
         dual_init_params=potentials,
-        dual_proj=lambda x: marginal_oracle(x, known_total),
+        dual_proj=lambda x: marginal_oracle(x, 1.0),
         max_iter_search=30,
         target_acc=0.0,
-        stepsize=1.0 / known_total,
+        stepsize=initial_stepsize,
         norm=2,
         linesearch=True,
     )
@@ -958,6 +968,7 @@ def universal_accelerated_method(
         # jax.lax.while_loop traces the body function, so no need to jit it.
         carry = jax.lax.while_loop(cond_fun, body_fun, carry)
         carry = carry._replace(accept=jnp.asarray(False))
-        callback_fn(carry.x)
-    sol = carry.x
+        callback_fn(known_total * carry.x)
+    sol = known_total * carry.x
     return mle_from_marginals(sol, known_total)
+


### PR DESCRIPTION
## Summary

Scale the loss function to operate on the unit simplex internally, avoiding softmax saturation when optimizing over the N-scaled simplex (Δ_N).

## Root Cause

UAM's linesearch uses an L2 Taylor bound: `f(x) ≤ f(y) + ⟨∇f, x-y⟩ + ½L‖x-y‖²`. On the N-scaled simplex, when potentials grow large, the softmax saturates and produces degenerate distributions. Both `x` and `y` become identical point masses, so `‖x-y‖ ≈ 0` and the bound trivially holds — the linesearch **never rejects**, even as the loss explodes to millions. The algorithm gets stuck at a degenerate solution.

## Fix

Define `scaled_loss(p) = loss_fn(N * p)` where `p` lives on the unit simplex. Use `marginal_oracle(θ, 1.0)` for dual projection (unit simplex instead of N-scaled). Set initial stepsize to `1/(N·L)` to account for the N² Hessian scaling. Scale final marginals back by N.

## Results (loss after 1000 iterations)

| N | σ | UAM (before) | **UAM (fixed)** | MD (reference) |
|---|---|-------------|----------------|----------------|
| 1K | 1 | 479 ❌ | **31.0** ✅ | 31.0 |
| 1K | 1000 | 59.8 ✅ | **59.8** ✅ | 61.0 |
| 10K | 1 | 49555 ❌ | **22.1** ✅ | 22.1 |
| 10K | 10 | 2208 ❌ | **22.1** ✅ | 22.1 |
| 10K | 1000 | 38.1 | **36.6** ✅ | 40.0 |
| 100K | 1 | 6.1M ❌ | **33.1** ✅ | 33.0 |
| 100K | 10 | 36569 ❌ | **33.1** ✅ | 33.1 |
| 100K | 100 | 403 ❌ | **33.1** ✅ | 33.1 |
| 100K | 1000 | 90.7 | **33.1** ✅ | 33.1 |

All 7 existing UAM tests pass.