### PR TITLE
Estimator cleanup: warm_start, marginal_oracle default, Sequence types

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -20,7 +20,7 @@ import functools
 import math
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple
 
 import attr
@@ -66,7 +66,7 @@ class Estimator(ABC):
         * ``extensions.ReweightedDatasetEstimator``
     """
 
-    marginal_oracle: marginal_oracles.MarginalOracle | None
+    marginal_oracle: marginal_oracles.MarginalOracle | None = None
 
     # ------------------------------------------------------------------
     # Abstract interface — subclasses must implement
@@ -88,7 +88,7 @@ class Estimator(ABC):
         state: Any,
         loss_fn: MarginalLossFn,
         known_total: float,
-        constraints: tuple[Constraint, ...] = (),
+        constraints: Sequence[Constraint] = (),
     ) -> Any:
         """Perform one optimization step (or one scan block)."""
 
@@ -102,7 +102,7 @@ class Estimator(ABC):
     # Overridable hooks
     # ------------------------------------------------------------------
 
-    def _callback_value(self, state: Any, known_total: float) -> Any:  # pylint: disable=unused-argument
+    def _callback_value(self, state: Any, known_total: float, constraints=()) -> Any:  # pylint: disable=unused-argument
         """Extract the value to pass to ``callback_fn``.
 
         Default: ``state[0]`` (first element of the state tuple).
@@ -125,12 +125,19 @@ class Estimator(ABC):
         domain: Domain,
         loss_fn: MarginalLossFn | list[LinearMeasurement],
         known_total: float | None = None,
-        constraints: tuple[Constraint, ...] = (),
+        constraints: Sequence[Constraint] = (),
         iters: int = 1000,
         callback_fn: Callable | None = None,
+        warm_start: Model | None = None,
         **kwargs: Any,
     ) -> Model:
-        """Estimate a Model from noisy marginal measurements."""
+        """Estimate a Model from noisy marginal measurements.
+
+        If ``warm_start`` is provided, the estimator initializes from a
+        previously estimated model instead of from scratch.  For potential-based
+        estimators the model's potentials are expanded to cover any new cliques;
+        for MixtureOfProducts the model is used directly.
+        """
         constraints = tuple(constraints)
         if isinstance(loss_fn, list):
             if known_total is None:
@@ -150,14 +157,21 @@ class Estimator(ABC):
             )
 
         state = self._init(
-            domain, loss_fn, known_total, constraints=constraints, **kwargs
+            domain,
+            loss_fn,
+            known_total,
+            constraints=constraints,
+            warm_start=warm_start,
+            **kwargs,
         )
         # De-alias so that donate_argnames in _multi_step is safe.
         state = jax.tree.map(jnp.copy, state)
         for _ in range(math.ceil(iters / CALLBACK_EVERY)):
             state = self._multi_step(state, loss_fn, known_total, constraints)
             if callback_fn is not None:
-                callback_fn(self._callback_value(state, known_total))
+                callback_fn(
+                    self._callback_value(state, known_total, constraints)
+                )
         return self._finalize(state, known_total, constraints=constraints)
 
     @jax.jit(static_argnames=["self"], donate_argnames=["state"])
@@ -175,7 +189,7 @@ class Estimator(ABC):
         measurements: list[LinearMeasurement] | None = None,
         *,
         extra_cliques: list[tuple[str, ...]] | None = None,
