### PR TITLE
Add ArbitraryConstraint for general structural constraints

### DIFF
--- a/src/mbi/extensions/__init__.py
+++ b/src/mbi/extensions/__init__.py
@@ -1,5 +1,7 @@
 """Extensions for mbi providing alternative estimation approaches."""
 
+from .constraints import ArbitraryConstraint
+
 from .mixture_of_products import MixtureOfProducts, MixtureOfProductsEstimator
 from .reweighted_dataset import ReweightedDatasetEstimator
 from .synthetic_data import precompile, synthetic_data

--- a/src/mbi/extensions/constraints.py
+++ b/src/mbi/extensions/constraints.py
@@ -1,10 +1,14 @@
-"""Efficient handling of deterministic variable constraints.
+"""Handling of structural constraints between variables.
 
-Provides utilities for exploiting deterministic relationships between variables
-(e.g., A' = f(A) where A' is a coarsening of A) during message passing in
-graphical models. Instead of materializing full |A| x |A'| constraint factors,
-messages are routed through the constraint in O(|A|) time using coarsen/refine
-operations.
+Provides two constraint types:
+
+* ``DeterministicConstraint`` — exploits many-to-one (coarsening)
+  relationships via O(|fine|) coarsen/refine operations during message
+  passing, avoiding full |fine| × |coarse| factor materialization.
+
+* ``ArbitraryConstraint`` — represents any set of allowed (or disallowed)
+  index combinations as a dense ``-inf``/``0`` log-space factor.  No special
+  message-passing shortcuts; the factor participates in standard inference.
 """
 
 from __future__ import annotations
@@ -63,6 +67,105 @@ class DeterministicConstraint:
     @property
     def n_coarse(self) -> int:
         return int(self.mapping.max()) + 1
+
+
+@attr.dataclass(frozen=True, hash=False, eq=False)
+class ArbitraryConstraint:
+    """Structural constraint over an arbitrary subset of value combinations.
+
+    Materialized as a dense -inf/0 log-space factor for standard message
+    passing.  Specify exactly one of ``valid`` or ``invalid``.
+
+    Attributes:
+        attributes: Variable names.
+        valid: Array of shape (n, len(attributes)) listing allowed combos.
+        invalid: Array of shape (n, len(attributes)) listing forbidden combos.
+    """
+
+    attributes: tuple[str, ...]
+    valid: np.ndarray | None = None
+    invalid: np.ndarray | None = None
+
+    def __attrs_post_init__(self):
+        if (self.valid is None) == (self.invalid is None):
+            raise ValueError(
+                "Specify exactly one of 'valid' or 'invalid', not both."
+            )
+        data = self.valid if self.valid is not None else self.invalid
+        if data.ndim != 2 or data.shape[1] != len(self.attributes):
+            raise ValueError(
+                f'Expected shape (n, {len(self.attributes)}), got {data.shape}.'
+            )
+
+    def __hash__(self):
+        data = self.valid if self.valid is not None else self.invalid
+        return hash((self.attributes, data.tobytes(), self.valid is not None))
+
+    def __eq__(self, other):
+        if not isinstance(other, ArbitraryConstraint):
+            return NotImplemented
+        data_self = self.valid if self.valid is not None else self.invalid
+        data_other = other.valid if other.valid is not None else other.invalid
+        return (
+            self.attributes == other.attributes
+            and (self.valid is not None) == (other.valid is not None)
+            and np.array_equal(data_self, data_other)
+        )
+
+    @property
+    def clique(self) -> tuple[str, ...]:
+        return tuple(sorted(self.attributes))
+
+    def as_potential(self, domain: Domain) -> Factor:
+        """Return a log-space potential: 0 for allowed, -inf for forbidden."""
+        proj = domain.project(self.attributes)
+        if self.valid is not None:
+            idx = tuple(self.valid[:, i] for i in range(self.valid.shape[1]))
+            values = jnp.full(proj.shape, -jnp.inf).at[idx].set(0.0)
+        else:
+            idx = tuple(
+                self.invalid[:, i] for i in range(self.invalid.shape[1])
+            )
+            values = jnp.zeros(proj.shape).at[idx].set(-jnp.inf)
+        return Factor(proj, values)
+
+    @classmethod
+    def from_mapping(
+        cls, fine: str, coarse: str, mapping: np.ndarray
+    ) -> ArbitraryConstraint:
+        """Create from a deterministic mapping (functional dependency)."""
+        valid = np.column_stack([np.arange(len(mapping)), np.asarray(mapping)])
+        return cls(attributes=(fine, coarse), valid=valid)
+
+
+# Union type for constraint parameters.
+Constraint = DeterministicConstraint | ArbitraryConstraint
+
+
+def _separate_constraints(constraints, potentials):
+    """Split mixed constraints; fold ArbitraryConstraints into potentials."""
+    deterministic = []
+    for c in constraints:
+        if isinstance(c, DeterministicConstraint):
+            deterministic.append(c)
+        elif isinstance(c, ArbitraryConstraint):
+            domain = potentials.domain
+            cl = domain.canonical(c.clique)
+            factor = c.as_potential(domain)
+            cliques = list(potentials.cliques)
+            arrays = {k: potentials[k] for k in cliques}
+            if cl in arrays:
+                arrays[cl] = arrays[cl] + factor
+            else:
+                cliques.append(cl)
+                arrays[cl] = factor
+            potentials = CliqueVector(domain, cliques, arrays)
+        else:
+            raise TypeError(
+                'Expected DeterministicConstraint or ArbitraryConstraint, '
+                f'got {type(c).__name__}.'
+            )
+    return tuple(deterministic), potentials
 
 
 def _replace_variable(factor, old, new, new_size):
@@ -347,20 +450,24 @@ def constrained_shafer_shenoy(
     potentials: CliqueVector,
     total: float = 1,
     jtree: nx.Graph | None = None,
-    constraints: tuple[DeterministicConstraint, ...] = (),
+    constraints: tuple[Constraint, ...] = (),
 ) -> CliqueVector:
     """Compute marginals using Shafer-Shenoy with constraint-aware shortcuts.
 
     Extends message_passing_shafer_shenoy to handle deterministic constraints
