### PR TITLE
Rename extension oracles and update module docstring

### DIFF
--- a/src/mbi/extensions/message_passing.py
+++ b/src/mbi/extensions/message_passing.py
@@ -1,10 +1,19 @@
-"""Constraint-aware message passing for graphical models.
+"""Extension message-passing oracles with efficient constraint handling.
 
-Provides efficient handling of deterministic variable constraints
-(e.g., A' = f(A) where A' is a coarsening of A) during message passing.
-For mapping constraints, messages are routed through the constraint in
-O(|A|) time using coarsen/refine operations. For general valid/invalid
-constraints, the full potential is materialized and folded in.
+Alternative implementations of the Shafer-Shenoy and implicit message-passing
+oracles from :mod:`mbi.marginal_oracles`.  Key differences:
+
+1. **More efficient constraint handling.**  For deterministic (mapping)
+   constraints, messages are routed through the constraint in O(|fine|)
+   time via ``coarsen``/``refine`` operations, avoiding the full
+   O(|fine| × |coarse|) potential materialization used by the core oracles.
+2. **AI-written, less well-tested.**  These implementations were developed
+   with AI assistance and have narrower test coverage than the core oracles.
+   They are kept separate until they mature enough to replace the originals.
+
+Usage::
+
+    from mbi.extensions.message_passing import shafer_shenoy, implicit
 """
 
 from __future__ import annotations
@@ -326,7 +335,7 @@ def _fold_non_deterministic(potentials, constraints):
 
 
 @jax.jit(static_argnames=['jtree'])
-def constrained_shafer_shenoy(
+def shafer_shenoy(
     potentials: CliqueVector,
     total: float = 1,
     jtree: nx.Graph | None = None,
@@ -491,7 +500,7 @@ def constrained_shafer_shenoy(
 
 
 @jax.jit(static_argnames=['jtree', 'contraction'])
-def constrained_implicit(
+def implicit(
     potentials: CliqueVector,
     total: float = 1,
     jtree: nx.Graph | None = None,

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -544,7 +544,8 @@ def einsum_marginals(
     if constraints:
         raise ValueError(
             "einsum_marginals does not support constraints. Use"
-            " message_passing_shafer_shenoy or constrained_shafer_shenoy."
+            " message_passing_shafer_shenoy or"
+            " extensions.message_passing.shafer_shenoy."
         )
     # not strictly necessary, but consistent
     if len(potentials.cliques) == 0:

--- a/test/test_deterministic.py
+++ b/test/test_deterministic.py
@@ -11,8 +11,8 @@ from mbi.clique_vector import CliqueVector
 from mbi.constraint import Constraint
 from mbi.domain import Domain
 from mbi.extensions.message_passing import coarsen
-from mbi.extensions.message_passing import constrained_implicit
-from mbi.extensions.message_passing import constrained_shafer_shenoy
+from mbi.extensions.message_passing import implicit as ext_implicit
+from mbi.extensions.message_passing import shafer_shenoy as ext_shafer_shenoy
 from mbi.extensions.message_passing import project_to_coarse
 from mbi.extensions.message_passing import refine
 from mbi.factor import Factor
@@ -63,7 +63,7 @@ def _baseline_marginals(domain, cliques, potentials, constraints, total=10.0):
     )
 
 
-_ORACLES = [constrained_shafer_shenoy, constrained_implicit]
+_ORACLES = [ext_shafer_shenoy, ext_implicit]
 
 
 def _assert_matches_baseline(

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -13,8 +13,8 @@ from mbi.marginal_oracles import (
 )
 from mbi.constraint import Constraint
 from mbi.extensions.message_passing import (
-    constrained_shafer_shenoy,
-    constrained_implicit,
+    shafer_shenoy as ext_shafer_shenoy,
+    implicit as ext_implicit,
 )
 import jax.numpy as jnp
 import numpy as np
@@ -57,11 +57,11 @@ _implicit_fused = functools.partial(
     message_passing_implicit, contraction=einsum_fused
 )
 _implicit_constraints_materialized = functools.partial(
-    constrained_implicit,
+    ext_implicit,
     contraction=einsum_materialized,
 )
 _implicit_constraints_fused = functools.partial(
-    constrained_implicit,
+    ext_implicit,
     contraction=einsum_fused,
 )
 
@@ -76,7 +76,7 @@ _ORACLES = [
     _implicit_fused,
     message_passing_hugin,
     message_passing_shafer_shenoy,
-    constrained_shafer_shenoy,
+    ext_shafer_shenoy,
     _implicit_constraints_materialized,
     _implicit_constraints_fused,
     _variable_elimination_oracle,
@@ -88,7 +88,7 @@ _STABLE_ORACLES = [
     marginal_oracles.brute_force_marginals,
     marginal_oracles.message_passing_shafer_shenoy,
     message_passing_shafer_shenoy,
-    constrained_shafer_shenoy,
+    ext_shafer_shenoy,
 ]
 
 _DOMAIN = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
@@ -328,9 +328,9 @@ _CONSTRAINED_CLIQUE_SETS = [
 ]
 
 _CONSTRAINED_ORACLES = [
-    constrained_shafer_shenoy,
-    functools.partial(constrained_implicit, contraction=einsum_materialized),
-    functools.partial(constrained_implicit, contraction=einsum_fused),
+    ext_shafer_shenoy,
+    functools.partial(ext_implicit, contraction=einsum_materialized),
+    functools.partial(ext_implicit, contraction=einsum_fused),
 ]
 
 # Baseline oracles that accept constraints= and fold them as -inf potentials.


### PR DESCRIPTION
Rename `constrained_shafer_shenoy` → `shafer_shenoy` and `constrained_implicit` → `implicit` in `extensions/message_passing.py`.

Now that all core oracles accept `constraints=` (from #164), the `constrained_` prefix is misleading. The module path provides the namespace:

```python
from mbi.extensions.message_passing import shafer_shenoy, implicit
```

Also updates the module docstring to document how these differ from the core implementations:
1. **More efficient constraint handling** — O(|fine|) via coarsen/refine vs O(|fine| × |coarse|) potential materialization.
2. **AI-written, less well-tested** — kept separate until they mature enough to replace the originals.