### PR TITLE
Accept array-likes in LinearMeasurement annotations

### DIFF
--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -16,6 +16,7 @@ from typing import Any
 import chex
 import jax
 import jax.numpy as jnp
+from jax.typing import ArrayLike
 import numpy as np
 import optax
 
@@ -98,10 +99,10 @@ class LinearMeasurement:
         a vector with the same shape and interpretation as `noisy_measurement`.
     """
 
-    noisy_measurement: jax.Array
+    noisy_measurement: ArrayLike
     clique: Clique = jax.tree.static()
     stddev: float = jax.tree.static(default=1.0)
-    query: Callable[[Factor], jax.Array] = jax.tree.static(
+    query: Callable[[Factor], ArrayLike] = jax.tree.static(
         default=DatavectorQuery()
     )
 


### PR DESCRIPTION
## Summary

Widens the `noisy_measurement` and `query` return-type annotations on `LinearMeasurement` from `jax.Array` to `jax.typing.ArrayLike`.

## Motivation

`LinearMeasurement` accepts numpy arrays at runtime — jax operations coerce array-likes transparently, and internal code already calls `np.asarray(self.noisy_measurement)`. But the annotations declared `jax.Array`, which rejects `np.ndarray` (and numpy-returning query callables) at type-check time.

First-party consumers such as **dpsynth** construct measurements directly from numpy arrays (e.g. `np.zeros(...)`) and pass numpy-returning query functions, triggering spurious `wrong-arg-types` errors during import. This is the same class of issue as #184 (Clique widening): the annotation was narrower than the actual runtime contract.

## Changes

- `noisy_measurement: jax.Array` → `ArrayLike`
- `query: Callable[[Factor], jax.Array]` → `Callable[[Factor], ArrayLike]`

## Verification

All CI checks pass locally: pyink, flake8, pytype, pytest (1319 passed), doctest (12 passed).