-    without materializing |fine| x |coarse| factors.
+    without materializing |fine| x |coarse| factors.  Also accepts
+    ``ArbitraryConstraint`` objects, which are folded into the potentials
+    as dense factors before inference.
 
     Args:
         potentials: The (log-space) potentials of a graphical model.
         total: The normalization factor.
-
         jtree: An optional junction tree that defines the message passing
             order.
-        constraints: Deterministic constraints to handle efficiently.
+        constraints: Deterministic and/or arbitrary constraints.
+            ``DeterministicConstraint`` objects get efficient O(|fine|)
+            routing; ``ArbitraryConstraint`` objects are materialized as
+            dense factors and added to the potentials.
 
     Returns:
         The marginals of the graphical model.
@@ -368,6 +475,7 @@ def constrained_shafer_shenoy(
     if len(potentials.cliques) == 0:
         return CliqueVector(potentials.domain, [], {})
 
+    constraints, potentials = _separate_constraints(constraints, potentials)
     domain, cliques = potentials.domain, potentials.cliques
 
     # Build the junction tree, including constraint edges.
@@ -512,7 +620,7 @@ def constrained_implicit(
     total: float = 1,
     jtree: nx.Graph | None = None,
     *,
-    constraints: tuple[DeterministicConstraint, ...] = (),
+    constraints: tuple[Constraint, ...] = (),
     contraction: collections.abc.Callable = (
         marginal_oracles.einsum_materialized
     ),
@@ -521,15 +629,15 @@ def constrained_implicit(
 
     Uses the memory-efficient implicit contraction for cliques that do not
     involve constraints, and falls back to Shafer-Shenoy style constraint
-    routing for pure and embedded constraint cliques.  This avoids *both*
-    super-clique expansion (for standard cliques) and the cost of
-    refining coarse factors to fine-variable space (for constraint cliques).
+    routing for pure and embedded constraint cliques.  Also accepts
+    ``ArbitraryConstraint`` objects, which are folded into the potentials
+    as dense factors before inference.
 
     Args:
         potentials: The (log-space) potentials of a graphical model.
         total: The normalization factor.
         jtree: An optional junction tree.
-        constraints: Deterministic constraints to handle efficiently.
+        constraints: Deterministic and/or arbitrary constraints.
         contraction: Contraction function for log-space sum-product.
 
     Returns:
@@ -539,6 +647,7 @@ def constrained_implicit(
     if len(potentials.cliques) == 0:
         return CliqueVector(potentials.domain, [], {})
 
+    constraints, potentials = _separate_constraints(constraints, potentials)
     domain, cliques = potentials.domain, potentials.cliques
 
     # Build junction tree with constraint edges.

--- a/test/test_arbitrary_constraint.py
+++ b/test/test_arbitrary_constraint.py
@@ -1,0 +1,381 @@
+"""Tests for ArbitraryConstraint."""
+
+import unittest
+
+import jax.numpy as jnp
+from mbi.domain import Domain
+from mbi.extensions.constraints import ArbitraryConstraint
+from mbi.extensions.constraints import DeterministicConstraint
+from mbi.factor import Factor
+import numpy as np
+
+
+class ArbitraryConstraintConstructionTest(unittest.TestCase):
+    """Tests for ArbitraryConstraint construction and validation."""
+
+    def test_valid_construction(self):
+        c = ArbitraryConstraint(
+            attributes=('A', 'B'),
+            valid=np.array([[0, 0], [1, 1], [2, 2]]),
+        )
+        self.assertEqual(c.attributes, ('A', 'B'))
+        self.assertEqual(c.valid.shape, (3, 2))
+        self.assertIsNone(c.invalid)
+
+    def test_invalid_construction(self):
+        c = ArbitraryConstraint(
+            attributes=('A', 'B'),
+            invalid=np.array([[0, 1], [1, 0]]),
+        )
+        self.assertEqual(c.attributes, ('A', 'B'))
+        self.assertIsNone(c.valid)
+        self.assertEqual(c.invalid.shape, (2, 2))
+
+    def test_neither_raises(self):
+        with self.assertRaises(ValueError, msg='exactly one'):
+            ArbitraryConstraint(attributes=('A', 'B'))
+
+    def test_both_raises(self):
+        with self.assertRaises(ValueError, msg='exactly one'):
+            ArbitraryConstraint(
+                attributes=('A', 'B'),
+                valid=np.array([[0, 0]]),
+                invalid=np.array([[1, 1]]),
+            )
+
+    def test_wrong_shape_raises(self):
+        with self.assertRaises(ValueError, msg='shape'):
+            ArbitraryConstraint(
+                attributes=('A', 'B'),
+                valid=np.array([[0, 0, 0]]),  # 3 cols, but 2 attributes
+            )
+
+    def test_1d_array_raises(self):
+        with self.assertRaises(ValueError, msg='shape'):
+            ArbitraryConstraint(
+                attributes=('A', 'B'),
+                valid=np.array([0, 1]),  # 1D, not 2D
+            )
+
+    def test_clique_is_sorted(self):
+        c = ArbitraryConstraint(
+            attributes=('B', 'A'),
+            valid=np.array([[0, 0]]),
+        )
+        self.assertEqual(c.clique, ('A', 'B'))
+
+    def test_three_attributes(self):
+        c = ArbitraryConstraint(
+            attributes=('X', 'Y', 'Z'),
+            valid=np.array([[0, 0, 0], [1, 1, 1]]),
+        )
+        self.assertEqual(c.attributes, ('X', 'Y', 'Z'))
+        self.assertEqual(c.valid.shape, (2, 3))
+
+
+class ArbitraryConstraintPotentialTest(unittest.TestCase):
+    """Tests for ArbitraryConstraint.as_potential."""
+
+    def test_valid_potential(self):
+        domain = Domain(['A', 'B'], [3, 4])
+        c = ArbitraryConstraint(
+            attributes=('A', 'B'),
+            valid=np.array([[0, 0], [1, 1], [2, 2]]),
+        )
+        potential = c.as_potential(domain)
+
+        self.assertEqual(potential.domain.attributes, ('A', 'B'))
+        self.assertEqual(potential.domain.shape, (3, 4))
+
+        vals = np.array(potential.values)
+        # Valid entries should be 0
+        self.assertEqual(vals[0, 0], 0.0)
+        self.assertEqual(vals[1, 1], 0.0)
+        self.assertEqual(vals[2, 2], 0.0)
+        # Invalid entries should be -inf
+        self.assertEqual(vals[0, 1], -np.inf)
+        self.assertEqual(vals[1, 0], -np.inf)
+        self.assertEqual(vals[2, 3], -np.inf)
+
+    def test_invalid_potential(self):
+        domain = Domain(['A', 'B'], [3, 4])
+        c = ArbitraryConstraint(
+            attributes=('A', 'B'),
+            invalid=np.array([[0, 1], [1, 0]]),
+        )
+        potential = c.as_potential(domain)
+
+        vals = np.array(potential.values)
+        # Invalid entries should be -inf
+        self.assertEqual(vals[0, 1], -np.inf)
+        self.assertEqual(vals[1, 0], -np.inf)
+        # Everything else should be 0
+        self.assertEqual(vals[0, 0], 0.0)
+        self.assertEqual(vals[0, 2], 0.0)
+        self.assertEqual(vals[1, 1], 0.0)
+        self.assertEqual(vals[2, 3], 0.0)
+
+    def test_valid_and_invalid_are_complementary(self):
+        """A constraint from valid combos should produce the same potential
+        as one from the complementary invalid combos."""
+        domain = Domain(['A', 'B'], [3, 4])
+
+        valid = np.array([[0, 0], [1, 1], [2, 2]])
+        # Complement: everything NOT in valid
+        all_combos = np.array([[a, b] for a in range(3) for b in range(4)])
+        valid_set = {tuple(r) for r in valid}
+        invalid = np.array([r for r in all_combos if tuple(r) not in valid_set])
+
+        c_valid = ArbitraryConstraint(attributes=('A', 'B'), valid=valid)
+        c_invalid = ArbitraryConstraint(attributes=('A', 'B'), invalid=invalid)
+
+        p_valid = c_valid.as_potential(domain)
+        p_invalid = c_invalid.as_potential(domain)
+
+        np.testing.assert_array_equal(
+            np.array(p_valid.values), np.array(p_invalid.values)
+        )
+
+    def test_three_attribute_potential(self):
+        domain = Domain(['X', 'Y', 'Z'], [2, 3, 2])
+        c = ArbitraryConstraint(
+            attributes=('X', 'Y', 'Z'),
+            valid=np.array([[0, 0, 0], [1, 2, 1]]),
+        )
+        potential = c.as_potential(domain)
+
+        vals = np.array(potential.values)
+        self.assertEqual(vals[0, 0, 0], 0.0)
+        self.assertEqual(vals[1, 2, 1], 0.0)
+        # Everything else is -inf
+        n_inf = np.sum(vals == -np.inf)
+        self.assertEqual(n_inf, 2 * 3 * 2 - 2)
+
+    def test_potential_with_message_passing(self):
+        """ArbitraryConstraint potential integrates with standard inference."""
+        from mbi.clique_vector import CliqueVector
+        from mbi.marginal_oracles import message_passing_shafer_shenoy
+
+        domain = Domain(['A', 'B', 'C'], [3, 3, 4])
+
+        # Diagonal constraint: A == B
+        valid = np.array([[i, i] for i in range(3)])
+        c = ArbitraryConstraint(attributes=('A', 'B'), valid=valid)
+
+        # Random potentials on (A, C) and (B, C)
+        np.random.seed(42)
+        cliques = [('A', 'C'), ('B', 'C')]
+        arrays = {
+            cl: Factor(
+                domain.project(cl),
+                jnp.array(np.random.randn(*domain.project(cl).shape)),
+            )
+            for cl in cliques
+        }
+
+        # Add constraint potential
+        con_cl = c.clique
+        cliques_with_con = list(cliques) + [con_cl]
+        arrays[con_cl] = c.as_potential(domain)
+
+        potentials = CliqueVector(domain, cliques_with_con, arrays)
+        result = message_passing_shafer_shenoy(potentials, total=1.0)
+
+        # The (A, B) marginal should only have mass on the diagonal
+        ab_marginal = result.project(('A', 'B'))
+        vals = np.array(ab_marginal.values)
+        for a in range(3):
+            for b in range(3):
+                if a == b:
+                    self.assertGreater(vals[a, b], 0)
+                else:
+                    np.testing.assert_allclose(vals[a, b], 0, atol=1e-6)
+
+
+class ArbitraryConstraintFromMappingTest(unittest.TestCase):
+    """Tests for ArbitraryConstraint.from_mapping."""
+
+    def test_from_mapping(self):
+        mapping = np.array([0, 0, 1, 1, 2, 2])
+        c = ArbitraryConstraint.from_mapping('A', 'Ap', mapping)
+
+        self.assertEqual(c.attributes, ('A', 'Ap'))
+        self.assertIsNotNone(c.valid)
+        self.assertEqual(c.valid.shape, (6, 2))
+
+    def test_from_mapping_matches_deterministic(self):
+        """from_mapping potential should match DeterministicConstraint's
+        implicit -inf/0 factor."""
+        mapping = np.array([0, 0, 1, 1, 2, 2])
+        domain = Domain(['A', 'Ap'], [6, 3])
+
+        arb = ArbitraryConstraint.from_mapping('A', 'Ap', mapping)
+        det = DeterministicConstraint('A', 'Ap', mapping)
+
+        # Build the DeterministicConstraint's equivalent factor
+        shape = (det.n_fine, det.n_coarse)
+        vals = np.full(shape, -np.inf)
+        for a, ap in enumerate(det.mapping):
+            vals[a, ap] = 0.0
+        det_factor = Factor(Domain(['A', 'Ap'], list(shape)), jnp.array(vals))
+
+        arb_factor = arb.as_potential(domain)
+
+        np.testing.assert_array_equal(
+            np.array(arb_factor.values), np.array(det_factor.values)
+        )
+
+
+class ArbitraryConstraintEqualityTest(unittest.TestCase):
+    """Tests for __eq__ and __hash__."""
+
+    def test_equal_valid(self):
+        c1 = ArbitraryConstraint(
+            attributes=('A', 'B'), valid=np.array([[0, 0], [1, 1]])
+        )
+        c2 = ArbitraryConstraint(
+            attributes=('A', 'B'), valid=np.array([[0, 0], [1, 1]])
+        )
+        self.assertEqual(c1, c2)
+        self.assertEqual(hash(c1), hash(c2))
+
+    def test_not_equal_different_data(self):
+        c1 = ArbitraryConstraint(
+            attributes=('A', 'B'), valid=np.array([[0, 0]])
+        )
+        c2 = ArbitraryConstraint(
+            attributes=('A', 'B'), valid=np.array([[1, 1]])
+        )
+        self.assertNotEqual(c1, c2)
+
+    def test_not_equal_valid_vs_invalid(self):
+        data = np.array([[0, 0], [1, 1]])
+        c1 = ArbitraryConstraint(attributes=('A', 'B'), valid=data)
+        c2 = ArbitraryConstraint(attributes=('A', 'B'), invalid=data)
+        self.assertNotEqual(c1, c2)
+
+
+class ArbitraryConstraintMessagePassingTest(unittest.TestCase):
+    """Tests for plumbing ArbitraryConstraint through constrained_* functions."""
+
+    def test_shafer_shenoy_with_arbitrary_constraint(self):
+        """ArbitraryConstraint passed via constraints= should work."""
+        from mbi.clique_vector import CliqueVector
+        from mbi.extensions.constraints import constrained_shafer_shenoy
+
+        domain = Domain(['A', 'B', 'C'], [3, 3, 4])
+
+        # Diagonal constraint: A == B
+        valid = np.array([[i, i] for i in range(3)])
+        c = ArbitraryConstraint(attributes=('A', 'B'), valid=valid)
+
+        np.random.seed(42)
+        cliques = [('A', 'C'), ('B', 'C')]
+        arrays = {
+            cl: Factor(
+                domain.project(cl),
+                jnp.array(np.random.randn(*domain.project(cl).shape)),
+            )
+            for cl in cliques
+        }
+        potentials = CliqueVector(domain, cliques, arrays)
+
+        result = constrained_shafer_shenoy(
+            potentials, total=1.0, constraints=(c,)
+        )
+
+        # The (A, B) constraint should be enforced
+        for cl in cliques:
+            marginal = result[cl]
+            self.assertEqual(marginal.domain.shape, domain.project(cl).shape)
+            # Marginal should sum to approximately 1
+            np.testing.assert_allclose(float(marginal.sum()), 1.0, atol=1e-5)
+
+    def test_shafer_shenoy_matches_manual_potential(self):
+        """Passing ArbitraryConstraint via constraints= should produce the
+        same result as manually adding the factor to potentials."""
+        from mbi.clique_vector import CliqueVector
+        from mbi.extensions.constraints import constrained_shafer_shenoy
+        from mbi.marginal_oracles import message_passing_shafer_shenoy
+
+        domain = Domain(['A', 'B', 'C'], [3, 3, 4])
+        valid = np.array([[i, i] for i in range(3)])
+        c = ArbitraryConstraint(attributes=('A', 'B'), valid=valid)
+
+        np.random.seed(42)
+        cliques = [('A', 'C'), ('B', 'C')]
+        arrays = {
+            cl: Factor(
+                domain.project(cl),
+                jnp.array(np.random.randn(*domain.project(cl).shape)),
+            )
+            for cl in cliques
+        }
+        potentials = CliqueVector(domain, cliques, arrays)
+
+        # Method 1: via constraints= parameter
+        result1 = constrained_shafer_shenoy(
+            potentials, total=1.0, constraints=(c,)
+        )
+
+        # Method 2: manually add factor to potentials
+        con_cl = domain.canonical(c.clique)
+        arrays2 = dict(arrays)
+        arrays2[con_cl] = c.as_potential(domain)
+        cliques2 = list(cliques) + [con_cl]
+        potentials2 = CliqueVector(domain, cliques2, arrays2)
+        result2 = message_passing_shafer_shenoy(potentials2, total=1.0)
+
+        for cl in cliques:
+            np.testing.assert_allclose(
+                np.array(result1[cl].values),
+                np.array(result2.project(cl).values),
+                atol=1e-5,
+            )
+
+    def test_mixed_constraints(self):
+        """A tuple with both DeterministicConstraint and ArbitraryConstraint."""
+        from mbi.clique_vector import CliqueVector
+        from mbi.extensions.constraints import constrained_shafer_shenoy
+
+        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+        mapping = np.array([0, 0, 1, 1, 2, 2])
+        det_c = DeterministicConstraint('A', 'Ap', mapping)
+
+        # Constraint on (Ap, B): only certain combos are valid.
+        valid = np.array([
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1],
+            [1, 2],
+            [2, 0],
+            [2, 1],
+            [2, 2],
+            [2, 3],
+        ])
+        arb_c = ArbitraryConstraint(attributes=('Ap', 'B'), valid=valid)
+
+        np.random.seed(123)
+        # Use cliques that cover all variables properly.
+        cliques = [('A', 'B'), ('A', 'Ap'), ('Ap', 'B')]
+        arrays = {
+            cl: Factor(
+                domain.project(cl),
+                jnp.array(np.random.randn(*domain.project(cl).shape)),
+            )
+            for cl in cliques
+        }
+        potentials = CliqueVector(domain, cliques, arrays)
+
+        # Should not raise
+        result = constrained_shafer_shenoy(
+            potentials, total=1.0, constraints=(det_c, arb_c)
+        )
+
+        for cl in cliques:
+            self.assertEqual(result[cl].domain.shape, domain.project(cl).shape)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds `ArbitraryConstraint` to `extensions/constraints.py` alongside the existing `DeterministicConstraint`. The two are complementary siblings:

| | `DeterministicConstraint` | `ArbitraryConstraint` |
|---|---|---|
| **Expressiveness** | Many-to-one only | Arbitrary |
| **Message passing** | O(|fine|) via coarsen/refine | Dense -inf/0 factor |
| **Use when** | Functional dependencies | Conditional / universe constraints |

## API

```python
# From valid combinations
c = ArbitraryConstraint(
    attributes=('gqtype', 'gq'),
    valid=np.array([[0, 0], [0, 1], [1, 3], [2, 3], ...]),
)

# From invalid combinations (complement)
c = ArbitraryConstraint(
    attributes=('sex', 'chborn'),
    invalid=np.array([[0, 1], [0, 2], ...]),  # males can't have children born
)

# From a deterministic mapping
c = ArbitraryConstraint.from_mapping('bpld', 'bpl', mapping_array)

# Get the constraint potential
factor = c.as_potential(domain)
```

Exactly one of `valid` or `invalid` must be specified. Supports any number of attributes.

## Motivation

The census domain has 14 cross-attribute constraints. 13 are functional dependencies handled by `DeterministicConstraint`, but `gqtype ↔ gq` is a conditional constraint (one-to-many in both directions). This class fills that gap.

## Tests

18 unit tests covering construction, validation, both potential modes, complementarity, from_mapping equivalence, message passing integration, and equality semantics.