### PR TITLE
Add configurable logging (default: print)

### DIFF
--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -30,6 +30,7 @@ if jax.config.jax_enable_compilation_cache:  # pylint: disable=no-member
     )
 
 from . import callbacks, estimation, extensions, junction_tree, marginal_oracles
+from .callbacks import set_log_fn
 from ._model_summary import ModelSummary, summarize
 from ._api import Model, Projectable
 from .estimation import Estimator
@@ -61,6 +62,7 @@ __all__ = [
     "Estimator",
     "ModelSummary",
     "summarize",
+    "set_log_fn",
     "estimation",
     "extensions",
     "callbacks",

--- a/src/mbi/callbacks.py
+++ b/src/mbi/callbacks.py
@@ -14,6 +14,19 @@ from .domain import Domain
 from .factor import Projectable
 from .marginal_loss import LinearMeasurement
 
+_log_fn = print
+
+
+def set_log_fn(fn):
+    """Override the library-wide log function (default: print)."""
+    global _log_fn
+    _log_fn = fn
+
+
+def log(*args, **kwargs):
+    """Log a message using the configured log function."""
+    _log_fn(*args, **kwargs)
+
 
 def _pad(string: str, length: int):
     """Pads a string with spaces on both sides to a target length."""
@@ -35,12 +48,12 @@ class Callback:
             header = "|".join(
                 [_pad(x, 12) for x in ["step", *self.loss_fns.keys()]]
             )
-            print(header)
-            print("=" * len(header))
+            log(header)
+            log("=" * len(header))
         row = [self.loss_fns[key](marginals) for key in self.loss_fns]
         self._logs.append([self._step] + row)
         padded_step = str(self._step) + " " * (9 - len(str(self._step)))
-        print(padded_step, *[f"{v:.6f}"[:6] for v in row], sep="   |   ")
+        log(padded_step, *[f"{v:.6f}"[:6] for v in row], sep="   |   ")
         self._step += 1
 
     @property


### PR DESCRIPTION
Add a lightweight logging abstraction so library output can be redirected without modifying source code.

By default, `mbi.log()` delegates to `print()`, preserving existing behavior. Override with `mbi.set_log_fn()`:

```python
import mbi
from absl import logging
mbi.set_log_fn(logging.info)  # redirect to Abseil
```

Or with stdlib logging:
```python
mbi.set_log_fn(logging.getLogger('mbi').info)
```

Or silence entirely:
```python
mbi.set_log_fn(lambda *a, **kw: None)
```

**Changes:**
- New `src/mbi/_logging.py`: `log()` and `set_log_fn()` (~30 lines)
- `callbacks.py`: `print()` → `log()`
- `__init__.py`: export `log`, `set_log_fn`