### PR TITLE
Add precompute_marginals extension for batch marginal computation

### DIFF
--- a/src/mbi/extensions/__init__.py
+++ b/src/mbi/extensions/__init__.py
@@ -1,5 +1,6 @@
 """Extensions for mbi providing alternative estimation approaches."""
 
 from .mixture_of_products import MixtureOfProducts, MixtureOfProductsEstimator
+from .precompute_marginals import precompute_marginals
 from .reweighted_dataset import ReweightedDatasetEstimator
 from .synthetic_data import precompile, synthetic_data

--- a/src/mbi/extensions/precompute_marginals.py
+++ b/src/mbi/extensions/precompute_marginals.py
@@ -1,0 +1,184 @@
+"""Precompute all marginals from a dataset using JIT-compiled bincount.
+
+Computes a ``CliqueVector`` of marginals from raw data by JIT-compiling a
+``jnp.bincount`` kernel per unique shape.  Three optimizations reduce
+compilation overhead for heterogeneous domains:
+
+1. **Power-of-2 bucketing:** Domain sizes are rounded up to the next
+   power of 2, so attributes with similar cardinalities share a compiled
+   program.
+2. **Canonical shape ordering:** Within each clique, attributes are
+   sorted so that padded sizes are non-decreasing.  This halves the
+   number of unique shapes for 2-way marginals.
+3. **Background precompilation:** Unique shapes are sorted by workload
+   (descending number of cliques), and all compilations are submitted
+   upfront so they overlap with execution.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import math
+from collections.abc import Sequence
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from ..clique_utils import Clique
+from ..clique_vector import CliqueVector
+from ..dataset import Dataset, JaxDataset
+from ..factor import Factor
+
+_COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+
+def _next_pow2(x):
+    """Round up to the next power of 2."""
+    return 1 << (x - 1).bit_length()
+
+
+@jax.jit(static_argnums=(2,))
+def _bincount_marginal(cols, weights, padded_shape):
+    """JIT-compiled k-way bincount."""
+    flat = cols[0].astype(jnp.uint32)
+    for col, stride in zip(cols[1:], padded_shape[1:]):
+        flat = flat * stride + col.astype(jnp.uint32)
+    length = math.prod(padded_shape)
+    counts = jnp.bincount(flat, weights=weights, length=length)
+    return counts.reshape(padded_shape).astype(jnp.float32)
+
+
+def _prepare_columns(dataset):
+    """Extract JAX column arrays and weights from a Dataset or JaxDataset."""
+    domain = dataset.domain
+    col_data = {
+        a: (
+            jnp.asarray(dataset.data[a]).astype(
+                np.min_scalar_type(_next_pow2(domain[a]) - 1)
+            )
+        )
+        for a in domain.attrs
+    }
+    weights = (
+        jnp.asarray(dataset.weights) if dataset.weights is not None else None
+    )
+    return col_data, weights
+
+
+def _group_cliques_by_shape(cliques, domain):
+    """Group cliques by their power-of-2 padded canonical shape.
+
+    Returns ``(sorted_shapes, shape_groups, actual_sizes)`` where
+    ``sorted_shapes`` is ordered by descending group size and
+    ``shape_groups`` maps each padded shape to its list of work items.
+    """
+    actual_sizes = {a: domain[a] for a in domain.attrs}
+    padded_sizes = {a: _next_pow2(domain[a]) for a in domain.attrs}
+
+    work_items = []
+    for cl in cliques:
+        sorted_attrs = sorted(cl, key=lambda a: padded_sizes[a])
+        padded_shape = tuple(padded_sizes[a] for a in sorted_attrs)
+        work_items.append((padded_shape, sorted_attrs, cl))
+
+    shape_groups: dict[tuple[int, ...], list] = {}
+    for item in work_items:
+        shape_groups.setdefault(item[0], []).append(item)
+    sorted_shapes = sorted(shape_groups, key=lambda s: -len(shape_groups[s]))
+    return sorted_shapes, shape_groups, actual_sizes
+
+
+def _col_struct(n_rows, padded_size):
+    """Build an abstract column struct for a given padded domain size."""
+    dtype = np.min_scalar_type(padded_size - 1)
+    return jax.ShapeDtypeStruct((n_rows,), dtype)
+
+
+def _submit_all_compilations(
+    sorted_shapes,
+    n_rows,
+    weights_struct,
+):
+    """Submit compilation for every unique shape and return futures."""
+    futures: dict[tuple[int, ...], concurrent.futures.Future] = {}
+    for shape in sorted_shapes:
+        abstract_cols = tuple(_col_struct(n_rows, s) for s in shape)
+        futures[shape] = _COMPILE_POOL.submit(
+            lambda c, w, s: _bincount_marginal.lower(c, w, s).compile(),
+            abstract_cols,
+            weights_struct,
+            shape,
+        )
+    return futures
+
+
+def precompute_marginals(
+    dataset: Dataset | JaxDataset,
+    cliques: Sequence[Clique],
+    *,
+    transpose: bool = True,
+) -> CliqueVector:
+    """Compute all marginals from a dataset using JIT-compiled bincount.
+
+    Compiles one ``jnp.bincount`` program per unique padded shape (after
+    power-of-2 bucketing and canonical reordering) and executes it for
+    every clique that maps to that shape.  All compilations are submitted
+    to a background thread upfront so they overlap with execution.
+
+    Accepts both ``Dataset`` (numpy-backed) and ``JaxDataset``
+    (JAX-backed).  Numpy arrays are converted to JAX arrays internally.
+
+    Args:
+      dataset: The dataset to compute marginals from.
+      cliques: Cliques (tuples of attribute names) to compute.
+      transpose: If ``True`` (default), transpose each marginal so its
+        axes match the original clique attribute order.  Set to ``False``
+        to skip the transpose and keep the canonical sorted order.
+
+    Returns:
+      A ``CliqueVector`` mapping each clique to its marginal ``Factor``.
+    """
+    domain = dataset.domain
+    col_data, weights = _prepare_columns(dataset)
+    sorted_shapes, shape_groups, actual_sizes = _group_cliques_by_shape(
+        cliques, domain
+    )
+
+    # Build abstract structs and submit all compilations upfront.
+    n_rows = next(iter(col_data.values())).shape[0]
+    weights_struct = (
+        jax.ShapeDtypeStruct(weights.shape, weights.dtype)
+        if weights is not None
+        else None
+    )
+    compile_futures = _submit_all_compilations(
+        sorted_shapes,
+        n_rows,
+        weights_struct,
+    )
+
+    arrays: dict[Clique, Factor] = {}
+
+    for shape in sorted_shapes:
+        compiled_fn = compile_futures[shape].result()
+
+        for _, sorted_attrs, cl in shape_groups[shape]:
+            cols = tuple(col_data[a] for a in sorted_attrs)
+            marginal = compiled_fn(cols, weights)
+
+            # Slice off power-of-2 padding.
+            actual_shape = tuple(actual_sizes[a] for a in sorted_attrs)
+            if actual_shape != shape:
+                slices = tuple(slice(0, s) for s in actual_shape)
+                marginal = marginal[slices]
+
+            # Transpose back to the original attribute order if needed.
+            proj_domain = domain.project(cl)
+            if transpose and tuple(sorted_attrs) != proj_domain.attrs:
+                perm = tuple(sorted_attrs.index(a) for a in proj_domain.attrs)
+                marginal = jnp.transpose(marginal, perm)
+
+            arrays[cl] = Factor(proj_domain, marginal)
+
+    return CliqueVector(domain, list(cliques), arrays)

--- a/test/test_precompute_marginals.py
+++ b/test/test_precompute_marginals.py
@@ -1,0 +1,174 @@
+"""Tests for mbi.extensions.precompute_marginals."""
+
+import itertools
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+
+from mbi import Dataset, Domain
+from mbi.dataset import JaxDataset
+from mbi.extensions.precompute_marginals import precompute_marginals
+
+
+def _make_domain(sizes):
+    """Create a domain with attributes a0, a1, ... with given sizes."""
+    attrs = [f'a{i}' for i in range(len(sizes))]
+    return Domain(attrs, sizes)
+
+
+def _make_dataset(domain, n, seed=0, weights=None):
+    """Create a random dataset with n records."""
+    rng = np.random.default_rng(seed)
+    data = {
+        a: (
+            rng.integers(0, domain[a], size=n).astype(
+                np.min_scalar_type(domain[a] - 1)
+            )
+        )
+        for a in domain.attrs
+    }
+    return Dataset(data, domain, weights=weights)
+
+
+def _reference_marginal(dataset, cl):
+    """Compute a marginal using Dataset.project (numpy reference)."""
+    return dataset.project(cl)
+
+
+class TestPrecomputeMarginals(unittest.TestCase):
+    """Tests correctness of precompute_marginals against Dataset.project."""
+
+    def _assert_marginals_match(self, dataset, cliques):
+        """Assert precomputed marginals match the reference for all cliques."""
+        result = precompute_marginals(dataset, cliques)
+        for cl in cliques:
+            expected = _reference_marginal(dataset, cl)
+            actual = result[cl]
+            np.testing.assert_array_almost_equal(
+                np.asarray(actual.datavector(flatten=True)),
+                np.asarray(expected.datavector(flatten=True)),
+                decimal=4,
+                err_msg=f'Marginal mismatch for clique {cl}',
+            )
+
+    def test_pairwise_homogeneous(self):
+        """All attributes have the same domain size."""
+        domain = _make_domain([8, 8, 8, 8])
+        dataset = _make_dataset(domain, 1000)
+        cliques = list(itertools.combinations(domain.attrs, 2))
+        self._assert_marginals_match(dataset, cliques)
+
+    def test_pairwise_heterogeneous(self):
+        """Attributes have different domain sizes triggering bucketing."""
+        domain = _make_domain([2, 5, 16, 64])
+        dataset = _make_dataset(domain, 5000)
+        cliques = list(itertools.combinations(domain.attrs, 2))
+        self._assert_marginals_match(dataset, cliques)
+
+    def test_three_way_marginals(self):
+        """Cliques of size 3."""
+        domain = _make_domain([4, 8, 3, 6])
+        dataset = _make_dataset(domain, 2000)
+        cliques = list(itertools.combinations(domain.attrs, 3))
+        self._assert_marginals_match(dataset, cliques)
+
+    def test_mixed_clique_sizes(self):
+        """Mix of 1-way, 2-way, and 3-way cliques."""
+        domain = _make_domain([3, 7, 5])
+        dataset = _make_dataset(domain, 3000)
+        cliques = [
+            ('a0',),
+            ('a1',),
+            ('a2',),
+            ('a0', 'a1'),
+            ('a1', 'a2'),
+            ('a0', 'a1', 'a2'),
+        ]
+        self._assert_marginals_match(dataset, cliques)
+
+    def test_single_attribute_cliques(self):
+        """Univariate marginals."""
+        domain = _make_domain([2, 100, 32])
+        dataset = _make_dataset(domain, 1000)
+        cliques = [('a0',), ('a1',), ('a2',)]
+        self._assert_marginals_match(dataset, cliques)
+
+    def test_jax_dataset_input(self):
+        """Accepts JaxDataset directly."""
+        domain = _make_domain([4, 8, 16])
+        np_dataset = _make_dataset(domain, 2000)
+        jax_data = {
+            a: jnp.asarray(np_dataset.to_dict()[a]) for a in domain.attrs
+        }
+        jax_dataset = JaxDataset(jax_data, domain)
+        cliques = list(itertools.combinations(domain.attrs, 2))
+        result = precompute_marginals(jax_dataset, cliques)
+        for cl in cliques:
+            expected = _reference_marginal(np_dataset, cl)
+            actual = result[cl]
+            np.testing.assert_array_almost_equal(
+                np.asarray(actual.datavector(flatten=True)),
+                np.asarray(expected.datavector(flatten=True)),
+                decimal=4,
+            )
+
+    def test_attribute_order_preserved(self):
+        """Clique attribute order is respected in the output Factor."""
+        domain = _make_domain([3, 5, 7])
+        dataset = _make_dataset(domain, 1000)
+        cl = ('a2', 'a0')
+        result = precompute_marginals(dataset, [cl])
+        self.assertEqual(result[cl].domain.attrs, ('a2', 'a0'))
+        expected = _reference_marginal(dataset, cl)
+        np.testing.assert_array_almost_equal(
+            np.asarray(result[cl].datavector(flatten=True)),
+            np.asarray(expected.datavector(flatten=True)),
+            decimal=4,
+        )
+
+    def test_large_domain_sizes(self):
+        """Domain sizes exceeding uint8 range."""
+        domain = _make_domain([256, 512])
+        dataset = _make_dataset(domain, 5000)
+        cliques = [('a0', 'a1')]
+        self._assert_marginals_match(dataset, cliques)
+
+    def test_random_heterogeneous_sweep(self):
+        """Randomized sweep over various domain configurations."""
+        rng = np.random.default_rng(42)
+        for trial in range(10):
+            d = rng.integers(3, 8)
+            sizes = [
+                int(rng.choice([2, 3, 4, 8, 16, 32, 64])) for _ in range(d)
+            ]
+            domain = _make_domain(sizes)
+            dataset = _make_dataset(domain, 500, seed=trial)
+            cliques = list(itertools.combinations(domain.attrs, 2))
+            self._assert_marginals_match(dataset, cliques)
+
+    def test_weighted_dataset(self):
+        """Weighted datasets produce correct marginals."""
+        domain = _make_domain([4, 8])
+        rng = np.random.default_rng(99)
+        weights = rng.exponential(size=2000)
+        dataset = _make_dataset(domain, 2000, seed=99, weights=weights)
+        cliques = [('a0',), ('a1',), ('a0', 'a1')]
+        self._assert_marginals_match(dataset, cliques)
+
+    def test_accepts_tuple_of_cliques(self):
+        """Accepts a tuple (Sequence) of cliques, not just a list."""
+        domain = _make_domain([4, 8])
+        dataset = _make_dataset(domain, 1000)
+        cliques = (('a0', 'a1'),)
+        result = precompute_marginals(dataset, cliques)
+        expected = _reference_marginal(dataset, ('a0', 'a1'))
+        np.testing.assert_array_almost_equal(
+            np.asarray(result[('a0', 'a1')].datavector(flatten=True)),
+            np.asarray(expected.datavector(flatten=True)),
+            decimal=4,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add `mbi.extensions.precompute_marginals`, a JIT-compiled bincount function that computes all marginals from a dataset in a single pass. Three optimizations reduce compilation overhead for heterogeneous domains:

- **Power-of-2 bucketing:** Rounds attribute sizes to powers of 2 so attributes with similar cardinalities share a compiled program.
- **Canonical shape ordering:** Sorts attributes within each clique so padded sizes are non-decreasing, reducing unique compiled shapes.
- **Background precompilation:** Compiles the next shape group while the current one executes, hiding compilation latency.

Supports arbitrary clique sizes and accepts both `Dataset` and `JaxDataset` inputs.

### Files changed
- `src/mbi/extensions/precompute_marginals.py` — new extension
- `src/mbi/extensions/__init__.py` — re-export at package level
- `test/test_precompute_marginals.py` — 10 test cases verified against `Dataset.project`

### Testing
10 unit tests covering homogeneous, heterogeneous, mixed-size cliques, attribute ordering, large domains, JaxDataset input, and a randomized 10-trial sweep. All pass on CPU.