-        constraints: tuple[Constraint, ...] = (),
+        constraints: Sequence[Constraint] = (),
     ) -> concurrent.futures.Future:
         """Warm up the JIT cache for ``estimate`` asynchronously.
 
@@ -354,9 +368,12 @@ class MirrorDescent(Estimator):
         known_total: float,
         *,
         potentials: CliqueVector | None = None,
+        warm_start=None,
         constraints=(),
     ) -> MirrorDescentState:
         """Initialize the optimization state."""
+        if warm_start is not None and potentials is None:
+            potentials = warm_start.potentials
         if potentials is None:
             potentials = CliqueVector.zeros(domain, loss_fn.cliques)
         else:
@@ -454,9 +471,12 @@ class DualAveraging(Estimator):
         known_total: float,
         *,
         potentials: CliqueVector | None = None,
+        warm_start=None,
         constraints=(),
     ) -> DualAveragingState:
         """Initialize the optimization state."""
+        if warm_start is not None and potentials is None:
+            potentials = warm_start.potentials
         if potentials is None:
             potentials = CliqueVector.zeros(domain, loss_fn.cliques)
         else:
@@ -508,6 +528,10 @@ class DualAveraging(Estimator):
         known_total: float,
         constraints=(),
     ) -> MarkovRandomField:
+        # Recover potentials from the weighted-average marginals via MLE.
+        # NOTE: warm_start from DA (and IG/UAM) uses these recovered
+        # potentials, not the internal averaging state — so it seeds a
+        # reasonable initial guess rather than exactly continuing.
         loss = marginal_loss.mle_loss_fn(state.w)
         est = LBFGS(marginal_oracle=self.marginal_oracle)
         return est.estimate(state.w.domain, loss, known_total, constraints)
@@ -540,9 +564,12 @@ class InteriorGradient(Estimator):
         known_total: float,
         *,
         potentials: CliqueVector | None = None,
+        warm_start=None,
         constraints=(),
     ) -> InteriorGradientState:
         """Initialize the optimization state."""
+        if warm_start is not None and potentials is None:
+            potentials = warm_start.potentials
         if potentials is None:
             potentials = CliqueVector.zeros(domain, loss_fn.cliques)
         else:
@@ -612,8 +639,17 @@ class LBFGS(Estimator):
     marginal_oracle: marginal_oracles.MarginalOracle | None = None
 
     def _init(
-        self, domain, loss_fn, known_total, *, potentials=None, constraints=()
+        self,
+        domain,
+        loss_fn,
+        known_total,
+        *,
+        potentials=None,
+        warm_start=None,
+        constraints=(),
     ):
+        if warm_start is not None and potentials is None:
+            potentials = warm_start.potentials
         if potentials is None:
             potentials = CliqueVector.zeros(domain, loss_fn.cliques)
         else:
@@ -649,9 +685,15 @@ class LBFGS(Estimator):
         potentials = optax.apply_updates(state.potentials, updates)
         return LBFGSState(potentials, opt_state)
 
-    def _callback_value(self, state, known_total):
+    def _callback_value(self, state, known_total, constraints=()):
+        # Unlike MD/DA/IG, LBFGSState stores only potentials (not marginals)
+        # to avoid an extra oracle call on every step.  Marginals are
+        # recomputed here on-demand since callbacks fire only every
+        # CALLBACK_EVERY steps.
         marginal_oracle = self._oracle(
-            state.potentials.cliques, state.potentials.domain
+            state.potentials.cliques,
+            state.potentials.domain,
+            constraints=constraints,
         )
         return marginal_oracle(state.potentials, known_total)
 
@@ -710,8 +752,17 @@ class UniversalAcceleratedMethod(Estimator):
     linesearch: bool = False
 
     def _init(
-        self, domain, loss_fn, known_total, *, potentials=None, constraints=()
+        self,
+        domain,
+        loss_fn,
+        known_total,
+        *,
+        potentials=None,
+        warm_start=None,
+        constraints=(),
     ):
+        if warm_start is not None and potentials is None:
+            potentials = warm_start.potentials
         if potentials is None:
             potentials = CliqueVector.zeros(domain, loss_fn.cliques)
         else:
@@ -822,7 +873,7 @@ class UniversalAcceleratedMethod(Estimator):
         carry = jax.lax.while_loop(cond_fun, body_fun, state)
         return carry._replace(accept=jnp.asarray(False))
 
-    def _callback_value(self, state, known_total):
+    def _callback_value(self, state, known_total, constraints=()):
         # Scale back to N-simplex for user-facing callbacks.
         return state.x * known_total
 

--- a/src/mbi/extensions/message_passing.py
+++ b/src/mbi/extensions/message_passing.py
@@ -19,7 +19,7 @@ Usage::
 from __future__ import annotations
 
 import collections
-import collections.abc
+from collections.abc import Callable, Sequence
 
 
 import jax
@@ -339,7 +339,7 @@ def shafer_shenoy(
     potentials: CliqueVector,
     total: float = 1,
     jtree: nx.Graph | None = None,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
     """Compute marginals using Shafer-Shenoy with constraint-aware shortcuts.
 
