### PR TITLE
Deprecate potentials= kwarg in favor of warm_start=model

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -156,6 +156,17 @@ class Estimator(ABC):
                 total=known_total,
             )
 
+        if "potentials" in kwargs:
+            import warnings
+
+            warnings.warn(
+                "Passing potentials= directly is deprecated. Use"
+                " warm_start=model instead, where model is a previously"
+                " estimated Model.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         state = self._init(
             domain,
             loss_fn,


### PR DESCRIPTION
Adds a `DeprecationWarning` when users pass `potentials=` directly to `estimate()`. The preferred API is `warm_start=model`, added in PR #172.

The old kwarg continues to work (forwarded to `_init` via `**kwargs`) but will be removed in a future release.

**Before:**
```python
model2 = est.estimate(domain, loss_fn, potentials=model1.potentials)
```

**After:**
```python
model2 = est.estimate(domain, loss_fn, warm_start=model1)
```