### PR TITLE
Add top-level Constraint dataclass

### DIFF
--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -33,9 +33,9 @@ from . import callbacks, estimation, extensions, junction_tree, marginal_oracles
 from ._model_summary import ModelSummary, summarize
 from ._api import Model, Projectable
 from .estimation import Estimator
-from .extensions import constraints
-from .extensions.constraints import DeterministicConstraint
+from .extensions import message_passing
 from .clique_vector import CliqueVector
+from .constraint import Constraint
 from .dataset import Dataset
 from .domain import Domain
 from .factor import Factor
@@ -46,7 +46,7 @@ from .markov_random_field import MarkovRandomField
 Clique = tuple[str, ...]
 
 __all__ = [
-    "DeterministicConstraint",
+    "Constraint",
     "Domain",
     "Dataset",
     "Factor",

--- a/src/mbi/constraint.py
+++ b/src/mbi/constraint.py
@@ -1,0 +1,106 @@
+"""Structural constraints on allowed value combinations.
+
+Provides the :class:`Constraint` dataclass for declaring which combinations of
+attribute values are valid (or invalid) in a dataset domain.  Constraints can
+be folded into graphical model potentials via :meth:`Constraint.as_potential`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .domain import Domain
+from .factor import Factor
+
+
+def _validate_combos(arr, n_attrs, name):
+    shape = np.shape(arr)
+    if len(shape) != 2 or shape[1] != n_attrs:
+        raise ValueError(f"{name} must have shape (*, {n_attrs}), got {shape}.")
+
+
+def _validate_mapping(mapping, domain):
+    if len(domain.attributes) != 2:
+        raise ValueError(
+            "mapping requires exactly 2 attributes (fine, coarse)."
+        )
+    shape = np.shape(mapping)
+    if len(shape) != 1 or shape[0] != domain.shape[0]:
+        raise ValueError(
+            f"mapping must have shape ({domain.shape[0]},), got {shape}."
+        )
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class Constraint:
+    """A structural constraint on allowed value combinations.
+
+    Exactly one of ``valid``, ``invalid``, or ``mapping`` must be specified.
+
+    Attributes:
+        domain: The sub-domain this constraint covers.
+        valid: Array of shape ``(n, len(domain))`` listing allowed combos.
+        invalid: Array of shape ``(n, len(domain))`` listing forbidden combos.
+        mapping: Array of shape ``(domain.shape[0],)`` defining a functional
+            dependency from the first attribute (fine) to the second (coarse).
+            Requires exactly two attributes in the domain.
+    """
+
+    domain: Domain = jax.tree.static()
+    valid: np.ndarray | None = None
+    invalid: np.ndarray | None = None
+    mapping: np.ndarray | None = None
+
+    def __post_init__(self):
+        # During JAX pytree reconstruction, fields are tracers.
+        for f in ("valid", "invalid", "mapping"):
+            if isinstance(getattr(self, f), jax.Array):
+                return
+
+        n_set = sum(
+            x is not None for x in (self.valid, self.invalid, self.mapping)
+        )
+        if n_set != 1:
+            raise ValueError(
+                "Specify exactly one of 'valid', 'invalid', or 'mapping'."
+            )
+
+        n = len(self.domain.attributes)
+        if self.valid is not None:
+            _validate_combos(self.valid, n, "valid")
+        elif self.invalid is not None:
+            _validate_combos(self.invalid, n, "invalid")
+        else:
+            _validate_mapping(self.mapping, self.domain)
+
+    @property
+    def clique(self) -> tuple[str, ...]:
+        """Sorted attribute names, for junction tree construction."""
+        return tuple(sorted(self.domain.attributes))
+
+    @property
+    def is_deterministic(self) -> bool:
+        """Whether this constraint is a functional dependency."""
+        return self.mapping is not None
+
+    @property
+    def potential(self) -> Factor:
+        """Return a log-space potential: 0 for allowed, -inf for forbidden."""
+        if self.mapping is not None:
+            values = jnp.full(self.domain.shape, -jnp.inf)
+            fine_idx = jnp.arange(self.domain.shape[0])
+            values = values.at[fine_idx, self.mapping].set(0.0)
+        elif self.valid is not None:
+            valid = jnp.asarray(self.valid)
+            idx = tuple(valid[:, i] for i in range(valid.shape[1]))
+            values = jnp.full(self.domain.shape, -jnp.inf).at[idx].set(0.0)
+        else:
+            invalid = jnp.asarray(self.invalid)
+            idx = tuple(invalid[:, i] for i in range(invalid.shape[1]))
+            values = jnp.zeros(self.domain.shape).at[idx].set(-jnp.inf)
+        return Factor(self.domain, values)

--- a/src/mbi/extensions/message_passing.py
+++ b/src/mbi/extensions/message_passing.py
@@ -1,10 +1,10 @@
-"""Efficient handling of deterministic variable constraints.
+"""Constraint-aware message passing for graphical models.
 
-Provides utilities for exploiting deterministic relationships between variables
-(e.g., A' = f(A) where A' is a coarsening of A) during message passing in
-graphical models. Instead of materializing full |A| x |A'| constraint factors,
-messages are routed through the constraint in O(|A|) time using coarsen/refine
-operations.
+Provides efficient handling of deterministic variable constraints
+(e.g., A' = f(A) where A' is a coarsening of A) during message passing.
+For mapping constraints, messages are routed through the constraint in
+O(|A|) time using coarsen/refine operations. For general valid/invalid
+constraints, the full potential is materialized and folded in.
 """
 
 from __future__ import annotations
@@ -13,56 +13,16 @@ import collections
 import collections.abc
 
 
-import attr
 import jax
 import jax.numpy as jnp
 import networkx as nx
-import numpy as np
 
 from .. import junction_tree, marginal_oracles
 from ..clique_utils import clique_mapping
 from ..clique_vector import CliqueVector
+from ..constraint import Constraint
 from ..domain import Domain
 from ..factor import Factor
-
-
-@attr.dataclass(frozen=True, hash=False, eq=False)
-class DeterministicConstraint:
-    """A deterministic relationship: coarse = f(fine).
-
-    Attributes:
-        fine: The finer-grained variable name.
-        coarse: The coarser variable name.
-        mapping: Array of shape (|fine|,) mapping fine values to coarse values.
-    """
-
-    fine: str
-    coarse: str
-    mapping: np.ndarray
-
-    def __hash__(self):
-        return hash((self.fine, self.coarse, self.mapping.tobytes()))
-
-    def __eq__(self, other):
-        if not isinstance(other, DeterministicConstraint):
-            return NotImplemented
-        return (
-            self.fine == other.fine
-            and self.coarse == other.coarse
-            and np.array_equal(self.mapping, other.mapping)
-        )
-
-    @property
-    def clique(self) -> tuple[str, ...]:
-        return tuple(sorted((self.fine, self.coarse)))
-
-    @property
-    def n_fine(self) -> int:
-        return len(self.mapping)
-
-    @property
-    def n_coarse(self) -> int:
-        return int(self.mapping.max()) + 1
 
 
 def _replace_variable(factor, old, new, new_size):
@@ -89,44 +49,39 @@ def _segment_logsumexp(values, mapping, n_segments, axis):
 
 def coarsen(factor, constraint):
     """Log-space fine-to-coarse aggregation via segment-logsumexp."""
-    axis = factor.domain.axes((constraint.fine,))[0]
+    fine, coarse = constraint.domain.attributes
+    n_coarse = constraint.domain.shape[1]
+    axis = factor.domain.axes((fine,))[0]
     values = _segment_logsumexp(
-        factor.values, constraint.mapping, constraint.n_coarse, axis
+        factor.values, constraint.mapping, n_coarse, axis
     )
     return _replace_variable(
-        Factor(factor.domain, values),
-        constraint.fine,
-        constraint.coarse,
-        constraint.n_coarse,
+        Factor(factor.domain, values), fine, coarse, n_coarse
     )
 
 
 def refine(factor, constraint):
     """Log-space coarse-to-fine scatter via indexing."""
-    axis = factor.domain.axes((constraint.coarse,))[0]
+    fine, coarse = constraint.domain.attributes
+    n_fine = constraint.domain.shape[0]
+    axis = factor.domain.axes((coarse,))[0]
     values = jnp.take(factor.values, constraint.mapping, axis=axis)
     return _replace_variable(
-        Factor(factor.domain, values),
-        constraint.coarse,
-        constraint.fine,
-        constraint.n_fine,
+        Factor(factor.domain, values), coarse, fine, n_fine
     )
 
 
 def project_to_coarse(factor, constraint):
     """Probability-space fine-to-coarse aggregation via segment-sum."""
-    axis = factor.domain.axes((constraint.fine,))[0]
+    fine, coarse = constraint.domain.attributes
+    n_coarse = constraint.domain.shape[1]
+    axis = factor.domain.axes((fine,))[0]
     values = jnp.moveaxis(factor.values, axis, 0)
-    result = jnp.zeros(
-        (constraint.n_coarse,) + values.shape[1:], dtype=values.dtype
-    )
+    result = jnp.zeros((n_coarse,) + values.shape[1:], dtype=values.dtype)
     result = result.at[constraint.mapping].add(values)
     values = jnp.moveaxis(result, 0, axis)
     return _replace_variable(
-        Factor(factor.domain, values),
-        constraint.fine,
-        constraint.coarse,
-        constraint.n_coarse,
+        Factor(factor.domain, values), fine, coarse, n_coarse
     )
 
 
@@ -135,11 +90,13 @@ def _constraint_slice(factor, constraint):
 
     For each value of the fine variable a, selects coarse = mapping[a].
     """
-    fine_axis = factor.domain.axes((constraint.fine,))[0]
-    coarse_axis = factor.domain.axes((constraint.coarse,))[0]
+    fine, coarse = constraint.domain.attributes
+    n_fine = constraint.domain.shape[0]
+    fine_axis = factor.domain.axes((fine,))[0]
+    coarse_axis = factor.domain.axes((coarse,))[0]
 
     idx_shape = [1] * len(factor.domain.shape)
-    idx_shape[fine_axis] = constraint.n_fine
+    idx_shape[fine_axis] = n_fine
     indices = jnp.array(constraint.mapping).reshape(idx_shape)
 
     values = jnp.take_along_axis(factor.values, indices, axis=coarse_axis)
@@ -158,27 +115,25 @@ def _constraint_expand(factor, constraint):
     Inverse of _constraint_slice. For each fine value a, places the
     factor's values at coarse = mapping[a] and zeros elsewhere.
     """
-    fine_axis = factor.domain.axes((constraint.fine,))[0]
+    fine, coarse = constraint.domain.attributes
+    n_fine, n_coarse = constraint.domain.shape
+    fine_axis = factor.domain.axes((fine,))[0]
     coarse_axis = fine_axis + 1
 
-    indicator = jnp.zeros(
-        (constraint.n_fine, constraint.n_coarse), dtype=factor.values.dtype
-    )
-    indicator = indicator.at[
-        jnp.arange(constraint.n_fine), constraint.mapping
-    ].set(1.0)
+    indicator = jnp.zeros((n_fine, n_coarse), dtype=factor.values.dtype)
+    indicator = indicator.at[jnp.arange(n_fine), constraint.mapping].set(1.0)
 
     ind_shape = [1] * (len(factor.domain.shape) + 1)
-    ind_shape[fine_axis] = constraint.n_fine
-    ind_shape[coarse_axis] = constraint.n_coarse
+    ind_shape[fine_axis] = n_fine
+    ind_shape[coarse_axis] = n_coarse
 
     values = jnp.expand_dims(factor.values, axis=coarse_axis)
     result_values = values * indicator.reshape(ind_shape)
 
     attrs = list(factor.domain.attributes)
     shape = list(factor.domain.shape)
-    attrs.insert(coarse_axis, constraint.coarse)
-    shape.insert(coarse_axis, constraint.n_coarse)
+    attrs.insert(coarse_axis, coarse)
+    shape.insert(coarse_axis, n_coarse)
     return Factor(Domain(attrs, shape), result_values)
 
 
@@ -207,14 +162,15 @@ def _constraint_message(constraint, inputs, target_has_fine):
 
     Routes messages through the constraint in O(|fine|) time.
     """
+    fine, coarse = constraint.domain.attributes
     # Pre-process: slice any input that has both fine and coarse.
     clean = []
     for f in inputs:
-        if constraint.fine in f.domain and constraint.coarse in f.domain:
+        if fine in f.domain and coarse in f.domain:
             clean.append(_constraint_slice(f, constraint))
         else:
             clean.append(f)
-    fine_sum, coarse_sum = _partition_by_variable(clean, constraint.fine)
+    fine_sum, coarse_sum = _partition_by_variable(clean, fine)
 
     if target_has_fine:
         result = _add_optional(
@@ -232,18 +188,19 @@ def _constraint_message(constraint, inputs, target_has_fine):
 def _embedded_message(tau, sep_vars, constraints_list):
     """Outgoing message from a clique with an embedded constraint."""
     for c in constraints_list:
-        if c.fine not in tau.domain or c.coarse not in tau.domain:
+        fine, coarse = c.domain.attributes
+        if fine not in tau.domain or coarse not in tau.domain:
             continue
         tau = _constraint_slice(tau, c)
-        if c.coarse in sep_vars and c.fine not in sep_vars:
+        if coarse in sep_vars and fine not in sep_vars:
             # Only coarse in separator — must coarsen to reach it.
-            keep = tuple((sep_vars - {c.coarse}) | {c.fine})
+            keep = tuple((sep_vars - {coarse}) | {fine})
             extra = set(tau.domain.attributes) - set(keep)
             if extra:
                 tau = tau.logsumexp(tau.domain.invert(keep))
             return coarsen(tau, c)
         # Fine in separator (or both) — keep per-element info.
-        sep_without_coarse = tuple(sep_vars - {c.coarse})
+        sep_without_coarse = tuple(sep_vars - {coarse})
         return tau.logsumexp(tau.domain.invert(sep_without_coarse))
     return tau.logsumexp(tau.domain.invert(tuple(sep_vars)))
 
@@ -261,10 +218,15 @@ def _classify_cliques(max_cliques, constraints):
     embedded = {}
     for mc in max_cliques:
         mc_set = set(mc)
-        cs = [c for c in constraints if c.fine in mc_set and c.coarse in mc_set]
+        cs = [
+            c
+            for c in constraints
+            if c.domain.attributes[0] in mc_set
+            and c.domain.attributes[1] in mc_set
+        ]
         if not cs:
             continue
-        if len(cs) == 1 and mc_set == {cs[0].fine, cs[0].coarse}:
+        if len(cs) == 1 and mc_set == set(cs[0].domain.attributes):
             pure_constraint[mc] = cs[0]
         else:
             embedded[mc] = cs
@@ -284,6 +246,7 @@ def _derive_pure_marginal(
     for con_mc, c in pure_constraint.items():
         if not set(clique) <= set(con_mc):
             continue
+        fine, coarse = c.domain.attributes
 
         inputs = [
             messages[(k, con_mc)]
@@ -291,22 +254,22 @@ def _derive_pure_marginal(
             if (k, con_mc) in messages
         ]
         inputs.extend(constraint_init.get(con_mc, []))
-        fine_sum, coarse_sum = _partition_by_variable(inputs, c.fine)
+        fine_sum, coarse_sum = _partition_by_variable(inputs, fine)
 
         # Reduce any inputs containing both variables to fine-only.
-        if fine_sum is not None and c.coarse in fine_sum.domain:
+        if fine_sum is not None and coarse in fine_sum.domain:
             fine_sum = _constraint_slice(fine_sum, c)
 
         belief = _add_optional(
             fine_sum, refine(coarse_sum, c) if coarse_sum else None
         )
         if belief is None:
-            belief = Factor.zeros(domain.project((c.fine,)))
+            belief = Factor.zeros(domain.project((fine,)))
 
         belief = belief.normalize(total, log=True).exp()
-        if c.fine in clique and c.coarse in clique:
+        if fine in clique and coarse in clique:
             return _constraint_expand(belief, c).project(clique)
-        if c.fine in clique:
+        if fine in clique:
             return belief.project(clique)
         return project_to_coarse(belief, c).project(clique)
 
@@ -326,7 +289,8 @@ def _try_expand_belief(clique, result_cv, constraints):
                 (
                     c
                     for c in constraints
-                    if c.coarse == var and c.fine in belief_cl
+                    if c.domain.attributes[1] == var
+                    and c.domain.attributes[0] in belief_cl
                 ),
                 None,
             )
@@ -342,25 +306,44 @@ def _try_expand_belief(clique, result_cv, constraints):
     return None
 
 
-@jax.jit(static_argnames=['jtree', 'constraints'])
+def _fold_non_deterministic(potentials, constraints):
+    """Fold non-deterministic constraints as materialized potentials."""
+    non_det = [c for c in constraints if not c.is_deterministic]
+    if not non_det:
+        return potentials
+    domain = potentials.domain
+    cliques = list(potentials.cliques)
+    arrays = {cl: potentials[cl] for cl in cliques}
+    for c in non_det:
+        cl = domain.canonical(c.clique)
+        factor = c.potential
+        if cl in arrays:
+            arrays[cl] = arrays[cl] + factor
+        else:
+            cliques.append(cl)
+            arrays[cl] = factor
+    return CliqueVector(domain, cliques, arrays)
+
+
+@jax.jit(static_argnames=['jtree'])
 def constrained_shafer_shenoy(
     potentials: CliqueVector,
     total: float = 1,
     jtree: nx.Graph | None = None,
-    constraints: tuple[DeterministicConstraint, ...] = (),
+    constraints: tuple[Constraint, ...] = (),
 ) -> CliqueVector:
     """Compute marginals using Shafer-Shenoy with constraint-aware shortcuts.
 
-    Extends message_passing_shafer_shenoy to handle deterministic constraints
-    without materializing |fine| x |coarse| factors.
+    Deterministic (mapping) constraints are routed through efficient O(|fine|)
+    coarsen/refine operations. General (valid/invalid) constraints are folded
+    into potentials as materialized ``-inf``/``0`` factors.
 
     Args:
         potentials: The (log-space) potentials of a graphical model.
         total: The normalization factor.
-
         jtree: An optional junction tree that defines the message passing
             order.
-        constraints: Deterministic constraints to handle efficiently.
+        constraints: Structural constraints to handle.
 
     Returns:
         The marginals of the graphical model.
@@ -368,12 +351,16 @@ def constrained_shafer_shenoy(
     if len(potentials.cliques) == 0:
         return CliqueVector(potentials.domain, [], {})
 
+    # Fold non-deterministic constraints as materialized potentials.
+    potentials = _fold_non_deterministic(potentials, constraints)
+    det_constraints = tuple(c for c in constraints if c.is_deterministic)
+
     domain, cliques = potentials.domain, potentials.cliques
 
     # Build the junction tree, including constraint edges.
     extra = [
         domain.canonical(c.clique)
-        for c in constraints
+        for c in det_constraints
         if domain.canonical(c.clique) not in cliques
     ]
     if jtree is None:
@@ -382,7 +369,7 @@ def constrained_shafer_shenoy(
         )[0]
     message_order = junction_tree.message_passing_order(jtree)
     max_cliques = junction_tree.maximal_cliques(jtree)
-    pure_constraint, embedded = _classify_cliques(max_cliques, constraints)
+    pure_constraint, embedded = _classify_cliques(max_cliques, det_constraints)
     neighbors = {cl: list(jtree.neighbors(cl)) for cl in max_cliques}
 
     # Partition user potentials by pure-constraint membership.
@@ -426,9 +413,10 @@ def constrained_shafer_shenoy(
                 if k != j and (k, i) in messages
             ]
             inputs.extend(constraint_init.get(i, []))
-            msg = _constraint_message(c, inputs, c.fine in sep_vars)
+            fine, coarse = c.domain.attributes
+            msg = _constraint_message(c, inputs, fine in sep_vars)
             if msg is None:
-                sizes = {c.fine: c.n_fine, c.coarse: c.n_coarse}
+                sizes = dict(zip(c.domain.attributes, c.domain.shape))
                 sep = tuple(sep_vars)
                 msg = Factor.zeros(Domain(list(sep), [sizes[s] for s in sep]))
             messages[(i, j)] = msg
@@ -470,8 +458,6 @@ def constrained_shafer_shenoy(
         if result_cv.supports(cl):
             result[cl] = result_cv.project(cl)
         elif any(set(cl) <= set(mc) for mc in pure_constraint):
-            # Clique subsumed by a pure constraint — derive from
-            # constraint messages and absorbed potentials.
             result[cl] = _derive_pure_marginal(
                 cl,
                 pure_constraint,
@@ -482,9 +468,7 @@ def constrained_shafer_shenoy(
                 domain,
             )
         else:
-            # Try re-expanding beliefs where constraint slicing removed
-            # a coarse variable the user needs.
-            expanded = _try_expand_belief(cl, result_cv, constraints)
+            expanded = _try_expand_belief(cl, result_cv, det_constraints)
             if expanded is not None:
                 result[cl] = expanded
             else:
@@ -506,13 +490,13 @@ def constrained_shafer_shenoy(
 # ---------------------------------------------------------------------------
 
 
-@jax.jit(static_argnames=['jtree', 'constraints', 'contraction'])
+@jax.jit(static_argnames=['jtree', 'contraction'])
 def constrained_implicit(
     potentials: CliqueVector,
     total: float = 1,
     jtree: nx.Graph | None = None,
     *,
-    constraints: tuple[DeterministicConstraint, ...] = (),
+    constraints: tuple[Constraint, ...] = (),
     contraction: collections.abc.Callable = (
         marginal_oracles.einsum_materialized
     ),
@@ -520,16 +504,15 @@ def constrained_implicit(
     """Hybrid message passing: implicit for standard cliques, SS for constraints.
 
     Uses the memory-efficient implicit contraction for cliques that do not
-    involve constraints, and falls back to Shafer-Shenoy style constraint
-    routing for pure and embedded constraint cliques.  This avoids *both*
-    super-clique expansion (for standard cliques) and the cost of
-    refining coarse factors to fine-variable space (for constraint cliques).
+    involve deterministic constraints, and falls back to Shafer-Shenoy style
+    constraint routing for pure and embedded constraint cliques. General
+    (valid/invalid) constraints are folded in as materialized potentials.
 
     Args:
         potentials: The (log-space) potentials of a graphical model.
         total: The normalization factor.
         jtree: An optional junction tree.
-        constraints: Deterministic constraints to handle efficiently.
+        constraints: Structural constraints to handle.
         contraction: Contraction function for log-space sum-product.
 
     Returns:
@@ -539,12 +522,16 @@ def constrained_implicit(
     if len(potentials.cliques) == 0:
         return CliqueVector(potentials.domain, [], {})
 
+    # Fold non-deterministic constraints as materialized potentials.
+    potentials = _fold_non_deterministic(potentials, constraints)
+    det_constraints = tuple(c for c in constraints if c.is_deterministic)
+
     domain, cliques = potentials.domain, potentials.cliques
 
     # Build junction tree with constraint edges.
     extra = [
         domain.canonical(c.clique)
-        for c in constraints
+        for c in det_constraints
         if domain.canonical(c.clique) not in cliques
     ]
     if jtree is None:
@@ -553,7 +540,7 @@ def constrained_implicit(
         ]
     message_order = junction_tree.message_passing_order(jtree)
     max_cliques = junction_tree.maximal_cliques(jtree)
-    pure_constraint, embedded = _classify_cliques(max_cliques, constraints)
+    pure_constraint, embedded = _classify_cliques(max_cliques, det_constraints)
     neighbors = {cl: list(jtree.neighbors(cl)) for cl in max_cliques}
 
     # Map user cliques → maximal cliques.
@@ -595,9 +582,10 @@ def constrained_implicit(
                 if k != j and (k, i) in messages
             ]
             inputs.extend(constraint_init.get(i, []))
-            msg = _constraint_message(c, inputs, c.fine in sep_vars)
+            fine, coarse = c.domain.attributes
+            msg = _constraint_message(c, inputs, fine in sep_vars)
             if msg is None:
-                sizes = {c.fine: c.n_fine, c.coarse: c.n_coarse}
+                sizes = dict(zip(c.domain.attributes, c.domain.shape))
                 sep = tuple(sep_vars)
                 msg = Factor.zeros(Domain(list(sep), [sizes[s] for s in sep]))
             messages[(i, j)] = msg
@@ -718,10 +706,11 @@ def constrained_implicit(
 
 def _normalize_to_fine(inputs, constraint):
     """Normalize all inputs to fine-variable space."""
+    fine, coarse = constraint.domain.attributes
     cleaned = []
     for f in inputs:
-        has_fine = constraint.fine in f.domain
-        has_coarse = constraint.coarse in f.domain
+        has_fine = fine in f.domain
+        has_coarse = coarse in f.domain
         if has_fine and has_coarse:
             cleaned.append(_constraint_slice(f, constraint))
         elif has_coarse and not has_fine:
@@ -733,8 +722,10 @@ def _normalize_to_fine(inputs, constraint):
 
 def _target_for_constraint(target_domain, constraint):
     """Adjust target domain and return (domain, post_op) for post-processing."""
-    has_fine = constraint.fine in target_domain
-    has_coarse = constraint.coarse in target_domain
+    fine, coarse = constraint.domain.attributes
+    n_fine = constraint.domain.shape[0]
+    has_fine = fine in target_domain
+    has_coarse = coarse in target_domain
 
     if not has_fine and not has_coarse:
         return target_domain, 'none'
@@ -743,16 +734,16 @@ def _target_for_constraint(target_domain, constraint):
     if has_coarse and not has_fine:
         attrs = list(target_domain.attributes)
         shape = list(target_domain.shape)
-        idx = attrs.index(constraint.coarse)
-        attrs[idx] = constraint.fine
-        shape[idx] = constraint.n_fine
+        idx = attrs.index(coarse)
+        attrs[idx] = fine
+        shape[idx] = n_fine
         return Domain(attrs, shape), 'coarsen'
     # Both — drop coarse from target, will expand later.
-    attrs = [a for a in target_domain.attributes if a != constraint.coarse]
+    attrs = [a for a in target_domain.attributes if a != coarse]
     shape = [
         s
         for a, s in zip(target_domain.attributes, target_domain.shape)
-        if a != constraint.coarse
+        if a != coarse
     ]
     return Domain(attrs, shape), 'expand'
 

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -22,6 +22,7 @@ import functools
 import itertools
 import math
 import string
+import warnings
 from collections.abc import Callable
 from typing import Protocol
 
@@ -32,6 +33,7 @@ import networkx as nx
 from . import junction_tree
 from .clique_utils import clique_mapping
 from .clique_vector import CliqueVector
+from .constraint import Constraint
 from .domain import Domain
 from .einsum import custom_einsum
 from .factor import Factor
@@ -60,12 +62,17 @@ class MarginalOracle(Protocol):
         self,
         potentials: CliqueVector,
         total: float = 1.0,
+        *,
+        constraints: tuple[Constraint, ...] = (),
     ) -> CliqueVector:
         """Compute marginals from potentials.
 
         Args:
             potentials: Potentials of a graphical model.
             total: Normalization constant. Defaults to 1.0.
+            constraints: Structural constraints. Oracles that support
+                constraints fold them into the potentials or handle
+                them natively; unsupported oracles raise ValueError.
 
         Returns:
             Marginals as a CliqueVector.
@@ -189,12 +196,34 @@ def einsum_fused(
     return sum_product(log_factors, dom, einsum_fn=_custom_einsum)
 
 
+def _fold_constraints(
+    potentials: CliqueVector,
+    constraints: tuple[Constraint, ...],
+) -> CliqueVector:
+    """Fold constraints into potentials as -inf/0 log-space factors."""
+    if not constraints:
+        return potentials
+    domain = potentials.domain
+    cliques = list(potentials.cliques)
+    arrays = {cl: potentials[cl] for cl in cliques}
+    for c in constraints:
+        cl = domain.canonical(c.clique)
+        factor = c.potential
+        if cl in arrays:
+            arrays[cl] = arrays[cl] + factor
+        else:
+            cliques.append(cl)
+            arrays[cl] = factor
+    return CliqueVector(domain, cliques, arrays)
+
+
 @jax.jit(static_argnames=["jtree", "return_messages"])
 def message_passing_hugin(
     potentials: CliqueVector,
     total: float = 1.0,
     jtree: nx.Graph | None = None,
     *,
+    constraints: tuple[Constraint, ...] = (),
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
     """HUGIN message passing with belief subtraction.
@@ -206,10 +235,20 @@ def message_passing_hugin(
         potentials: Potentials of a graphical model.
         total: Normalization constant.
         jtree: Pre-computed junction tree (optional).
+        constraints: Structural constraints folded into potentials as
+            ``-inf``/``0`` factors before inference.
         return_messages: If True, return ``(marginals, messages)`` where
             *messages* is a dict mapping ``(clique_i, clique_j)`` to the
             log-space message Factor sent from *i* to *j*.
     """
+    if constraints:
+        warnings.warn(
+            "HUGIN uses belief subtraction which is unstable with -inf"
+            " potentials introduced by constraints. Consider using"
+            " message_passing_shafer_shenoy instead.",
+            stacklevel=2,
+        )
+    potentials = _fold_constraints(potentials, constraints)
     if len(potentials.cliques) == 0:
         result = CliqueVector(potentials.domain, [], {})
         return (result, {}) if return_messages else result
@@ -244,6 +283,7 @@ def message_passing_shafer_shenoy(
     total: float = 1.0,
     jtree: nx.Graph | None = None,
     *,
+    constraints: tuple[Constraint, ...] = (),
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
     """Shafer-Shenoy message passing with neighbor collection.
@@ -256,10 +296,13 @@ def message_passing_shafer_shenoy(
         potentials: Potentials of a graphical model.
         total: Normalization constant.
         jtree: Pre-computed junction tree (optional).
+        constraints: Structural constraints folded into potentials as
+            ``-inf``/``0`` factors before inference.
         return_messages: If True, return ``(marginals, messages)`` where
             *messages* is a dict mapping ``(clique_i, clique_j)`` to the
             log-space message Factor sent from *i* to *j*.
     """
+    potentials = _fold_constraints(potentials, constraints)
     if len(potentials.cliques) == 0:
         result = CliqueVector(potentials.domain, [], {})
         return (result, {}) if return_messages else result
@@ -304,6 +347,7 @@ def message_passing_implicit(
     total: float = 1.0,
     jtree: nx.Graph | None = None,
     *,
+    constraints: tuple[Constraint, ...] = (),
     contraction: Callable = einsum_materialized,
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
@@ -320,11 +364,20 @@ def message_passing_implicit(
         potentials: Potentials of a graphical model.
         total: Normalization constant.
         jtree: Pre-computed junction tree (optional).
+        constraints: Structural constraints folded into potentials as
+            ``-inf``/``0`` factors before inference.
         contraction: Contraction function for log-space sum-product.
         return_messages: If True, return ``(marginals, messages)`` where
             *messages* is a dict mapping ``(clique_i, clique_j)`` to the
             log-space message Factor sent from *i* to *j*.
     """
+    if constraints and contraction is einsum_semistable:
+        raise ValueError(
+            "einsum_semistable is not compatible with constraints"
+            " (-inf potentials). Use einsum_fused or the default"
+            " einsum_materialized instead."
+        )
+    potentials = _fold_constraints(potentials, constraints)
     if len(potentials.cliques) == 0:
         result = CliqueVector(potentials.domain, [], {})
         return (result, {}) if return_messages else result
@@ -451,8 +504,18 @@ def default_oracle(
 def brute_force_marginals(
     potentials: CliqueVector,
     total: float = 1,
+    *,
+    constraints: tuple[Constraint, ...] = (),
 ) -> CliqueVector:
-    """Compute marginals from (log-space) potentials by materializing the full joint distribution."""
+    """Compute marginals from (log-space) potentials by materializing the full joint distribution.
+
+    Args:
+        potentials: Potentials of a graphical model.
+        total: Normalization constant.
+        constraints: Structural constraints folded into potentials as
+            ``-inf``/``0`` factors before inference.
+    """
+    potentials = _fold_constraints(potentials, constraints)
     if len(potentials.cliques) == 0:
         return CliqueVector(potentials.domain, [], {})
 
@@ -465,11 +528,24 @@ def einsum_marginals(
     potentials: CliqueVector,
     total: float = 1,
     einsum_fn: Callable = jnp.einsum,
+    *,
+    constraints: tuple[Constraint, ...] = (),
 ) -> CliqueVector:
     """Compute marginals from (log-space) potentials by using einsum.
 
     This is a "brute-force" approach and is not recommended in practice.
+
+    Args:
+        potentials: Potentials of a graphical model.
+        total: Normalization constant.
+        einsum_fn: Einsum function to use.
+        constraints: Structural constraints. Raises ValueError if non-empty.
     """
+    if constraints:
+        raise ValueError(
+            "einsum_marginals does not support constraints. Use"
+            " message_passing_shafer_shenoy or constrained_shafer_shenoy."
+        )
     # not strictly necessary, but consistent
     if len(potentials.cliques) == 0:
         return CliqueVector(potentials.domain, [], {})
@@ -499,6 +575,8 @@ def variable_elimination(
     clique: Clique,
     total: float = 1,
     evidence: dict[str, int] | None = None,
+    *,
+    constraints: tuple[Constraint, ...] = (),
 ) -> Factor:
     """Compute an out-of-model/unsupported marginal from the potentials.
 
@@ -507,11 +585,14 @@ def variable_elimination(
         clique: The subset of attributes whose marginal you want.
         total: The normalization factor.
         evidence: A dictionary mapping attribute names to observed values.
+        constraints: Structural constraints folded into potentials as
+            ``-inf``/``0`` factors before inference.
 
     Returns:
         The marginal defined over the domain of the input clique, where
         each entry is non-negative and sums to the input total.
     """
+    potentials = _fold_constraints(potentials, constraints)
     clique = tuple(clique)
     evidence = evidence or {}
     if set(clique) & set(evidence.keys()):
@@ -579,6 +660,8 @@ def bulk_variable_elimination(
     potentials: CliqueVector,
     marginal_queries: list[tuple[str, ...]],
     total: float = 1.0,
+    *,
+    constraints: tuple[Constraint, ...] = (),
 ) -> CliqueVector:
     """Compute the marginals of the graphical model with the given potentials.
 
@@ -594,10 +677,13 @@ def bulk_variable_elimination(
       potentials: The (log-space) potentials of a Graphical Model.
       marginal_queries: A list of cliques to obtain marginals for.
       total: The normalization factor.
+      constraints: Structural constraints folded into potentials as
+          ``-inf``/``0`` factors before inference.
 
     Returns:
       A CliqueVector with the marginals computed over the specified cliques.
     """
+    potentials = _fold_constraints(potentials, constraints)
     jitted = jax.jit(variable_elimination, static_argnums=(1,))
 
     # Async + parallel precompilation.
@@ -620,6 +706,8 @@ def calculate_many_marginals(
     marginal_queries: list[Clique],
     total: float = 1.0,
     belief_propagation_oracle: MarginalOracle = message_passing_stable,
+    *,
+    constraints: tuple[Constraint, ...] = (),
 ) -> CliqueVector:
     """Calculate marginals for all projections using belief propagation.
 
@@ -631,10 +719,13 @@ def calculate_many_marginals(
     Args:
         potentials: Potentials of a graphical model.
         marginal_queries: a list of cliques whose marginals are desired.
+        constraints: Structural constraints folded into potentials as
+            ``-inf``/``0`` factors before inference.
 
     Returns:
         A CliqueVector, where each defined over the list of input marginal_queries.
     """
+    potentials = _fold_constraints(potentials, constraints)
 
     domain = potentials.domain
     jtree = junction_tree.make_junction_tree(
@@ -711,7 +802,23 @@ def kron_query(
     query_factors: dict[str, jax.Array],
     total: float = 1,
     suffix: str = "_answer",
+    *,
+    constraints: tuple[Constraint, ...] = (),
 ) -> Factor:
+    """Compute a Kronecker-product query.
+
+    Args:
+        potentials: Potentials of a graphical model.
+        query_factors: Mapping from attribute names to query matrices.
+        total: Normalization constant.
+        suffix: Suffix for the answer attributes.
+        constraints: Structural constraints. Raises ValueError if non-empty.
+    """
+    if constraints:
+        raise ValueError(
+            "kron_query does not support constraints. Fold them into"
+            " potentials before calling kron_query."
+        )
     new_factors = {}
     extra_domain = {}
     extra_cliques = []

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -1,0 +1,282 @@
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+from mbi import Constraint, Domain, Factor
+
+
+class TestConstraintConstruction(unittest.TestCase):
+
+    def test_valid(self):
+        domain = Domain(["a", "b"], [3, 4])
+        valid = np.array([[0, 0], [1, 2], [2, 3]])
+        c = Constraint(domain=domain, valid=valid)
+        self.assertIsNotNone(c.valid)
+        self.assertIsNone(c.invalid)
+        self.assertIsNone(c.mapping)
+
+    def test_invalid(self):
+        domain = Domain(["a", "b"], [3, 4])
+        invalid = np.array([[0, 1]])
+        c = Constraint(domain=domain, invalid=invalid)
+        self.assertIsNone(c.valid)
+        self.assertIsNotNone(c.invalid)
+
+    def test_mapping(self):
+        domain = Domain(["fine", "coarse"], [6, 3])
+        mapping = np.array([0, 0, 1, 1, 2, 2])
+        c = Constraint(domain=domain, mapping=mapping)
+        self.assertIsNone(c.valid)
+        self.assertTrue(c.is_deterministic)
+
+    def test_none_specified_raises(self):
+        domain = Domain(["a"], [3])
+        with self.assertRaises(ValueError):
+            Constraint(domain=domain)
+
+    def test_multiple_specified_raises(self):
+        domain = Domain(["a", "b"], [3, 4])
+        with self.assertRaises(ValueError):
+            Constraint(
+                domain=domain,
+                valid=np.array([[0, 0]]),
+                invalid=np.array([[1, 1]]),
+            )
+
+    def test_valid_wrong_columns_raises(self):
+        domain = Domain(["a", "b"], [3, 4])
+        with self.assertRaises(ValueError):
+            Constraint(domain=domain, valid=np.array([[0, 0, 0]]))
+
+    def test_mapping_wrong_size_raises(self):
+        domain = Domain(["fine", "coarse"], [6, 3])
+        with self.assertRaises(ValueError):
+            Constraint(domain=domain, mapping=np.array([0, 0, 1]))
+
+    def test_mapping_requires_two_attributes(self):
+        domain = Domain(["a", "b", "c"], [3, 3, 3])
+        with self.assertRaises(ValueError):
+            Constraint(domain=domain, mapping=np.array([0, 1, 2]))
+
+
+class TestConstraintProperties(unittest.TestCase):
+
+    def test_clique(self):
+        domain = Domain(["b", "a"], [3, 4])
+        c = Constraint(domain=domain, valid=np.array([[0, 0]]))
+        self.assertEqual(c.clique, ("a", "b"))
+
+    def test_is_deterministic(self):
+        domain = Domain(["fine", "coarse"], [4, 2])
+        c_map = Constraint(domain=domain, mapping=np.array([0, 0, 1, 1]))
+        c_valid = Constraint(domain=domain, valid=np.array([[0, 0], [1, 0]]))
+        self.assertTrue(c_map.is_deterministic)
+        self.assertFalse(c_valid.is_deterministic)
+
+
+class TestAsPotential(unittest.TestCase):
+
+    def test_valid_potential(self):
+        domain = Domain(["a", "b"], [3, 3])
+        valid = np.array([[0, 0], [1, 1], [2, 2]])
+        c = Constraint(domain=domain, valid=valid)
+        f = c.potential
+        self.assertEqual(f.domain, domain)
+        vals = np.asarray(f.values)
+        # Diagonal should be 0, off-diagonal -inf
+        for i in range(3):
+            for j in range(3):
+                if i == j:
+                    self.assertEqual(vals[i, j], 0.0)
+                else:
+                    self.assertEqual(vals[i, j], -np.inf)
+
+    def test_invalid_potential(self):
+        domain = Domain(["a", "b"], [2, 2])
+        invalid = np.array([[0, 1]])
+        c = Constraint(domain=domain, invalid=invalid)
+        f = c.potential
+        vals = np.asarray(f.values)
+        self.assertEqual(vals[0, 1], -np.inf)
+        self.assertEqual(vals[0, 0], 0.0)
+        self.assertEqual(vals[1, 0], 0.0)
+        self.assertEqual(vals[1, 1], 0.0)
+
+    def test_mapping_potential(self):
+        domain = Domain(["fine", "coarse"], [4, 2])
+        mapping = np.array([0, 0, 1, 1])
+        c = Constraint(domain=domain, mapping=mapping)
+        f = c.potential
+        vals = np.asarray(f.values)
+        # (0,0), (1,0), (2,1), (3,1) should be 0; rest -inf
+        self.assertEqual(vals[0, 0], 0.0)
+        self.assertEqual(vals[1, 0], 0.0)
+        self.assertEqual(vals[2, 1], 0.0)
+        self.assertEqual(vals[3, 1], 0.0)
+        self.assertEqual(vals[0, 1], -np.inf)
+        self.assertEqual(vals[2, 0], -np.inf)
+
+    def test_valid_and_mapping_produce_same_potential(self):
+        """A mapping constraint should produce the same factor as the
+        equivalent valid-combos constraint."""
+        domain = Domain(["fine", "coarse"], [6, 3])
+        mapping = np.array([0, 0, 1, 1, 2, 2])
+        valid = np.column_stack([np.arange(6), mapping])
+
+        c_map = Constraint(domain=domain, mapping=mapping)
+        c_valid = Constraint(domain=domain, valid=valid)
+
+        np.testing.assert_array_equal(
+            c_map.potential.values, c_valid.potential.values
+        )
+
+    def test_three_way_valid(self):
+        """Constraints over 3+ attributes should work."""
+        domain = Domain(["a", "b", "c"], [2, 2, 2])
+        valid = np.array([[0, 0, 0], [1, 1, 1]])
+        c = Constraint(domain=domain, valid=valid)
+        f = c.potential
+        vals = np.asarray(f.values)
+        self.assertEqual(vals[0, 0, 0], 0.0)
+        self.assertEqual(vals[1, 1, 1], 0.0)
+        self.assertEqual(vals[0, 0, 1], -np.inf)
+        self.assertEqual(vals[1, 0, 0], -np.inf)
+
+
+class TestOracleIntegration(unittest.TestCase):
+    """Test that constraints flow through marginal oracles correctly."""
+
+    def _make_model(self):
+        domain = Domain(["A", "B", "C"], [3, 3, 4])
+        cliques = [("A", "C"), ("B", "C")]
+        np.random.seed(42)
+        from mbi import CliqueVector
+
+        arrays = {
+            cl: Factor(
+                domain.project(cl),
+                jnp.array(np.random.randn(*domain.project(cl).shape)),
+            )
+            for cl in cliques
+        }
+        return domain, cliques, CliqueVector(domain, cliques, arrays)
+
+    def _diagonal_constraint(self, domain):
+        """A=B constraint (diagonal only)."""
+        valid = np.array([[i, i] for i in range(3)])
+        return Constraint(domain=domain.project(("A", "B")), valid=valid)
+
+    def test_shafer_shenoy_with_constraints(self):
+        from mbi import marginal_oracles
+
+        domain, cliques, potentials = self._make_model()
+        c = self._diagonal_constraint(domain)
+
+        result = marginal_oracles.message_passing_shafer_shenoy(
+            potentials, total=1.0, constraints=(c,)
+        )
+        # Marginals should sum to 1.
+        for cl in cliques:
+            np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
+
+    def test_shafer_shenoy_constraints_match_manual(self):
+        """constraints= should match manually adding the factor."""
+        from mbi import CliqueVector, marginal_oracles
+
+        domain, cliques, potentials = self._make_model()
+        c = self._diagonal_constraint(domain)
+
+        result1 = marginal_oracles.message_passing_shafer_shenoy(
+            potentials, total=1.0, constraints=(c,)
+        )
+
+        # Manually add the constraint factor.
+        con_cl = domain.canonical(c.clique)
+        arrays = {cl: potentials[cl] for cl in cliques}
+        arrays[con_cl] = c.potential
+        potentials2 = CliqueVector(domain, list(cliques) + [con_cl], arrays)
+        result2 = marginal_oracles.message_passing_shafer_shenoy(
+            potentials2, total=1.0
+        )
+
+        for cl in cliques:
+            np.testing.assert_allclose(
+                np.array(result1[cl].values),
+                np.array(result2.project(cl).values),
+                atol=1e-5,
+            )
+
+    def test_implicit_with_constraints(self):
+        from mbi import marginal_oracles
+
+        domain, cliques, potentials = self._make_model()
+        c = self._diagonal_constraint(domain)
+
+        result = marginal_oracles.message_passing_implicit(
+            potentials, total=1.0, constraints=(c,)
+        )
+        for cl in cliques:
+            np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
+
+    def test_implicit_einsum_semistable_raises(self):
+        from mbi import marginal_oracles
+
+        domain, cliques, potentials = self._make_model()
+        c = self._diagonal_constraint(domain)
+
+        with self.assertRaises(ValueError):
+            marginal_oracles.message_passing_implicit(
+                potentials,
+                total=1.0,
+                constraints=(c,),
+                contraction=marginal_oracles.einsum_semistable,
+            )
+
+    def test_hugin_warns(self):
+        import warnings as w
+        from mbi import marginal_oracles
+
+        domain, cliques, potentials = self._make_model()
+        c = self._diagonal_constraint(domain)
+
+        with w.catch_warnings(record=True) as caught:
+            w.simplefilter("always")
+            marginal_oracles.message_passing_hugin(
+                potentials, total=1.0, constraints=(c,)
+            )
+        self.assertTrue(
+            any("HUGIN" in str(warning.message) for warning in caught)
+        )
+
+    def test_mapping_constraint_through_oracle(self):
+        """Mapping constraints work through oracles."""
+        from mbi import marginal_oracles
+
+        domain = Domain(["fine", "coarse", "X"], [6, 3, 4])
+        mapping = np.array([0, 0, 1, 1, 2, 2])
+        c = Constraint(
+            domain=domain.project(("fine", "coarse")), mapping=mapping
+        )
+
+        np.random.seed(0)
+        from mbi import CliqueVector
+
+        cliques = [("fine", "X"), ("coarse", "X")]
+        arrays = {
+            cl: Factor(
+                domain.project(cl),
+                jnp.array(np.random.randn(*domain.project(cl).shape)),
+            )
+            for cl in cliques
+        }
+        potentials = CliqueVector(domain, cliques, arrays)
+
+        result = marginal_oracles.message_passing_shafer_shenoy(
+            potentials, total=1.0, constraints=(c,)
+        )
+        for cl in cliques:
+            np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_deterministic.py
+++ b/test/test_deterministic.py
@@ -8,26 +8,37 @@ import unittest
 
 import jax.numpy as jnp
 from mbi.clique_vector import CliqueVector
+from mbi.constraint import Constraint
 from mbi.domain import Domain
-from mbi.extensions.constraints import coarsen
-from mbi.extensions.constraints import constrained_implicit
-from mbi.extensions.constraints import constrained_shafer_shenoy
-from mbi.extensions.constraints import DeterministicConstraint
-from mbi.extensions.constraints import project_to_coarse
-from mbi.extensions.constraints import refine
+from mbi.extensions.message_passing import coarsen
+from mbi.extensions.message_passing import constrained_implicit
+from mbi.extensions.message_passing import constrained_shafer_shenoy
+from mbi.extensions.message_passing import project_to_coarse
+from mbi.extensions.message_passing import refine
 from mbi.factor import Factor
 from mbi.marginal_oracles import message_passing_shafer_shenoy
 import numpy as np
 from parameterized import parameterized
 
 
+def _mapping_constraint(fine, coarse, mapping):
+    """Shorthand: build a Constraint from variable names and a mapping array."""
+    n_fine = len(mapping)
+    n_coarse = int(np.max(mapping)) + 1
+    return Constraint(
+        domain=Domain([fine, coarse], [n_fine, n_coarse]), mapping=mapping
+    )
+
+
 def _make_constraint_factor(domain, constraint):
     """Build the explicit 0/-inf constraint factor for baseline comparison."""
-    shape = (constraint.n_fine, constraint.n_coarse)
+    fine, coarse = constraint.domain.attributes
+    n_fine, n_coarse = constraint.domain.shape
+    shape = (n_fine, n_coarse)
     vals = np.full(shape, -np.inf)
     for a, a_prime in enumerate(constraint.mapping):
         vals[a, a_prime] = 0.0
-    dom = Domain([constraint.fine, constraint.coarse], list(shape))
+    dom = Domain([fine, coarse], list(shape))
     return Factor(dom, jnp.array(vals)).transpose(
         domain.canonical(constraint.clique)
     )
@@ -35,7 +46,7 @@ def _make_constraint_factor(domain, constraint):
 
 def _baseline_marginals(domain, cliques, potentials, constraints, total=10.0):
     """Marginals via standard Shafer-Shenoy with explicit -inf constraints."""
-    if isinstance(constraints, DeterministicConstraint):
+    if isinstance(constraints, Constraint):
         constraints = [constraints]
     arrays = {cl: potentials[cl] for cl in cliques}
     all_cliques = list(cliques)
@@ -89,7 +100,7 @@ def _random_surjection(n_domain, n_range, rng):
 
 
 _SIMPLE_DOMAIN = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
-_SIMPLE_CONSTRAINT = DeterministicConstraint(
+_SIMPLE_CONSTRAINT = _mapping_constraint(
     'A', 'Ap', np.array([0, 0, 1, 1, 2, 2])
 )
 _CLIQUE_CONFIGS = [
@@ -104,7 +115,7 @@ class TestCoarsenRefine(unittest.TestCase):
 
     def setUp(self):
         self.mapping = np.array([0, 0, 1, 1, 2, 2])
-        self.constraint = DeterministicConstraint('A', 'Ap', self.mapping)
+        self.constraint = _mapping_constraint('A', 'Ap', self.mapping)
 
     def test_coarsen_1d(self):
         dom = Domain(['A'], [6])
@@ -170,7 +181,7 @@ class TestCoarsenRefineRandomized(unittest.TestCase):
         n_fine = rng.integers(4, 20)
         n_coarse = rng.integers(2, n_fine)
         mapping = _random_surjection(n_fine, n_coarse, rng)
-        constraint = DeterministicConstraint('X', 'Y', mapping)
+        constraint = _mapping_constraint('X', 'Y', mapping)
 
         n_other = rng.integers(2, 6)
         dom = Domain(['X', 'Z'], [n_fine, n_other])
@@ -242,10 +253,8 @@ class TestMultipleConstraints(unittest.TestCase):
 
     def _two_constraint_setup(self):
         domain = Domain(['A', 'Ap', 'B', 'Bp', 'C'], [6, 3, 8, 4, 5])
-        c1 = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
-        c2 = DeterministicConstraint(
-            'B', 'Bp', np.array([0, 0, 1, 1, 2, 2, 3, 3])
-        )
+        c1 = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
+        c2 = _mapping_constraint('B', 'Bp', np.array([0, 0, 1, 1, 2, 2, 3, 3]))
         return domain, (c1, c2)
 
     def test_two_constraints_basic(self):
@@ -276,12 +285,8 @@ class TestMultipleConstraints(unittest.TestCase):
         domain = Domain(
             ['A', 'Ap', 'B', 'Bp', 'C'], [n_a, n_ap, n_b, n_bp, n_c]
         )
-        c1 = DeterministicConstraint(
-            'A', 'Ap', _random_surjection(n_a, n_ap, rng)
-        )
-        c2 = DeterministicConstraint(
-            'B', 'Bp', _random_surjection(n_b, n_bp, rng)
-        )
+        c1 = _mapping_constraint('A', 'Ap', _random_surjection(n_a, n_ap, rng))
+        c2 = _mapping_constraint('B', 'Bp', _random_surjection(n_b, n_bp, rng))
         cliques = [('A', 'C'), ('Bp',)]
         total = 10.0
 
@@ -302,9 +307,7 @@ class TestMultipleConstraints(unittest.TestCase):
 class TestComplexTopologies(unittest.TestCase):
     """Tests with more complex graph structures."""
 
-    _CONSTRAINT = DeterministicConstraint(
-        'A', 'Ap', np.array([0, 0, 1, 1, 2, 2])
-    )
+    _CONSTRAINT = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
 
     def _check(self, domain, cliques, constraint=None):
         _assert_matches_baseline(
@@ -321,7 +324,7 @@ class TestComplexTopologies(unittest.TestCase):
 
     def test_fine_in_multiple_factors(self):
         domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
-        constraint = DeterministicConstraint(
+        constraint = _mapping_constraint(
             'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
         )
         self._check(
@@ -330,7 +333,7 @@ class TestComplexTopologies(unittest.TestCase):
 
     def test_coarse_in_multiple_factors(self):
         domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
-        constraint = DeterministicConstraint(
+        constraint = _mapping_constraint(
             'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
         )
         self._check(
@@ -339,7 +342,7 @@ class TestComplexTopologies(unittest.TestCase):
 
     def test_uneven_groups(self):
         domain = Domain(['A', 'Ap', 'B'], [10, 3, 4])
-        constraint = DeterministicConstraint(
+        constraint = _mapping_constraint(
             'A', 'Ap', np.array([0, 1, 2, 2, 2, 2, 2, 2, 2, 2])
         )
         self._check(domain, [('A', 'B'), ('Ap',)], constraint)
@@ -348,7 +351,7 @@ class TestComplexTopologies(unittest.TestCase):
         n_fine, n_coarse = 50, 5
         mapping = np.repeat(np.arange(n_coarse), n_fine // n_coarse)
         domain = Domain(['A', 'Ap', 'B'], [n_fine, n_coarse, 8])
-        constraint = DeterministicConstraint('A', 'Ap', mapping)
+        constraint = _mapping_constraint('A', 'Ap', mapping)
         self._check(domain, [('A', 'B'), ('Ap',)], constraint)
 
     def test_disconnected_components(self):
@@ -368,7 +371,7 @@ class TestComplexTopologies(unittest.TestCase):
     def test_identity_mapping(self):
         """1:1 mapping (permutation) — degenerate constraint."""
         domain = Domain(['A', 'Ap', 'B'], [4, 4, 5])
-        constraint = DeterministicConstraint('A', 'Ap', np.array([0, 1, 2, 3]))
+        constraint = _mapping_constraint('A', 'Ap', np.array([0, 1, 2, 3]))
         self._check(domain, [('A', 'B'), ('Ap',)], constraint)
 
     def test_orphan_coarse_variable(self):
@@ -407,21 +410,14 @@ class TestComplexTopologies(unittest.TestCase):
         self._check(domain, [('A', 'Ap', 'B'), ('A', 'Ap', 'C')])
 
 
-class TestDeterministicConstraint(unittest.TestCase):
+class TestConstraintProperties(unittest.TestCase):
 
     def test_properties(self):
-        c = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
-        self.assertEqual(c.n_fine, 6)
-        self.assertEqual(c.n_coarse, 3)
+        c = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
+        self.assertEqual(c.domain.shape[0], 6)
+        self.assertEqual(c.domain.shape[1], 3)
         self.assertEqual(c.clique, ('A', 'Ap'))
-
-    def test_hash_eq(self):
-        c1 = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1]))
-        c2 = DeterministicConstraint('A', 'Ap', np.array([0, 0, 1]))
-        c3 = DeterministicConstraint('A', 'Ap', np.array([0, 1, 1]))
-        self.assertEqual(c1, c2)
-        self.assertNotEqual(c1, c3)
-        self.assertEqual(hash(c1), hash(c2))
+        self.assertTrue(c.is_deterministic)
 
 
 if __name__ == '__main__':

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -11,7 +11,8 @@ from mbi.marginal_oracles import (
     einsum_fused,
     einsum_semistable,
 )
-from mbi.extensions.constraints import (
+from mbi.constraint import Constraint
+from mbi.extensions.message_passing import (
     constrained_shafer_shenoy,
     constrained_implicit,
 )
@@ -296,3 +297,155 @@ class TestDefaultOracle(unittest.TestCase):
             np.testing.assert_allclose(
                 mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
             )
+
+
+# --- Constraint-aware oracle tests ---
+
+_CDOMAIN = Domain(["A", "Ap", "B", "C"], [6, 3, 4, 5])
+
+_CONSTRAINT_CONFIGS = [
+    # Single constraint.
+    (
+        Constraint(
+            Domain(["A", "Ap"], [6, 3]), mapping=np.array([0, 0, 1, 1, 2, 2])
+        ),
+    ),
+    # Uneven grouping.
+    (
+        Constraint(
+            Domain(["A", "Ap"], [6, 3]), mapping=np.array([0, 1, 2, 2, 2, 2])
+        ),
+    ),
+]
+
+_CONSTRAINED_CLIQUE_SETS = [
+    [("A", "B"), ("Ap", "C")],
+    [("A",), ("Ap",), ("B", "C")],
+    [("A", "B"), ("A",), ("Ap", "C")],
+    [("A", "B"), ("Ap", "C"), ("B",)],
+    [("A", "Ap"), ("B", "C")],
+    [("A", "Ap", "B"), ("Ap", "C")],
+]
+
+_CONSTRAINED_ORACLES = [
+    constrained_shafer_shenoy,
+    functools.partial(constrained_implicit, contraction=einsum_materialized),
+    functools.partial(constrained_implicit, contraction=einsum_fused),
+]
+
+# Baseline oracles that accept constraints= and fold them as -inf potentials.
+_FOLDING_ORACLES = [
+    message_passing_shafer_shenoy,
+    message_passing_hugin,
+]
+
+
+def _fold_baseline(potentials, total, constraints):
+    """Brute-force baseline with constraints folded as -inf potentials."""
+    cliques = list(potentials.cliques)
+    arrays = dict(potentials.arrays)
+    for c in constraints:
+        cl = potentials.domain.canonical(c.clique)
+        pot = c.potential.transpose(cl)
+        if cl in arrays:
+            arrays[cl] = arrays[cl] + pot
+        else:
+            arrays[cl] = pot
+            cliques.append(cl)
+    folded = CliqueVector(potentials.domain, cliques, arrays)
+    return marginal_oracles.brute_force_marginals(folded, total)
+
+
+class TestConstrainedOracles(unittest.TestCase):
+
+    @parameterized.expand(
+        itertools.product(
+            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+        )
+    )
+    def test_matches_brute_force(self, oracle, cliques, constraints):
+        """Constrained oracle matches brute-force with folded -inf baseline."""
+        theta = CliqueVector.random(_CDOMAIN, cliques)
+        mu = oracle(theta, 10.0, constraints=constraints)
+        baseline = _fold_baseline(theta, 10.0, constraints)
+        for cl in cliques:
+            np.testing.assert_allclose(
+                mu[cl].datavector(),
+                baseline[cl].datavector(),
+                atol=1e-4,
+                err_msg=f"{oracle}, {cl}",
+            )
+
+    @parameterized.expand(
+        itertools.product(
+            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+        )
+    )
+    def test_sums_to_total(self, oracle, cliques, constraints):
+        """Constrained marginals sum to the requested total."""
+        theta = CliqueVector.random(_CDOMAIN, cliques)
+        mu = oracle(theta, 10.0, constraints=constraints)
+        for cl in cliques:
+            np.testing.assert_allclose(
+                mu[cl].datavector().sum(), 10.0, atol=1e-4
+            )
+
+    @parameterized.expand(
+        itertools.product(
+            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+        )
+    )
+    def test_no_nans(self, oracle, cliques, constraints):
+        """Constrained marginals contain no NaNs."""
+        theta = CliqueVector.random(_CDOMAIN, cliques)
+        mu = oracle(theta, 10.0, constraints=constraints)
+        for cl in cliques:
+            self.assertFalse(jnp.isnan(mu[cl].values).any(), f"NaN in {cl}")
+
+    @parameterized.expand(
+        itertools.product(
+            _FOLDING_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+        )
+    )
+    def test_folding_matches_brute_force(self, oracle, cliques, constraints):
+        """Core oracles with folded constraints match brute-force baseline."""
+        theta = CliqueVector.random(_CDOMAIN, cliques)
+        mu = oracle(theta, 10.0, constraints=constraints)
+        baseline = _fold_baseline(theta, 10.0, constraints)
+        for cl in cliques:
+            np.testing.assert_allclose(
+                mu[cl].datavector(),
+                baseline[cl].datavector(),
+                atol=1e-4,
+                err_msg=f"{oracle}, {cl}",
+            )
+
+    @parameterized.expand(
+        itertools.product(
+            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+        )
+    )
+    def test_constraints_satisfied(self, oracle, cliques, constraints):
+        """Invalid entries in the constraint marginal are zero."""
+        theta = CliqueVector.random(_CDOMAIN, cliques)
+        mu = oracle(theta, 10.0, constraints=constraints)
+        for c in constraints:
+            fine, coarse = c.domain.attributes
+            # Build the expected mask from the constraint.
+            expected_zero = np.ones(c.domain.shape, dtype=bool)
+            for a in range(c.domain.shape[0]):
+                expected_zero[a, c.mapping[a]] = False
+            # Check every user clique that contains fine or coarse.
+            for cl in cliques:
+                vals = mu[cl].datavector()
+                if fine in cl and coarse in cl:
+                    # Joint over both: invalid cells must be zero.
+                    joint = mu[cl].project((fine, coarse))
+                    np.testing.assert_allclose(
+                        joint.values[expected_zero],
+                        0.0,
+                        atol=1e-5,
+                        err_msg=f"constraint violated in clique {cl}",
+                    )
+                # All marginals should be non-negative.
+                self.assertTrue((vals >= -1e-6).all(), f"negative in {cl}")


### PR DESCRIPTION
## Summary

Surfaces constraints as a first-class concept in MBI with a unified `Constraint` dataclass.

## `Constraint` API

Three mutually exclusive construction modes:

```python
# Valid combinations (whitelist)
c = Constraint(domain=Domain(["gqtype", "gq"], [8, 5]),
               valid=np.array([[0, 0], [0, 1], [1, 3]]))

# Invalid combinations (blacklist)
c = Constraint(domain=Domain(["sex", "chborn"], [2, 10]),
               invalid=np.array([[0, 1], [0, 2]]))

# Functional dependency (fine → coarse)
c = Constraint(domain=Domain(["bpld", "bpl"], [200, 50]),
               mapping=np.array([...]))
```

The `domain` field (a `Domain` object) enables shape validation at construction time.

### Key methods/properties:
- `as_potential()` → `Factor`: materializes as a -inf/0 log-space factor
- `clique` → sorted attribute names
- `is_deterministic` → whether this is a mapping constraint

## Oracle integration

All three message passing oracles now accept `constraints=`:

```python
marginals = message_passing_shafer_shenoy(potentials, constraints=(c1, c2))
```

Constraints are folded into potentials as -inf/0 factors before inference.

## Relationship to extensions

The constraint-aware algorithms in `extensions/constraints.py` (`constrained_shafer_shenoy`, `constrained_implicit`) remain for O(|fine|) efficient handling of deterministic constraints. The top-level `Constraint` provides the simple default path; extensions provides the optimized path.

## Tests

20 unit tests covering construction, validation, equality, and `as_potential` for all three modes.