### PR TITLE
Fix two regressions in MarkovRandomField.synthetic_data()

### DIFF
--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -74,13 +74,20 @@ class MarkovRandomField:
         """
         total = max(1, int(rows or self.total))
         domain = self.domain
-        cliques = [set(cl) for cl in self.cliques]
         jtree, elimination_order = junction_tree.make_junction_tree(
-            domain, cliques
+            domain, [set(cl) for cl in self.cliques]
         )
 
+        # Use maximal cliques from the junction tree for conditioning
+        # decisions (not the original measurement cliques).  The junction
+        # tree merges overlapping cliques into super-cliques that capture
+        # the full dependency structure of the model.
+        cliques = [set(cl) for cl in jtree.nodes]
+
         potentials = self.potentials.expand(list(jtree.nodes))
-        marginals = marginal_oracles.message_passing_stable(potentials)
+        marginals = marginal_oracles.message_passing_stable(
+            potentials, self.total
+        )
 
         def synthetic_col(counts, total):
             """Generates a synthetic column by sampling or rounding based on counts and total."""
@@ -145,11 +152,19 @@ class MarkovRandomField:
                     u = np.random.rand(total)
                 else:
                     perm = np.argsort(inverse, kind="stable")
-                    inverse_sorted = inverse[perm]
 
                     group_starts = np.zeros(len(counts), dtype=int)
                     np.cumsum(counts[:-1], out=group_starts[1:])
 
+                    # Shuffle within each parent group to break
+                    # spurious correlations with previously generated
+                    # columns that shared the same parent set.
+                    for gi in range(len(counts)):
+                        s = group_starts[gi]
+                        e = s + counts[gi]
+                        np.random.shuffle(perm[s:e])
+
+                    inverse_sorted = inverse[perm]
                     sorted_indices = np.arange(total)
 
                     ranks_sorted = sorted_indices - group_starts[inverse_sorted]


### PR DESCRIPTION
## Summary

Fixes two bugs in `synthetic_data()` that together caused synthetic data error to be **3.1x** the model error for AIM-style models.

## Bug 1: Wrong cliques for conditioning

`synthetic_data()` used `self.cliques` (original measurement cliques like `('age', 'relationship')`) to determine which previously-generated columns to condition on. The old `GraphicalModel` stored **junction tree maximal cliques** (super-cliques like `('age', 'marital-status', 'relationship', 'sex')`), which correctly capture all dependencies within each super-clique.

**Effect**: Columns like `sex`, `relationship`, `marital-status` were generated unconditionally when they should have been conditioned on each other through their shared super-clique.

**Fix**: Use `jtree.nodes` (maximal super-cliques) for conditioning decisions. Also pass `self.total` to `message_passing_stable` for correct scaling.

## Bug 2: Spurious correlations in rounding

The vectorized rounding code assigned deterministic ranks within each parent group based on row position. When two conditionally independent columns (e.g., `age` and `workclass`) shared the same parent set `(ms, sex, rel)`, rows with low rank for `age` also got low rank for `workclass` — creating **artificial positive correlation**.

The old pandas `groupby().apply()` code called `synthetic_col()` which shuffled outputs, breaking this correlation.

**Effect**: Cross-tree marginals like `('age', 'workclass')` had L1 gap of 0.31 with the `round` method (verified at 10M rows — not sampling noise). The `sample` method was unaffected (gap = 0.007).

**Fix**: Shuffle `perm` within each parent group before computing ranks.

## Verification

| Metric | Before | After |
|--------|--------|-------|
| `('age', 'workclass')` gap @ 1M rows | 0.317 | **0.006** |
| synth/model error ratio (AIM) | 3.1x | **~1.0x** |
| Direct model clique gaps | <0.001 | <0.001 |
| `sample` method (unaffected) | 0.007 | 0.007 |

## File changed
- `src/mbi/markov_random_field.py` (19 insertions, 4 deletions)