### PR TITLE
Refine default_oracle GPU heuristic based on systematic benchmarks

### DIFF
--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -459,12 +459,30 @@ def default_oracle(
     - **CPU**: ``message_passing_shafer_shenoy`` (has_constraints=True) or
       ``message_passing_hugin`` (has_constraints=False). Implicit is not used on
       CPU because the XLA compiler is less effective there.
-    - **GPU/TPU, large cliques (>= 1M)**: ``message_passing_implicit``
-      regardless of ``has_constraints`` (avoids materializing super-cliques).
+    - **GPU/TPU, memory-limited**: ``message_passing_implicit`` when the total
+      beliefs memory would exceed ~40% of estimated device HBM.  Implicit
+      keeps factors in their original low-dimensional form and only
+      materializes one super-clique at a time, using orders of magnitude
+      less memory than Hugin/SS which materialize all super-clique arrays
+      simultaneously.
+    - **GPU/TPU, huge but few super-cliques**: ``message_passing_implicit``
+      when individual super-cliques exceed 50M entries but there are fewer
+      than 30 nodes.  With few messages, implicit moves less data per
+      message by contracting small input factors rather than operating on
+      huge belief arrays.
     - **GPU/TPU, has_constraints=True** (default):
       ``message_passing_shafer_shenoy`` (numerically robust).
     - **GPU/TPU, has_constraints=False**: ``message_passing_hugin`` (faster when
       ``-inf`` is absent).
+
+    The heuristic is based on systematic A100 benchmarks across varied
+    graph structures (cardinality 4-256, bandwidth 1-3, 32-256 attributes).
+    When super-cliques are large but the junction tree has many nodes, Hugin
+    and Shafer-Shenoy outperform implicit by 30-40% because their uniform
+    add/logsumexp kernel pattern fuses better in XLA over many sequential
+    messages.  Implicit only wins when individual super-cliques are very
+    large (>50M entries) and the tree is small (<30 nodes), or when
+    Hugin/SS would exceed device memory.
 
     Args:
         cliques: Cliques of the graphical model. Used to estimate max clique
@@ -495,15 +513,32 @@ def default_oracle(
             return message_passing_shafer_shenoy
         return message_passing_hugin
 
-    # GPU/TPU with large cliques: implicit regardless of has_constraints.
+    # GPU/TPU: consider memory pressure and per-message data movement.
     if cliques is not None and domain is not None:
         jtree = junction_tree.make_junction_tree(domain, cliques)[0]
         max_cliques = junction_tree.maximal_cliques(jtree)
-        max_size = max(domain.project(cl).size() for cl in max_cliques)
-        if max_size >= 1_000_000:
+        sc_sizes = [domain.project(cl).size() for cl in max_cliques]
+        max_size = max(sc_sizes)
+        num_nodes = len(max_cliques)
+
+        # Estimate total beliefs memory for Hugin/SS (4 bytes per float32).
+        total_beliefs_bytes = sum(sc_sizes) * 4
+
+        # Memory-limited: use implicit to avoid OOM.  The 40% threshold
+        # leaves room for messages, temporaries, and JAX runtime overhead.
+        # Estimate 80 GB for A100; could be refined per device.
+        estimated_hbm = 80e9
+        if total_beliefs_bytes > estimated_hbm * 0.4:
             return message_passing_implicit
 
-    # GPU/TPU with small cliques.
+        # Few large super-cliques: implicit wins on data movement.
+        # With <30 SC nodes there are few messages, so kernel launch overhead
+        # is negligible, and implicit contracts small input factors instead
+        # of operating on huge belief arrays.
+        if max_size >= 50_000_000 and num_nodes < 30:
+            return message_passing_implicit
+
+    # GPU/TPU with moderate cliques: SS for constraints, Hugin otherwise.
     if has_constraints:
         return message_passing_shafer_shenoy
     return message_passing_hugin

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -274,11 +274,32 @@ class TestDefaultOracle(unittest.TestCase):
         )
         self.assertIs(oracle, message_passing_shafer_shenoy)
 
-    def test_gpu_large_returns_implicit(self):
+    def test_gpu_moderate_returns_shafer_shenoy(self):
+        """1M clique no longer triggers implicit (old threshold)."""
         domain = Domain(["a", "b", "c"], [100, 100, 100])
         cliques = (("a", "b", "c"),)
         oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
+        self.assertIs(oracle, message_passing_shafer_shenoy)
+
+    def test_gpu_huge_few_nodes_returns_implicit(self):
+        """Huge SCs (>50M) with few JT nodes -> implicit (data movement)."""
+        # 3 attrs with card ~370 each -> single 3-way clique ~ 50.6M entries.
+        domain = Domain(["a", "b", "c"], [370, 370, 370])
+        cliques = (("a", "b", "c"),)
+        oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
         self.assertIs(oracle, message_passing_implicit)
+
+    def test_gpu_huge_many_nodes_returns_shafer_shenoy(self):
+        """Huge SCs but many JT nodes -> SS (kernel fusion advantage)."""
+        # 40 attrs in a chain, card=100 each, bw=2 -> max SC=1M, 39 nodes.
+        attrs = [f"x{i}" for i in range(40)]
+        domain = Domain(attrs, [100] * 40)
+        cliques = tuple(
+            (attrs[i], attrs[i + 1], attrs[i + 2]) for i in range(38)
+        )
+        oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
+        # Max SC = 100^3 = 1M < 50M, many nodes -> SS.
+        self.assertIs(oracle, message_passing_shafer_shenoy)
 
     def test_gpu_no_cliques_returns_shafer_shenoy(self):
         oracle = marginal_oracles.default_oracle(backend="gpu")


### PR DESCRIPTION
## Summary

The previous `default_oracle` heuristic selected `message_passing_implicit` for any super-clique with >= 1M entries. Systematic A100 benchmarks across 14 configurations (cardinality 4–256, bandwidth 1–3, 32–256 attributes) showed that **implicit is never the fastest oracle at moderate scales** where Hugin/SS fit in memory.

## Benchmark Findings

### Cardinality sweep (128 attrs, bw=2)

| Card | Max SC | Hugin (ms) | Implicit (ms) | SS (ms) | Best |
|------|--------|-----------|--------------|---------|------|
| 4 | 64 | **4.45** | 11.98 | 7.94 | hugin |
| 64 | 262K | **12.61** | 22.52 | 14.49 | hugin |
| 128 | 2M | **20.42** | 38.77 | 27.08 | hugin |
| 256 | 16.8M | 80.57 | 87.88 | **61.47** | SS |

### Bandwidth sweep (128 attrs, card=64)

| BW | Max SC | Hugin (ms) | Implicit (ms) | SS (ms) | Best |
|----|--------|-----------|--------------|---------|------|
| 1 | 4K | **15.55** | 35.01 | 27.54 | hugin |
| 3 | 16.8M | 86.26 | 118.76 | **74.06** | SS |

**Key finding**: implicit only wins when individual SCs are very large (>50M entries) AND the junction tree has few nodes (<30), as demonstrated in prior benchmarks (xid/265490471: 19 cliques, 55M max SC → implicit 1.7× faster than hugin/SS).

## The 2D Decision Space

The crossover depends on both SC size and junction tree node count:

|  | Few nodes (<30) | Many nodes (>30) |
|--|---|---|
| **SC < 50M** | SS/hugin | SS/hugin |
| **SC >= 50M** | **implicit** | SS/hugin |
| **Total memory > 40% HBM** | **implicit** | **implicit** |

## Changes

The new heuristic uses two criteria instead of a single threshold:

1. **Memory pressure**: if total beliefs memory would exceed ~40% of estimated device HBM (80 GB for A100), use implicit to avoid OOM.
2. **Data movement**: if individual SCs are very large (>= 50M entries) but the tree has few nodes (< 30), use implicit for its per-message data movement advantage.

Otherwise, fall back to SS (with constraints) or Hugin (without), which outperform implicit by 30–40% for moderate-to-large junction trees.

## Tests

Updated `TestDefaultOracle`:
- `test_gpu_moderate_returns_shafer_shenoy`: 1M clique no longer triggers implicit
- `test_gpu_huge_few_nodes_returns_implicit`: 50.6M SC with 1 node → implicit
- `test_gpu_huge_many_nodes_returns_shafer_shenoy`: 1M SC with 39 nodes → SS