### PR TITLE
Widen Clique type to allow integer attribute names

### DIFF
--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -35,6 +35,7 @@ from ._model_summary import ModelSummary, summarize
 from ._api import Model, Projectable
 from .estimation import Estimator
 from .extensions import message_passing
+from .clique_utils import Clique
 from .clique_vector import CliqueVector
 from .constraint import Constraint
 from .dataset import Dataset
@@ -45,8 +46,6 @@ from .marginal_loss import NormalizedQuery, SlicedQuery, WeightedQuery
 from .marginal_oracles import MarginalOracle
 from .markov_random_field import MarkovRandomField
 from ._serialization import save, load
-
-Clique = tuple[str, ...]
 
 __all__ = [
     "Constraint",

--- a/src/mbi/_model_summary.py
+++ b/src/mbi/_model_summary.py
@@ -10,13 +10,12 @@ import jax
 import networkx as nx
 
 from . import junction_tree, marginal_oracles
+from .clique_utils import Clique
 from .clique_vector import CliqueVector
 from .domain import Domain
 
 if TYPE_CHECKING:
     from .marginal_oracles import MarginalOracle
-
-Clique = tuple[str, ...]
 
 
 def _fmt_size(n: int | float) -> str:

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import functools
 import itertools
-from typing import Any, NamedTuple, Protocol, TypeAlias
+from typing import Any, NamedTuple, Protocol
 
 import dataclasses
 import jax
@@ -26,12 +26,11 @@ from scipy.cluster.hierarchy import DisjointSet
 
 from . import estimation
 from . import marginal_loss
+from .clique_utils import Clique
 from .clique_vector import CliqueVector
 from .domain import Domain
 from .factor import Factor
 from .marginal_loss import LinearMeasurement
-
-Clique: TypeAlias = tuple[str, ...]
 
 # pylint: disable
 

--- a/src/mbi/clique_utils.py
+++ b/src/mbi/clique_utils.py
@@ -3,7 +3,7 @@
 This module provides helper functions for common operations on cliques,
 such as finding maximal subsets and creating mappings between cliques and
 their maximal counterparts. Cliques are typically represented as tuples of
-attribute names (strings).
+attribute names, which may be strings or integers.
 """
 
 import itertools
@@ -12,7 +12,9 @@ from typing import TypeAlias
 
 from .domain import Domain
 
-Clique: TypeAlias = tuple[str, ...]
+# Attribute names are usually strings, but integers are also supported (e.g. for
+# referring to columns by position). Only hashability and equality are required.
+Clique: TypeAlias = tuple[str | int, ...]
 
 
 def powerset(iterable: Iterable) -> Iterator[tuple]:

--- a/src/mbi/junction_tree.py
+++ b/src/mbi/junction_tree.py
@@ -10,14 +10,12 @@ computing greedy elimination orders, and estimating model size.
 import itertools
 from collections import OrderedDict
 from collections.abc import Collection, Sequence
-from typing import TypeAlias
 
 import networkx as nx
 import numpy as np
 
+from .clique_utils import Clique
 from .domain import Domain
-
-Clique: TypeAlias = tuple[str, ...]
 
 
 def maximal_cliques(junction_tree: nx.Graph) -> list[Clique]:

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -31,7 +31,7 @@ import jax.numpy as jnp
 import networkx as nx
 
 from . import junction_tree
-from .clique_utils import clique_mapping
+from .clique_utils import Clique, clique_mapping
 from .clique_vector import CliqueVector
 from .constraint import Constraint
 from .domain import Domain
@@ -611,9 +611,6 @@ def einsum_marginals(
     )
 
 
-Clique = tuple[str, ...]
-
-
 def variable_elimination(
     potentials: CliqueVector,
     clique: Clique,
@@ -753,9 +750,7 @@ def calculate_many_marginals(
     conditional = {}
     for Ci in max_cliques:
         for Cj in neighbors[Ci]:
-            Cj: tuple[
-                str, ...
-            ]  # networkx does not seem to have the right type annotation.
+            Cj: Clique  # networkx lacks a precise type annotation.
             Sij = tuple(set(Cj) & set(Ci))
             Z = marginals.project(Cj)
             Z_sep = Z.project(Sij)


### PR DESCRIPTION
## Summary

Widens the canonical `Clique` type alias from `tuple[str, ...]` to `tuple[str | int, ...]`, and consolidates four duplicate definitions into a single source of truth in `clique_utils.py`.

## Motivation

`mbi` already supports non-string (e.g. integer) attribute names **at runtime**:
- `Domain` uses attributes only as hashable dict keys (uniqueness is the only constraint).
- `Factor` contraction uses `dot_general` (integer axes), not letter-based `einsum` subscripts, so there is no hidden single-character-string requirement.

First-party consumers such as **dpsynth** rely on integer column indices for performance — real column names can be large nested proto-field paths, so cliques index columns by position instead. The mismatch was purely a **static type** error surfaced during import; runtime behavior was always correct.

## Changes

- `clique_utils.py`: widen the canonical alias to `tuple[str | int, ...]`.
- Consolidate 4 redundant `Clique = tuple[str, ...]` definitions (in `__init__.py`, `marginal_oracles.py`, `_model_summary.py`, `junction_tree.py`, `approximate_oracles.py`) to import from `clique_utils`.
- Fix an internal hardcoded `tuple[str, ...]` annotation (networkx workaround in `calculate_many_marginals`) to use the `Clique` alias.

## Verification

All CI checks pass locally: pyink, flake8, pylint (9.84/10), pydocstyle, pytype, pytest (1319 passed), doctest (12 passed).