### PR TITLE
Fix np.log(int) crash in DualAveraging._init

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -431,7 +431,7 @@ class DualAveraging(Estimator):
         marginal_oracle = self._oracle(loss_fn.cliques, domain)
 
         D = np.sqrt(
-            domain.size() * np.log(domain.size())
+            domain.size() * math.log(domain.size())
         )  # upper bound on entropy
         Q = 0  # upper bound on variance of stochastic gradients
         gamma = Q / D


### PR DESCRIPTION
`np.log(domain.size())` fails on some NumPy versions because `domain.size()` returns a plain Python `int`. Use `math.log` which handles ints natively.