### PR TITLE
Migrate type checking from pytype to pyrefly (phase 0)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,4 +74,4 @@ jobs:
 
       - name: Type checking
         run: |
-          pytype src/mbi/*.py
+          pyrefly check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Repository = "https://github.com/ryan112358/mbi"
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pytype",
+    "pyrefly",
     "parameterized",
     "pyink",
     "pylint",
@@ -61,5 +61,6 @@ pyink-annotation-pragmas = [
     "pylint:",
     "type: ignore",
     "pytype:",
+    "pyrefly:",
     "mypy:",
 ]

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,10 @@
+# Pyrefly type-checker configuration.
+# See https://pyrefly.org/en/docs/configuration/
+#
+# We start on the "basic" preset, which matches the set of checks that the
+# project passed under pytype. Stricter presets ("default", "strict") surface
+# additional findings that are being addressed incrementally; see the
+# migration notes in the PR that introduced pyrefly.
+project-includes = ["src/mbi/**/*.py"]
+python-version = "3.11"
+preset = "basic"


### PR DESCRIPTION
## Summary

Phase 0 of migrating the repo's type checker from **pytype** to **pyrefly** — a fast, Rust-based type checker (Meta's successor to Pyre) with an LSP server for editor integration.

This is a **zero-behavior-change swap**: pyrefly's `basic` preset reports the same clean result (**0 errors**) that the project already passed under pytype, so CI stays green.

## Changes

- Add `pyrefly.toml` pinning the `basic` preset and Python 3.11 (reproducible CI result).
- Swap the CI type-checking step: `pytype src/mbi/*.py` → `pyrefly check`.
- Swap the dev dependency: `pytype` → `pyrefly`.
- Register the `pyrefly:` annotation pragma with pyink.

## Why phased

Pyrefly's stricter presets surface additional findings (`default`: ~110, `strict`: ~419) — a mix of genuine latent bugs, third-party stub gaps, and annotation-tightness issues. These will be addressed incrementally in follow-up PRs so each change stays small and reviewable. Starting on `basic` gives contributors pyrefly's speed and editor integration immediately without a big up-front cleanup.

## Verification

`pyrefly check` (reading `pyrefly.toml`): **0 errors**. Existing lint/test/doctest CI steps are unchanged.