### PR TITLE
Fix latent unbound-variable bugs surfaced by pyrefly

### DIFF
--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -232,18 +232,19 @@ def convex_generalized_belief_propagation(
             for r in children[p]:
                 messages[p, r] = rho * messages[p, r] + (1.0 - rho) * new[p, r]
                 messages[r, p] = rho * messages[r, p] + (1.0 - rho) * new[r, p]
-        mu = {}
-        for r in cliques:
-            mu[r] = (
-                (
-                    pot[r]
-                    + sum(messages[c, r] for c in children[r])
-                    - sum(messages[r, p] for p in parents[r])
-                )
-                .normalize(total, log=True)
-                .exp()
-                .apply_sharding(mesh)
+
+    mu = {}
+    for r in cliques:
+        mu[r] = (
+            (
+                pot[r]
+                + sum(messages[c, r] for c in children[r])
+                - sum(messages[r, p] for p in parents[r])
             )
+            .normalize(total, log=True)
+            .exp()
+            .apply_sharding(mesh)
+        )
 
     return CliqueVector(domain, cliques, mu), messages
 

--- a/src/mbi/experimental/public_support.py
+++ b/src/mbi/experimental/public_support.py
@@ -67,7 +67,7 @@ def _to_clique_vector(data, cliques):
         dom = data.domain.project(cl)
         vals = data.project(cl).datavector(flatten=False)
         arrays[cl] = Factor(dom, vals)
-    return CliqueVector(dom, cliques, arrays)
+    return CliqueVector(data.domain, cliques, arrays)
 
 
 def public_support(

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -148,11 +148,10 @@ class MarkovRandomField:
                     return_counts=True,
                 )
 
+                perm = np.argsort(inverse, kind="stable")
                 if method == "sample":
                     u = np.random.rand(total)
                 else:
-                    perm = np.argsort(inverse, kind="stable")
-
                     group_starts = np.zeros(len(counts), dtype=int)
                     np.cumsum(counts[:-1], out=group_starts[1:])
 
@@ -182,9 +181,6 @@ class MarkovRandomField:
                     total, dtype=np.min_scalar_type(self.domain[col])
                 )
                 domain_size = self.domain[col]
-
-                if method == "sample":
-                    perm = np.argsort(inverse, kind="stable")
 
                 u_sorted = u[perm]
 


### PR DESCRIPTION
## Summary

Phase 1 of the pyrefly migration: fix genuine latent bugs that pyrefly's stricter analysis surfaced but pytype never caught. These are independently valuable and unrelated to the checker swap itself (#186).

Pyrefly flagged three `unbound-name` "may be uninitialized" cases; two are real bugs.

## Fixes

### `approximate_oracles.py` — `convex_gbp` (real bug)
The pseudo-marginal dict `mu` was computed *inside* the message-passing loop, so calling with `iters=0` raised `UnboundLocalError` at the `return`. `mu` only depends on the final `messages` state, so it's hoisted out of the loop — behavior-preserving for `iters>=1`, correct for `iters=0`, and avoids redundant recomputation each iteration.

### `public_support.py` — `_to_clique_vector` (real bug)
The `CliqueVector` was constructed with `dom` — the projected sub-domain of the *last* clique, leaked from the loop — instead of the full `data.domain`. `CliqueVector.domain` is documented as "the overall domain that encompasses all cliques." Passing a single clique's sub-domain is incorrect.

### `markov_random_field.py` — `_generate_data` (cleanup / false positive)
Hoisted the common `perm = np.argsort(inverse, kind="stable")` above the `sample`/`else` branch. It was already computed in both paths, so this removes a redundant `argsort` and resolves the warning. `argsort` does not consume numpy RNG state, so sampling output is unchanged.

## Verification

1319 tests + 12 doctests pass; pyink, flake8, pylint (9.84/10), pydocstyle all clean.