### PR TITLE
Add default_oracle to extensions.message_passing

### DIFF
--- a/src/mbi/extensions/message_passing.py
+++ b/src/mbi/extensions/message_passing.py
@@ -776,3 +776,40 @@ def _postprocess_log(result, constraint, post_op, original_target):
     if post_op == 'expand':
         return result
     raise ValueError(f'Unknown post_op: {post_op}')
+
+
+def default_oracle(
+    cliques: tuple[tuple[str, ...], ...] | None = None,
+    domain: Domain | None = None,
+    backend: str | None = None,
+) -> marginal_oracles.MarginalOracle:
+    """Select the best constraint-aware oracle for the given setting.
+
+    When constraints are present, this oracle uses the extensions
+    implementations which route messages through deterministic constraints
+    efficiently.  When no constraints are passed at call time, behavior is
+    identical to the core ``marginal_oracles.default_oracle``.
+
+    The selection heuristic mirrors the core oracle:
+
+    - **CPU**: ``shafer_shenoy`` (XLA compiler less effective on CPU).
+    - **GPU/TPU, large cliques (>= 1M)**: ``implicit``.
+    - **GPU/TPU, small cliques**: ``shafer_shenoy``.
+    """
+    if backend is None:
+        backend = jax.default_backend()
+
+    # CPU: always SS (XLA compiler less effective on CPU).
+    if backend == 'cpu':
+        return shafer_shenoy
+
+    # GPU/TPU with large cliques: implicit.
+    if cliques is not None and domain is not None:
+        jtree = junction_tree.make_junction_tree(domain, cliques)[0]
+        max_cliques = junction_tree.maximal_cliques(jtree)
+        max_size = max(domain.project(cl).size() for cl in max_cliques)
+        if max_size >= 1_000_000:
+            return implicit
+
+    # GPU/TPU with small cliques.
+    return shafer_shenoy


### PR DESCRIPTION
Adds a `default_oracle` function to `extensions.message_passing` that selects the best constraint-aware oracle for the given hardware and clique structure.

**Selection heuristic** (mirrors the core oracle):
- **CPU**: `extensions.shafer_shenoy`
- **GPU/TPU, large cliques (≥ 1M)**: `extensions.implicit`
- **GPU/TPU, small cliques**: `extensions.shafer_shenoy`

**Usage:**
```python
from mbi.extensions.message_passing import default_oracle

est = MirrorDescent(marginal_oracle=default_oracle(cliques, domain))
model = est.estimate(domain, measurements, constraints=[c])
```

This is an explicit opt-in — users who don't import from extensions never see the less-tested code. When no constraints are present at call time, the extensions oracles behave identically to the core ones. When constraints are present, they route messages through deterministic constraints efficiently via coarsen/refine operations.

1316 tests pass.