### PR TITLE
Fix pytype error in _model_summary.py

### DIFF
--- a/src/mbi/_model_summary.py
+++ b/src/mbi/_model_summary.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import jax
 import networkx as nx
@@ -84,6 +84,7 @@ def summarize(
 
     messages = []
     for u, v in jtree.edges():
+        u, v = cast(tuple[str, ...], u), cast(tuple[str, ...], v)
         sep = tuple(set(u) & set(v))
         messages.append((sep, domain.size(sep) if sep else 1))
     msg_sizes = [s for _, s in messages]


### PR DESCRIPTION
Cast junction tree edge nodes to `tuple` before passing to `set()`.

networkx types graph nodes as `Hashable`, but they are actually `tuple[str, ...]`. The explicit `tuple()` call satisfies pytype.