@@ -505,10 +505,8 @@ def implicit(
     total: float = 1,
     jtree: nx.Graph | None = None,
     *,
-    constraints: tuple[Constraint, ...] = (),
-    contraction: collections.abc.Callable = (
-        marginal_oracles.einsum_materialized
-    ),
+    constraints: Sequence[Constraint] = (),
+    contraction: Callable = marginal_oracles.einsum_materialized,
 ) -> CliqueVector:
     """Hybrid message passing: implicit for standard cliques, SS for constraints.
 

--- a/src/mbi/extensions/mixture_of_products.py
+++ b/src/mbi/extensions/mixture_of_products.py
@@ -162,11 +162,13 @@ class MixtureOfProductsEstimator(Estimator):
                 self, "optimizer", optax.adam(self.learning_rate)
             )
 
-    def _init(self, domain, loss_fn, known_total, **kwargs):
+    def _init(self, domain, loss_fn, known_total, *, warm_start=None, **kwargs):
         """Initialize model and optimizer state."""
         model = MixtureOfProducts.random(
             domain, known_total, self.num_components, self.seed
         )
+        if warm_start is not None:
+            model = warm_start
         opt_state = self.optimizer.init(model)
         return MixtureOfProductsState(model, opt_state)
 

--- a/src/mbi/extensions/reweighted_dataset.py
+++ b/src/mbi/extensions/reweighted_dataset.py
@@ -59,7 +59,7 @@ class ReweightedDatasetEstimator(Estimator):
         }
         object.__setattr__(self, "_jax_data", jax_data)
 
-    def _init(self, domain, loss_fn, known_total, **kwargs):
+    def _init(self, domain, loss_fn, known_total, *, warm_start=None, **kwargs):
         """Initialize log-weights and optimizer state."""
         log_weights = jnp.zeros(self.seed_data.records)
         opt_state = self.optimizer.init(log_weights)
@@ -84,7 +84,7 @@ class ReweightedDatasetEstimator(Estimator):
         log_weights = optax.apply_updates(state.log_weights, updates)
         return ReweightedDatasetState(log_weights, opt_state)
 
-    def _callback_value(self, state, known_total):
+    def _callback_value(self, state, known_total, constraints=()):
         weights = jax.nn.softmax(state.log_weights) * known_total
         return JaxDataset(self._jax_data, self.seed_data.domain, weights)
 

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -23,7 +23,7 @@ import itertools
 import math
 import string
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Protocol
 
 import jax
@@ -63,7 +63,7 @@ class MarginalOracle(Protocol):
         potentials: CliqueVector,
         total: float = 1.0,
         *,
-        constraints: tuple[Constraint, ...] = (),
+        constraints: Sequence[Constraint] = (),
     ) -> CliqueVector:
         """Compute marginals from potentials.
 
