### PR TITLE
Warn when running estimation without float64 precision

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -113,6 +113,18 @@ class Estimator(ABC):
         **kwargs: Any,
     ) -> Model:
         """Estimate a Model from noisy marginal measurements."""
+        if not jax.config.jax_enable_x64:
+            warnings.warn(
+                "MBI is running in float32 mode. For large datasets"
+                " (N > 100K), this can cause estimation algorithms to stall"
+                " or diverge due to insufficient floating-point precision."
+                " To enable float64, call:\n"
+                "\n"
+                "  jax.config.update('jax_enable_x64', True)\n",
+                UserWarning,
+                stacklevel=2,
+            )
+
         if isinstance(loss_fn, list):
             if known_total is None:
                 known_total = minimum_variance_unbiased_total(loss_fn)
@@ -940,6 +952,18 @@ def universal_accelerated_method(
     mesh: jax.sharding.Mesh | None = None,
 ) -> MarkovRandomField:
     """Optimization using the Universal Accelerated MD algorithm."""
+    if not jax.config.jax_enable_x64:
+        warnings.warn(
+            "MBI is running in float32 mode. For large datasets"
+            " (N > 100K), this can cause estimation algorithms to stall"
+            " or diverge due to insufficient floating-point precision."
+            " To enable float64, call:\n"
+            "\n"
+            "  jax.config.update('jax_enable_x64', True)\n",
+            UserWarning,
+            stacklevel=2,
+        )
+
     loss_fn, known_total, potentials = _initialize(
         domain, loss_fn, known_total, potentials
     )


### PR DESCRIPTION
## Summary

Adds a `UserWarning` when estimation is called without `jax_enable_x64` set. JAX defaults to float32, which causes numerical instability for large datasets (N > 100K):

1. **Mirror Descent** stalls prematurely due to step-size underflow (~10K iterations)
2. **Dual Averaging** diverges catastrophically due to softmax saturation (~46K iterations)
3. **UAM** stalls prematurely due to linesearch collapse (~1K iterations)

All three failures disappear with float64 enabled.

## Design decisions

- **Warning at estimation time**, not import time — avoids false alarms when users enable x64 after importing mbi.
- **No global state mutation** — the warning tells users what to do; we don't silently call `jax.config.update` for them.
- **No decorator/context-manager approach** — we investigated wrapping `estimate()` with `jax.enable_x64()`, but operations on the returned model outside the context would silently drop back to float32, defeating the purpose.

## Evidence

Benchmarked on Census (N=132M) with 100K iterations:

| Method | σ | float32 final | float64 final | Improvement |
|--------|---|--------------|--------------|-------------|
| MD | 1 | 31.0B (stalled) | 126M (converging) | 246× |
| DA | 1 | 1.88×10¹⁷ (diverged) | 137M (converging) | 10⁹× |
| UAM | 1 | 15.7B (stalled) | 47.9K (converging) | 327K× |
| MD | 1000 | 79.7K (stalled) | 47.2K (converging) | 1.7× |
| DA | 1000 | 192B (diverged) | 47.3K (converging) | 4.1M× |
| UAM | 1000 | 67.6K (stalled) | 47.0K (converging) | 1.4× |