### PR TITLE
Migrate examples and mechanisms to class-based estimator API

### DIFF
--- a/examples/adult_example.py
+++ b/examples/adult_example.py
@@ -42,8 +42,8 @@ for cl in cliques:
 
 estimated_total = estimation.minimum_variance_unbiased_total(measurements)
 loss_fn = marginal_loss.from_linear_measurements(measurements)
-model = estimation.mirror_descent(
-    domain, loss_fn, known_total=estimated_total, iters=2500, stepsize=4e-5
+model = estimation.MirrorDescent(stepsize=4e-5).estimate(
+    domain, loss_fn, known_total=estimated_total, iters=2500
 )
 
 # now answer new queries

--- a/examples/convergence.py
+++ b/examples/convergence.py
@@ -73,28 +73,28 @@ if __name__ == "__main__":
     for estimator in args.estimator:
         callback_fn = callbacks.default(measurements, data)
         if estimator == "MD":
-            model = estimation.mirror_descent(
+            model = estimation.MirrorDescent().estimate(
                 data.domain,
                 measurements,
                 iters=args.iters,
                 callback_fn=callback_fn,
             )
         if estimator == "RDA":
-            model = estimation.dual_averaging(
+            model = estimation.DualAveraging().estimate(
                 data.domain,
                 measurements,
                 iters=args.iters,
                 callback_fn=callback_fn,
             )
         if estimator == "IG":
-            model = estimation.interior_gradient(
+            model = estimation.InteriorGradient().estimate(
                 data.domain,
                 measurements,
                 iters=args.iters,
                 callback_fn=callback_fn,
             )
         if estimator == "LBFGS":
-            model = estimation.lbfgs(
+            model = estimation.LBFGS().estimate(
                 data.domain,
                 measurements,
                 iters=args.iters,

--- a/examples/toy_example.py
+++ b/examples/toy_example.py
@@ -31,7 +31,7 @@ measurements = [
 loss_fn = marginal_loss.from_linear_measurements(measurements)
 
 # estimate the data distribution
-model = estimation.mirror_descent(domain, loss_fn, known_total=1000)
+model = estimation.MirrorDescent().estimate(domain, loss_fn, known_total=1000)
 
 # recover consistent estimates of measurements
 ab2 = model.project(['A', 'B']).datavector()

--- a/mechanisms/adaptive_grid.py
+++ b/mechanisms/adaptive_grid.py
@@ -343,7 +343,7 @@ def adagrid(
         )
 
     iters = mbi_args.get("iters", 2500)
-    model = estimation.mirror_descent(
+    model = estimation.MirrorDescent().estimate(
         domain,
         linear_measurements,
         iters=iters,
@@ -384,7 +384,7 @@ def adagrid(
 
     print()
     print("Post-processing with Private-PGM, will take some time...")
-    model = estimation.mirror_descent(
+    model = estimation.MirrorDescent().estimate(
         domain,
         linear_measurements,
         iters=iters,

--- a/mechanisms/aim.py
+++ b/mechanisms/aim.py
@@ -133,11 +133,10 @@ class AIM(Mechanism):
 
         zeros = self.structural_zeros
         # NOTE: Haven't incorproated structural zeros back yet after refactoring
-        model = estimation.mirror_descent(
+        model = estimation.MirrorDescent().estimate(
             data.domain,
             measurements,
             iters=self.max_iters,
-            callback_fn=lambda *_: None,
         )
 
         t = 0
@@ -172,12 +171,11 @@ class AIM(Mechanism):
             # TODO: check if it helps to call maximal_subsets here
             pcliques = list(set(M.clique for M in measurements))
             potentials = model.potentials.expand(pcliques)
-            model = estimation.mirror_descent(
+            model = estimation.MirrorDescent().estimate(
                 data.domain,
                 measurements,
                 iters=self.max_iters,
                 potentials=potentials,
-                callback_fn=lambda *_: None,
             )
             w = model.project(cl).datavector()
             # print('Selected',cl,'Size',n,'Budget Used',rho_used/self.rho)
@@ -187,7 +185,7 @@ class AIM(Mechanism):
                 epsilon *= 2
 
         print("Generating Data...")
-        model = estimation.mirror_descent(
+        model = estimation.MirrorDescent().estimate(
             data.domain,
             measurements,
             iters=self.max_iters,

--- a/mechanisms/gaussian+appgm.py
+++ b/mechanisms/gaussian+appgm.py
@@ -109,12 +109,11 @@ if __name__ == "__main__":
     callback_fn = callbacks.default(measurements, data)
     stepsize = 5e-4
 
-    model = approximate_oracles.mirror_descent(
+    model = approximate_oracles.ApproxMirrorDescent(stepsize=stepsize).estimate(
         data.domain,
         measurements,
         iters=args.pgm_iters,
         callback_fn=callback_fn,
-        stepsize=stepsize,
     )
 
     errors = []

--- a/mechanisms/jam.py
+++ b/mechanisms/jam.py
@@ -287,12 +287,11 @@ class JAM(Mechanism):
                 flush=True,
             )
 
-            model = estimation.mirror_descent(
+            model = estimation.MirrorDescent().estimate(
                 domain,
                 measurements,
                 iters=self.optim_iters,
                 potentials=potentials,
-                callback_fn=lambda *_: None,
             )
             model_size = junction_tree.hypothetical_model_size(
                 domain, model.cliques
@@ -310,7 +309,7 @@ class JAM(Mechanism):
         # --- Final Model Estimation and Synthetic Data Generation ---
         print("Generating Data...", flush=True)
         final_potentials = model.potentials if model else None
-        final_model = estimation.mirror_descent(
+        final_model = estimation.MirrorDescent().estimate(
             domain,
             measurements,
             iters=self.optim_iters,

--- a/mechanisms/mst.py
+++ b/mechanisms/mst.py
@@ -32,7 +32,9 @@ def MST(data, epsilon, delta):
     data, log1, undo_compress_fn = compress_domain(data, log1)
     cliques = select(data, rho / 3.0, log1)
     log2 = measure(data, cliques, sigma)
-    est = estimation.mirror_descent(data.domain, log1 + log2, iters=10000)
+    est = estimation.MirrorDescent().estimate(
+        data.domain, log1 + log2, iters=10000
+    )
     synth = est.synthetic_data()
     return undo_compress_fn(synth)
 
@@ -82,7 +84,9 @@ def exponential_mechanism(q, eps, sensitivity, prng=np.random, monotonic=False):
 
 def select(data, rho, measurement_log, cliques=[]):
 
-    est = estimation.mirror_descent(data.domain, measurement_log, iters=2500)
+    est = estimation.MirrorDescent().estimate(
+        data.domain, measurement_log, iters=2500
+    )
 
     weights = {}
     candidates = list(itertools.combinations(data.domain.attrs, 2))

--- a/mechanisms/mwem+pgm.py
+++ b/mechanisms/mwem+pgm.py
@@ -107,7 +107,9 @@ def mwem_pgm(
     workload_answers = {cl: data.project(cl).datavector() for cl in workload}
 
     measurements = []
-    est = estimation.mirror_descent(domain, measurements, known_total=total)
+    est = estimation.MirrorDescent().estimate(
+        domain, measurements, known_total=total
+    )
     # import IPython; IPython.embed()
     cliques = []
     for i in range(1, rounds + 1):
@@ -132,7 +134,7 @@ def mwem_pgm(
                 loc=0, scale=marginal_sensitivity * sigma, size=n
             )
         measurements.append(LinearMeasurement(y, ax))
-        est = estimation.mirror_descent(
+        est = estimation.MirrorDescent().estimate(
             domain,
             measurements,
             known_total=total,


### PR DESCRIPTION
## Summary

Replace all deprecated function-style estimator calls with the class-based API across examples and mechanisms.

## Changes

| Deprecated | Replacement |
|------------|-------------|
| `estimation.mirror_descent()` | `MirrorDescent().estimate()` |
| `estimation.dual_averaging()` | `DualAveraging().estimate()` |
| `estimation.interior_gradient()` | `InteriorGradient().estimate()` |
| `estimation.lbfgs()` | `LBFGS().estimate()` |
| `approximate_oracles.mirror_descent()` | `ApproxMirrorDescent(stepsize=...).estimate()` |

The class-based API uses `default_oracle()` for automatic oracle selection instead of requiring manual oracle specification. Constructor parameters like `stepsize` are now passed to the estimator class rather than the `estimate()` call.

## Files changed (9)
- `examples/toy_example.py`
- `examples/adult_example.py`
- `examples/convergence.py`
- `mechanisms/aim.py`
- `mechanisms/mst.py`
- `mechanisms/mwem+pgm.py`
- `mechanisms/jam.py`
- `mechanisms/adaptive_grid.py`
- `mechanisms/gaussian+appgm.py`

## Testing
Smoke-tested `toy_example.py`, `adult_example.py`, and `mst.py` — all pass.