@@ -198,7 +198,7 @@ def einsum_fused(
 
 def _fold_constraints(
     potentials: CliqueVector,
-    constraints: tuple[Constraint, ...],
+    constraints: Sequence[Constraint],
 ) -> tuple[CliqueVector, tuple[tuple[str, ...], ...]]:
     """Fold constraints into potentials as -inf/0 log-space factors.
 
@@ -229,7 +229,7 @@ def message_passing_hugin(
     total: float = 1.0,
     jtree: nx.Graph | None = None,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
     """HUGIN message passing with belief subtraction.
@@ -289,7 +289,7 @@ def message_passing_shafer_shenoy(
     total: float = 1.0,
     jtree: nx.Graph | None = None,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
     """Shafer-Shenoy message passing with neighbor collection.
@@ -353,7 +353,7 @@ def message_passing_implicit(
     total: float = 1.0,
     jtree: nx.Graph | None = None,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
     contraction: Callable = einsum_materialized,
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
@@ -513,7 +513,7 @@ def brute_force_marginals(
     potentials: CliqueVector,
     total: float = 1,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
     """Compute marginals from (log-space) potentials by materializing the full joint distribution.
 
@@ -537,7 +537,7 @@ def einsum_marginals(
     total: float = 1,
     einsum_fn: Callable = jnp.einsum,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
     """Compute marginals from (log-space) potentials by using einsum.
 
@@ -585,7 +585,7 @@ def variable_elimination(
     total: float = 1,
     evidence: dict[str, int] | None = None,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
 ) -> Factor:
     """Compute an out-of-model/unsupported marginal from the potentials.
 
@@ -670,7 +670,7 @@ def bulk_variable_elimination(
     marginal_queries: list[tuple[str, ...]],
     total: float = 1.0,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
     """Compute the marginals of the graphical model with the given potentials.
 
@@ -716,7 +716,7 @@ def calculate_many_marginals(
     total: float = 1.0,
     belief_propagation_oracle: MarginalOracle = message_passing_stable,
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
     """Calculate marginals for all projections using belief propagation.
 
@@ -812,7 +812,7 @@ def kron_query(
     total: float = 1,
     suffix: str = "_answer",
     *,
-    constraints: tuple[Constraint, ...] = (),
+    constraints: Sequence[Constraint] = (),
 ) -> Factor:
     """Compute a Kronecker-product query.
 

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -174,14 +174,11 @@ class TestEstimation(unittest.TestCase):
         )
 
     @parameterized.expand([
-        (est,)
-        for est in [
-            estimation.MirrorDescent,
-            estimation.DualAveraging,
-            estimation.InteriorGradient,
-            estimation.LBFGS,
-            estimation.UniversalAcceleratedMethod,
-        ]
+        estimation.MirrorDescent,
+        estimation.DualAveraging,
+        estimation.InteriorGradient,
+        estimation.LBFGS,
+        estimation.UniversalAcceleratedMethod,
     ])
     def test_estimator_with_constraints(self, estimator_cls):
         """Estimator with constraints produces valid marginals."""
@@ -211,3 +208,86 @@ class TestEstimation(unittest.TestCase):
         np.testing.assert_allclose(
             model.project(("x",)).datavector().sum(), 1.0, atol=1e-4
         )
+
+    @parameterized.expand([
+        estimation.MirrorDescent,
+        estimation.DualAveraging,
+        estimation.InteriorGradient,
+        estimation.LBFGS,
+        estimation.UniversalAcceleratedMethod,
+    ])
+    def test_warm_start_expanding_cliques(self, estimator_cls):
+        """Warm-starting with new cliques produces a valid model."""
+        cliques1 = [("a", "b")]
+        measurements1 = fake_measurements(cliques1)
+
+        est = estimator_cls()
+        model1 = est.estimate(_DOMAIN, measurements1, known_total=1.0, iters=50)
+
+        # Round 2 adds a new clique.
+        cliques2 = [("a", "b"), ("b", "c")]
+        measurements2 = fake_measurements(cliques2)
+        model2 = est.estimate(
+            _DOMAIN,
+            measurements2,
+            known_total=1.0,
+            iters=50,
+            warm_start=model1,
+        )
+
+        np.testing.assert_allclose(
+            model2.project(("a",)).datavector().sum(), 1.0, atol=1e-4
+        )
+        # Model 2 should have the expanded clique set.
+        self.assertTrue(
+            set(cliques2).issubset(
+                {_DOMAIN.canonical(c) for c in model2.cliques}
+            )
+        )
+
+    def test_warm_start_legacy_potentials(self):
+        """Legacy potentials= kwarg still works for backwards compatibility."""
+        cliques = [("a", "b"), ("b", "c")]
+        measurements = fake_measurements(cliques)
+        loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+
+        est = estimation.MirrorDescent()
+        model1 = est.estimate(_DOMAIN, loss_fn, known_total=1.0, iters=50)
+
+        # Warm-start via legacy potentials= kwarg.
+        model2 = est.estimate(
+            _DOMAIN,
+            loss_fn,
+            known_total=1.0,
+            iters=50,
+            potentials=model1.potentials,
+        )
+
+        np.testing.assert_allclose(
+            model2.project(("a",)).datavector().sum(), 1.0, atol=1e-4
+        )
+
+    def test_warm_start_mixture_of_products(self):
+        """MixtureOfProducts warm-start reuses the model directly."""
+        from mbi.extensions.mixture_of_products import (
+            MixtureOfProductsEstimator,
+        )
+
+        cliques = [("a", "b"), ("b", "c")]
+        measurements = fake_measurements(cliques)
+        loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+
+        est = MixtureOfProductsEstimator(num_components=5)
+        model1 = est.estimate(_DOMAIN, loss_fn, known_total=1.0, iters=50)
+        loss1 = loss_fn(model1)
+
+        # Warm-starting should improve on the cold-start loss.
+        model2 = est.estimate(
+            _DOMAIN,
+            loss_fn,
+            known_total=1.0,
+            iters=50,
+            warm_start=model1,
+        )
+        loss2 = loss_fn(model2)
+        self.assertLessEqual(float(loss2), float(loss1) + 1e-6)


### PR DESCRIPTION
Cleanup PR tightening loose ends from the constraints refactor and adding warm-start support.

**Changes:**

1. **warm_start parameter on estimate()** — Initialize from a previously estimated Model instead of from scratch. For potential-based estimators, the model's potentials are expanded to cover new cliques. For MixtureOfProducts, the model is used directly. The old potentials= kwarg continues to work via **kwargs for backwards compatibility.

```python
est = MirrorDescent()
model1 = est.estimate(domain, measurements1, 100.0)
model2 = est.estimate(domain, measurements2, 100.0, warm_start=model1)
```

2. **marginal_oracle = None on parent Estimator** — fixes attrs field-ordering issues that made pytype complain on subclass constructors.

3. **Sequence[Constraint] everywhere** — changed all tuple[Constraint, ...] annotations to Sequence[Constraint] across estimation.py, marginal_oracles.py, and extensions/message_passing.py.

4. **Plumb constraints through _callback_value** — LBFGS now produces constraint-aware marginals in callbacks, with a comment explaining why it recomputes on-demand rather than storing marginals in state.

5. **Document DA/IG/UAM warm_start behavior** — these estimators recover potentials via LBFGS in _finalize, so warm_start seeds a reasonable initial guess rather than exactly continuing.

**Tests added:** 7 new tests covering warm_start across all 5 potential-based estimators, legacy potentials= backwards compat, and MixtureOfProducts warm_start.