### PR TITLE
Exclude labels from Domain eq/hash

### DIFF
--- a/src/mbi/domain.py
+++ b/src/mbi/domain.py
@@ -51,6 +51,8 @@ class Domain:
     )
     labels: tuple[tuple[Any, ...], ...] | None = attr.field(
         default=None,
+        eq=False,
+        hash=False,
         converter=lambda l: tuple(tuple(x) for x in l)
         if l is not None
         else None,


### PR DESCRIPTION
Adds `eq=False, hash=False` to the `labels` field on `Domain` so that labels are treated as informational annotations that do not affect Domain identity.

This is critical because `Domain` serves as JAX pytree metadata via `Factor` — label-only differences should not cause pytree mismatches or trigger recompilation.

```python
>>> d1 = Domain(("a", "b"), (2, 3))
>>> d2 = Domain(("a", "b"), (2, 3), labels=(("x", "y"), ("p", "q", "r")))
>>> d1 == d2  # True — labels excluded from equality
>>> hash(d1) == hash(d2)  # True — labels excluded from hash
```