### PR TITLE
Fix clique conditioning in extensions/synthetic_data.py

### DIFF
--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -178,10 +178,18 @@ def _build_plan(domain, cliques):
     maximal_cliques = junction_tree.maximal_cliques(jtree)
     order = tuple(reversed(elimination_order))
 
+    # Use maximal cliques (junction tree super-cliques) for parent
+    # determination, not the original measurement cliques.  The junction
+    # tree merges overlapping cliques into super-cliques that capture
+    # the full dependency structure.  Using original cliques misses
+    # dependencies between attributes that share a super-clique but
+    # not an original clique.
+    jtree_clique_sets = [set(cl) for cl in maximal_cliques]
+
     columns: dict[str, _ColumnPlan] = {}
     used: set[str] = set()
     for col in order:
-        relevant = [cl for cl in clique_sets if col in cl]
+        relevant = [cl for cl in jtree_clique_sets if col in cl]
         parents = tuple(sorted(used.intersection(set().union(*relevant))))
         used.add(col)
 


### PR DESCRIPTION
## Summary

Same root cause as PR #145: `_build_plan()` used original measurement cliques to determine parent conditioning instead of junction tree maximal cliques.

## The bug

`_build_plan()` line 184:
```python
relevant = [cl for cl in clique_sets if col in cl]  # ← original cliques
```

When two hubs (e.g., `age` and `workclass`) create super-cliques with shared separator attributes (`sex`, `relationship`, `marital-status`), the original cliques don't connect the separator attributes to each other. They get generated independently instead of from their joint distribution, corrupting all downstream marginals.

## The fix

Use `jtree_clique_sets` (from `maximal_cliques`) for parent determination:
```python
jtree_clique_sets = [set(cl) for cl in maximal_cliques]
relevant = [cl for cl in jtree_clique_sets if col in cl]
```

## Verification

Systematic 5-test suite comparing `MRF.synthetic_data()` (fixed in #145) against `extensions.synthetic_data()` at 500K rows:

| Test | MRF avg gap | Ext BEFORE | Ext AFTER |
|------|------------|-----------|----------|
| 1: Single clique | 0.000040 | 0.000035 | 0.000035 |
| 2: Independent | 0.002405 | 0.002389 | 0.002389 |
| 3: Chain | 0.001309 | 0.001195 | 0.001195 |
| 4: Star | 0.000581 | 0.000524 | 0.000524 |
| **5: AIM (full)** | **0.005831** | **0.040104** | **0.005814** |

Test 5 went from **6.8x worse** to **1.0x (parity)**.  Every per-clique ratio is now 0.5–1.2x.

The apparent "Bug 3" (elevated gaps on direct model cliques) turned out to be a downstream consequence of this same bug — not a separate issue.

## File changed
- `src/mbi/extensions/synthetic_data.py` (9 insertions, 1 deletion)