### PR TITLE
Add LinearMeasurement.compress() for domain compression

### DIFF
--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -13,6 +13,8 @@ import functools
 from collections.abc import Callable, Sequence
 from typing import Any
 
+import numpy as np
+
 import attr
 import chex
 import jax
@@ -23,6 +25,11 @@ from .clique_utils import Clique, maximal_subset
 from .clique_vector import CliqueVector
 from .domain import Domain
 from .factor import Factor
+
+
+def _weighted_datavector(weights: np.ndarray, x: Factor) -> jax.Array:
+    """Datavector scaled by pre-baked weights (pickle-safe)."""
+    return x.datavector() * weights
 
 
 @functools.partial(
@@ -46,6 +53,56 @@ class LinearMeasurement:
     clique: Clique = attr.field(converter=tuple)
     stddev: float = 1.0
     query: Callable[[Factor], jax.Array] = Factor.datavector
+
+    def compress(
+        self, mapping: dict[str, np.ndarray], domain: Domain
+    ) -> "LinearMeasurement":
+        """Compress this measurement by merging domain values.
+
+        Args:
+            mapping: Maps attribute names to 1D integer arrays.
+                ``mapping[attr][i]`` gives the compressed value for
+                original value ``i``.
+            domain: The full dataset domain (needed to reshape the
+                measurement vector into the clique's shape).
+
+        Returns:
+            A new ``LinearMeasurement`` over the compressed domain.
+        """
+        if not any(a in mapping for a in self.clique):
+            return self
+
+        y = np.asarray(self.noisy_measurement)
+
+        # Build per-attribute index arrays (mapping or identity).
+        indices, compressed_sizes = [], []
+        for a in self.clique:
+            if a in mapping:
+                m = np.asarray(mapping[a])
+                indices.append(m)
+                compressed_sizes.append(int(m.max()) + 1)
+            else:
+                indices.append(np.arange(domain[a]))
+                compressed_sizes.append(domain[a])
+
+        # Flat compressed index for every element of y.
+        grids = np.meshgrid(*indices, indexing="ij")
+        flat_idx = np.ravel_multi_index(
+            [g.ravel() for g in grids], compressed_sizes
+        )
+
+        total = int(np.prod(compressed_sizes))
+        y_compressed = np.bincount(flat_idx, weights=y, minlength=total)
+        inv_coefs = 1.0 / np.sqrt(
+            np.bincount(flat_idx, minlength=total).astype(float)
+        )
+
+        return LinearMeasurement(
+            y_compressed * inv_coefs,
+            self.clique,
+            self.stddev,
+            query=functools.partial(_weighted_datavector, inv_coefs),
+        )
 
 
 @functools.partial(

--- a/test/test_marginal_loss.py
+++ b/test/test_marginal_loss.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 import jax.numpy as jnp
 from mbi.domain import Domain
 from mbi.marginal_loss import LinearMeasurement, from_linear_measurements, calculate_l2_lipschitz
@@ -44,6 +45,61 @@ class TestMarginalLoss(unittest.TestCase):
         expected_L = 1.0 / m1.stddev**2
 
         self.assertAlmostEqual(calculated_L, expected_L, delta=1e-3)
+
+
+class TestCompress(unittest.TestCase):
+
+    def test_single_column(self):
+        """Compress a one-way measurement by merging pairs."""
+        domain = Domain.fromdict({'a': 6})
+        y = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+        m = LinearMeasurement(y, ('a',), stddev=1.0)
+        mapping = {'a': np.array([0, 0, 1, 1, 2, 2])}
+        mc = m.compress(mapping, domain)
+
+        expected = np.array([30, 70, 110]) / np.sqrt(2)
+        np.testing.assert_allclose(mc.noisy_measurement, expected)
+        self.assertEqual(mc.stddev, 1.0)
+        self.assertEqual(mc.clique, ('a',))
+
+    def test_multi_column(self):
+        """Compress one attribute of a two-way measurement."""
+        domain = Domain.fromdict({'a': 4, 'b': 3})
+        y = np.arange(12, dtype=float)  # shape (4, 3) flattened
+        m = LinearMeasurement(y, ('a', 'b'), stddev=2.0)
+        mapping = {'a': np.array([0, 0, 1, 1])}
+        mc = m.compress(mapping, domain)
+
+        y2d = y.reshape(4, 3)
+        # Compressed: sum pairs along axis 0, then divide by sqrt(2)
+        expected = np.vstack([y2d[0] + y2d[1], y2d[2] + y2d[3]]) / np.sqrt(2)
+        np.testing.assert_allclose(mc.noisy_measurement, expected.ravel())
+        self.assertEqual(mc.stddev, 2.0)
+
+    def test_irrelevant_mapping_returns_self(self):
+        domain = Domain.fromdict({'a': 4})
+        m = LinearMeasurement(np.ones(4), ('a',))
+        mc = m.compress({'z': np.array([0, 1])}, domain)
+        self.assertIs(m, mc)
+
+    def test_query_produces_correct_loss(self):
+        """Compressed measurement should recover true compressed marginal."""
+        domain = Domain.fromdict({'a': 6})
+        true_counts = np.array([100.0, 150.0, 200.0, 250.0, 300.0, 350.0])
+        m = LinearMeasurement(true_counts, ('a',), stddev=1.0)
+        mapping = {'a': np.array([0, 0, 1, 1, 2, 2])}
+        mc = m.compress(mapping, domain)
+
+        compressed_domain = Domain.fromdict({'a': 3})
+        loss_fn = from_linear_measurements([mc], compressed_domain)
+        # The compressed true counts: [250, 450, 650]
+        from mbi import estimation
+
+        model = estimation.MirrorDescent(stepsize=1e-3).estimate(
+            compressed_domain, loss_fn, known_total=1350.0, iters=200
+        )
+        result = np.asarray(model.project(('a',)).datavector())
+        np.testing.assert_allclose(result, [250, 450, 650], rtol=0.01)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a `compress()` method to `LinearMeasurement` that transforms a measurement over a larger domain into one over a compressed domain by merging values according to a mapping.

**Math**: For measurement `y = x + noise(σ)`, the compressed measurement is `y' = D^{-1/2} C^T y` where `C` is the compression indicator matrix and `D = diag(counts)`. The noise σ is preserved, and the query becomes `x / √counts`.

**API**:
```python
mapping = {"age": np.array([0, 0, 1, 1, 2, 2])}  # merge pairs
compressed = measurement.compress(mapping, domain)
```

**Features**:
- Works for arbitrary multi-column cliques (compresses each attribute independently)
- Irrelevant mappings (no overlap with clique) return `self` unchanged
- Query function is pickle-safe (module-level `_weighted_datavector`)

**Tests**: single-column, multi-column, irrelevant mapping, end-to-end with estimation.