### PR TITLE
Switch to 2-space indentation (Google style)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Check formatting with pyink
         run: |
-          pyink --check --diff src test mechanisms examples
+          pyink --check --diff src test
+          pyink --check --diff --pyink-indentation=4 mechanisms examples
 
       - name: Lint with flake8
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ where = ["src"]
 [tool.pyink]
 line-length = 80
 unstable = true
-pyink-indentation = 4
+pyink-indentation = 2
 pyink-use-majority-quotes = true
 pyink-annotation-pragmas = [
     "noqa",

--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -11,23 +11,23 @@ import warnings
 import jax
 
 if not jax.config.jax_enable_x64:  # pylint: disable=no-member
-    warnings.warn(
-        "JAX is running in float32 mode. For large datasets (N > 100K),"
-        " this can cause estimation algorithms to stall or diverge due to"
-        " insufficient floating-point precision. Enable float64 with:"
-        ' jax.config.update("jax_enable_x64", True)',
-        stacklevel=1,
-    )
+  warnings.warn(
+      "JAX is running in float32 mode. For large datasets (N > 100K),"
+      " this can cause estimation algorithms to stall or diverge due to"
+      " insufficient floating-point precision. Enable float64 with:"
+      ' jax.config.update("jax_enable_x64", True)',
+      stacklevel=1,
+  )
 
 if jax.config.jax_enable_compilation_cache:  # pylint: disable=no-member
-    warnings.warn(
-        "JAX persistent compilation cache is enabled. MBI generates many"
-        " small compiled programs, which makes the cache counterproductive"
-        " — especially when running sweeps of experiments that all write"
-        " to the same cache location. Consider disabling it with:"
-        ' jax.config.update("jax_enable_compilation_cache", False)',
-        stacklevel=1,
-    )
+  warnings.warn(
+      "JAX persistent compilation cache is enabled. MBI generates many"
+      " small compiled programs, which makes the cache counterproductive"
+      " — especially when running sweeps of experiments that all write"
+      " to the same cache location. Consider disabling it with:"
+      ' jax.config.update("jax_enable_compilation_cache", False)',
+      stacklevel=1,
+  )
 
 from . import callbacks, estimation, extensions, junction_tree, marginal_oracles
 from .callbacks import set_log_fn

--- a/src/mbi/_api.py
+++ b/src/mbi/_api.py
@@ -12,50 +12,50 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from .dataset import Dataset
-    from .domain import Domain
-    from .factor import Factor
+  from .dataset import Dataset
+  from .domain import Domain
+  from .factor import Factor
 
 
 class Projectable(Protocol):
-    """An object whose marginals can be computed over subsets of attributes.
+  """An object whose marginals can be computed over subsets of attributes.
 
-    Example projectables:
-        * Dataset
-        * Factor
-        * CliqueVector
-        * MarkovRandomField
-        * MixtureOfProducts
-        * JaxDataset
-    """
+  Example projectables:
+      * Dataset
+      * Factor
+      * CliqueVector
+      * MarkovRandomField
+      * MixtureOfProducts
+      * JaxDataset
+  """
 
-    @property
-    def domain(self) -> Domain:
-        """Returns the domain over which this projectable is defined."""
+  @property
+  def domain(self) -> Domain:
+    """Returns the domain over which this projectable is defined."""
 
-    def project(self, attrs: str | Sequence[str]) -> Factor:
-        """Projection onto a subset of attributes."""
+  def project(self, attrs: str | Sequence[str]) -> Factor:
+    """Projection onto a subset of attributes."""
 
-    def supports(self, attrs: str | Sequence[str]) -> bool:
-        """Returns true if the given attributes can be projected onto."""
+  def supports(self, attrs: str | Sequence[str]) -> bool:
+    """Returns true if the given attributes can be projected onto."""
 
 
 class Model(Projectable, Protocol):
-    """A fitted distribution that supports marginal queries and synthetic data.
+  """A fitted distribution that supports marginal queries and synthetic data.
 
-    All estimation functions return a Model.  Unlike a bare Projectable,
-    a Model can also generate synthetic tabular data that is consistent
-    with the learned distribution.
+  All estimation functions return a Model.  Unlike a bare Projectable,
+  a Model can also generate synthetic tabular data that is consistent
+  with the learned distribution.
 
-    Example models:
-        * MarkovRandomField
-        * MixtureOfProducts
-        * JaxDataset (with weights)
-    """
+  Example models:
+      * MarkovRandomField
+      * MixtureOfProducts
+      * JaxDataset (with weights)
+  """
 
-    @property
-    def total(self) -> float:
-        """The total count (number of records) represented by the model."""
+  @property
+  def total(self) -> float:
+    """The total count (number of records) represented by the model."""
 
-    def synthetic_data(self, rows: int | None = None) -> Dataset:
-        """Generate synthetic tabular data from the model."""
+  def synthetic_data(self, rows: int | None = None) -> Dataset:
+    """Generate synthetic tabular data from the model."""

--- a/src/mbi/_model_summary.py
+++ b/src/mbi/_model_summary.py
@@ -15,163 +15,151 @@ from .clique_vector import CliqueVector
 from .domain import Domain
 
 if TYPE_CHECKING:
-    from .marginal_oracles import MarginalOracle
+  from .marginal_oracles import MarginalOracle
 
 
 def _fmt_size(n: int | float) -> str:
-    """Format a number of cells as a human-readable string."""
-    if n >= 1e9:
-        return f"{n / 1e9:.2f}B"
-    if n >= 1e6:
-        return f"{n / 1e6:.2f}M"
-    if n >= 1e3:
-        return f"{n / 1e3:.2f}K"
-    return str(n)
+  """Format a number of cells as a human-readable string."""
+  if n >= 1e9:
+    return f"{n / 1e9:.2f}B"
+  if n >= 1e6:
+    return f"{n / 1e6:.2f}M"
+  if n >= 1e3:
+    return f"{n / 1e3:.2f}K"
+  return str(n)
 
 
 def _fmt_bytes(nbytes: int) -> str:
-    """Format a byte count as a human-readable string."""
-    if nbytes >= 2**30:
-        return f"{nbytes / 2**30:.2f} GiB"
-    if nbytes >= 2**20:
-        return f"{nbytes / 2**20:.2f} MiB"
-    if nbytes >= 2**10:
-        return f"{nbytes / 2**10:.2f} KiB"
-    return f"{nbytes} B"
+  """Format a byte count as a human-readable string."""
+  if nbytes >= 2**30:
+    return f"{nbytes / 2**30:.2f} GiB"
+  if nbytes >= 2**20:
+    return f"{nbytes / 2**20:.2f} MiB"
+  if nbytes >= 2**10:
+    return f"{nbytes / 2**10:.2f} KiB"
+  return f"{nbytes} B"
 
 
 @dataclasses.dataclass(frozen=True)
 class ModelSummary:
-    """Structured summary of a model's clique and junction tree structure."""
+  """Structured summary of a model's clique and junction tree structure."""
 
-    num_attributes: int
-    domain_size: int
-    num_cliques: int
-    largest_clique: Clique
-    largest_clique_size: int
-    total_clique_cells: int
-    treewidth: int
-    num_jtree_nodes: int
-    largest_jtree_node: Clique
-    largest_jtree_node_size: int
-    total_jtree_cells: int
-    num_messages: int
-    largest_message: Clique
-    largest_message_size: int
-    total_message_cells: int
-    bytes_per_cell: int
-    xla_flops: int | None = None
-    xla_transcendentals: int | None = None
-    xla_bytes_accessed: int | None = None
-    xla_arg_bytes: int | None = None
-    xla_output_bytes: int | None = None
-    xla_temp_bytes: int | None = None
+  num_attributes: int
+  domain_size: int
+  num_cliques: int
+  largest_clique: Clique
+  largest_clique_size: int
+  total_clique_cells: int
+  treewidth: int
+  num_jtree_nodes: int
+  largest_jtree_node: Clique
+  largest_jtree_node_size: int
+  total_jtree_cells: int
+  num_messages: int
+  largest_message: Clique
+  largest_message_size: int
+  total_message_cells: int
+  bytes_per_cell: int
+  xla_flops: int | None = None
+  xla_transcendentals: int | None = None
+  xla_bytes_accessed: int | None = None
+  xla_arg_bytes: int | None = None
+  xla_output_bytes: int | None = None
+  xla_temp_bytes: int | None = None
 
-    @property
-    def memory_bytes(self) -> int:
-        return (
-            self.total_jtree_cells + self.total_message_cells
-        ) * self.bytes_per_cell
+  @property
+  def memory_bytes(self) -> int:
+    return (
+        self.total_jtree_cells + self.total_message_cells
+    ) * self.bytes_per_cell
 
-    @property
-    def short(self) -> str:
-        """One-line summary: potentials, junction tree, and messages size."""
-        pot_bytes = self.total_clique_cells * self.bytes_per_cell
-        msg_bytes = self.total_message_cells * self.bytes_per_cell
-        return (
-            f"potentials={_fmt_bytes(pot_bytes)},"
-            f" jtree={_fmt_bytes(self.total_jtree_cells * self.bytes_per_cell)},"
-            f" messages={_fmt_bytes(msg_bytes)}"
-        )
+  @property
+  def short(self) -> str:
+    """One-line summary: potentials, junction tree, and messages size."""
+    pot_bytes = self.total_clique_cells * self.bytes_per_cell
+    msg_bytes = self.total_message_cells * self.bytes_per_cell
+    return (
+        f"potentials={_fmt_bytes(pot_bytes)},"
+        f" jtree={_fmt_bytes(self.total_jtree_cells * self.bytes_per_cell)},"
+        f" messages={_fmt_bytes(msg_bytes)}"
+    )
 
-    def __str__(self) -> str:
-        dtype_name = {4: "float32", 8: "float64"}.get(
-            self.bytes_per_cell, f"{self.bytes_per_cell}B"
-        )
-        lines = [
-            "=== Model Summary ===",
-            "",
-            (
-                f"Domain: {self.num_attributes} attributes, "
-                f"{_fmt_size(self.domain_size)} total cells"
-            ),
-            "",
-            "Cliques:",
-            f"  Input:    {self.num_cliques}",
-            (
-                f"  Largest:  {_fmt_size(self.largest_clique_size)} cells "
-                f"({self.largest_clique})"
-            ),
-            f"  Total:    {_fmt_size(self.total_clique_cells)} cells",
-            "",
-            "Junction Tree:",
-            f"  Treewidth: {self.treewidth}",
-            f"  Nodes:     {self.num_jtree_nodes}",
-            (
-                f"  Largest:   {_fmt_size(self.largest_jtree_node_size)} cells "
-                f"({self.largest_jtree_node})"
-            ),
-            f"  Total:     {_fmt_size(self.total_jtree_cells)} cells",
-            "",
-        ]
+  def __str__(self) -> str:
+    dtype_name = {4: "float32", 8: "float64"}.get(
+        self.bytes_per_cell, f"{self.bytes_per_cell}B"
+    )
+    lines = [
+        "=== Model Summary ===",
+        "",
+        (
+            f"Domain: {self.num_attributes} attributes, "
+            f"{_fmt_size(self.domain_size)} total cells"
+        ),
+        "",
+        "Cliques:",
+        f"  Input:    {self.num_cliques}",
+        (
+            f"  Largest:  {_fmt_size(self.largest_clique_size)} cells "
+            f"({self.largest_clique})"
+        ),
+        f"  Total:    {_fmt_size(self.total_clique_cells)} cells",
+        "",
+        "Junction Tree:",
+        f"  Treewidth: {self.treewidth}",
+        f"  Nodes:     {self.num_jtree_nodes}",
+        (
+            f"  Largest:   {_fmt_size(self.largest_jtree_node_size)} cells "
+            f"({self.largest_jtree_node})"
+        ),
+        f"  Total:     {_fmt_size(self.total_jtree_cells)} cells",
+        "",
+    ]
 
-        if self.num_messages > 0:
-            lines += [
-                "Messages:",
-                f"  Edges:   {self.num_messages}",
-                (
-                    f"  Largest: {_fmt_size(self.largest_message_size)} cells "
-                    f"({self.largest_message})"
-                ),
-                (
-                    "  Total:   "
-                    f"{_fmt_size(self.total_message_cells)} cells "
-                    "(x2 directions)"
-                ),
-                "",
-            ]
+    if self.num_messages > 0:
+      lines += [
+          "Messages:",
+          f"  Edges:   {self.num_messages}",
+          (
+              f"  Largest: {_fmt_size(self.largest_message_size)} cells "
+              f"({self.largest_message})"
+          ),
+          (
+              "  Total:   "
+              f"{_fmt_size(self.total_message_cells)} cells "
+              "(x2 directions)"
+          ),
+          "",
+      ]
 
+    lines += [
+        f"Memory ({dtype_name}):",
+        (
+            "  Nodes:   "
+            f" {_fmt_bytes(self.total_jtree_cells * self.bytes_per_cell)}"
+        ),
+        (
+            "  Messages:"
+            f" {_fmt_bytes(self.total_message_cells * self.bytes_per_cell)}"
+        ),
+        f"  Total:    {_fmt_bytes(self.memory_bytes)}",
+    ]
+
+    if self.xla_flops is not None:
+      lines += [
+          "",
+          "XLA Compilation:",
+          f"  FLOPs:           {_fmt_size(self.xla_flops)}",
+          f"  Transcendentals: {_fmt_size(self.xla_transcendentals or 0)}",
+          f"  Bytes accessed:  {_fmt_bytes(self.xla_bytes_accessed or 0)}",
+      ]
+      if self.xla_arg_bytes is not None:
         lines += [
-            f"Memory ({dtype_name}):",
-            (
-                "  Nodes:   "
-                f" {_fmt_bytes(self.total_jtree_cells * self.bytes_per_cell)}"
-            ),
-            (
-                "  Messages:"
-                f" {_fmt_bytes(self.total_message_cells * self.bytes_per_cell)}"
-            ),
-            f"  Total:    {_fmt_bytes(self.memory_bytes)}",
+            f"  Arg size:        {_fmt_bytes(self.xla_arg_bytes)}",
+            f"  Output size:     {_fmt_bytes(self.xla_output_bytes or 0)}",
+            f"  Temp size:       {_fmt_bytes(self.xla_temp_bytes or 0)}",
         ]
 
-        if self.xla_flops is not None:
-            lines += [
-                "",
-                "XLA Compilation:",
-                f"  FLOPs:           {_fmt_size(self.xla_flops)}",
-                (
-                    "  Transcendentals:"
-                    f" {_fmt_size(self.xla_transcendentals or 0)}"
-                ),
-                (
-                    "  Bytes accessed: "
-                    f" {_fmt_bytes(self.xla_bytes_accessed or 0)}"
-                ),
-            ]
-            if self.xla_arg_bytes is not None:
-                lines += [
-                    f"  Arg size:        {_fmt_bytes(self.xla_arg_bytes)}",
-                    (
-                        "  Output size:    "
-                        f" {_fmt_bytes(self.xla_output_bytes or 0)}"
-                    ),
-                    (
-                        "  Temp size:      "
-                        f" {_fmt_bytes(self.xla_temp_bytes or 0)}"
-                    ),
-                ]
-
-        return "\n".join(lines)
+    return "\n".join(lines)
 
 
 def summarize(
@@ -182,101 +170,93 @@ def summarize(
     compile: bool = False,
     bytes_per_cell: int | None = None,
 ) -> ModelSummary:
-    """Return a structured summary of the model.
+  """Return a structured summary of the model.
 
-    Args:
-        domain: The full data domain.
-        cliques: The measurement cliques (before maximal subsumption).
-        jtree: An optional pre-built junction tree.
-            If ``None``, one is constructed via ``make_junction_tree``.
-        marginal_oracle: A marginal oracle function.  If ``None`` and
-            ``compile=True``, uses ``default_oracle``.
-        compile: If True, compile the marginal oracle and surface XLA
-            cost/memory analysis. Defaults to False.
-        bytes_per_cell: Bytes per table cell. If ``None`` (default),
-            auto-detects from ``jax.config.jax_enable_x64``.
+  Args:
+      domain: The full data domain.
+      cliques: The measurement cliques (before maximal subsumption).
+      jtree: An optional pre-built junction tree.
+          If ``None``, one is constructed via ``make_junction_tree``.
+      marginal_oracle: A marginal oracle function.  If ``None`` and
+          ``compile=True``, uses ``default_oracle``.
+      compile: If True, compile the marginal oracle and surface XLA
+          cost/memory analysis. Defaults to False.
+      bytes_per_cell: Bytes per table cell. If ``None`` (default),
+          auto-detects from ``jax.config.jax_enable_x64``.
 
-    Returns:
-        A ``ModelSummary`` dataclass.
-    """
-    if bytes_per_cell is None:
-        bytes_per_cell = 8 if jax.config.jax_enable_x64 else 4
-    input_cliques = [tuple(cl) for cl in cliques]
+  Returns:
+      A ``ModelSummary`` dataclass.
+  """
+  if bytes_per_cell is None:
+    bytes_per_cell = 8 if jax.config.jax_enable_x64 else 4
+  input_cliques = [tuple(cl) for cl in cliques]
 
-    if jtree is None:
-        jtree, _ = junction_tree.make_junction_tree(domain, input_cliques)
-    jtree_nodes = junction_tree.maximal_cliques(jtree)
+  if jtree is None:
+    jtree, _ = junction_tree.make_junction_tree(domain, input_cliques)
+  jtree_nodes = junction_tree.maximal_cliques(jtree)
 
-    clique_sizes = {cl: domain.size(cl) for cl in input_cliques}
-    node_sizes = {cl: domain.size(cl) for cl in jtree_nodes}
+  clique_sizes = {cl: domain.size(cl) for cl in input_cliques}
+  node_sizes = {cl: domain.size(cl) for cl in jtree_nodes}
 
-    messages: list[tuple[Clique, int]] = []
-    for u, v in jtree.edges():
-        u, v = cast(tuple[str, ...], u), cast(tuple[str, ...], v)
-        sep = tuple(set(u) & set(v))
-        messages.append((sep, domain.size(sep) if sep else 1))
+  messages: list[tuple[Clique, int]] = []
+  for u, v in jtree.edges():
+    u, v = cast(tuple[str, ...], u), cast(tuple[str, ...], v)
+    sep = tuple(set(u) & set(v))
+    messages.append((sep, domain.size(sep) if sep else 1))
 
-    largest_clique = max(input_cliques, key=lambda c: clique_sizes[c])
-    largest_node = max(jtree_nodes, key=lambda c: node_sizes[c])
+  largest_clique = max(input_cliques, key=lambda c: clique_sizes[c])
+  largest_node = max(jtree_nodes, key=lambda c: node_sizes[c])
 
-    if messages:
-        largest_msg_idx = max(
-            range(len(messages)), key=lambda i: messages[i][1]
+  if messages:
+    largest_msg_idx = max(range(len(messages)), key=lambda i: messages[i][1])
+    largest_msg, largest_msg_size = messages[largest_msg_idx]
+  else:
+    largest_msg, largest_msg_size = (), 0
+
+  total_msg_cells = sum(s for _, s in messages) * 2
+
+  xla_kwargs: dict = {}
+  if compile:
+    try:
+      if marginal_oracle is None:
+        marginal_oracle = marginal_oracles.default_oracle(
+            cliques=tuple(input_cliques), domain=domain
         )
-        largest_msg, largest_msg_size = messages[largest_msg_idx]
-    else:
-        largest_msg, largest_msg_size = (), 0
+      potentials = CliqueVector.abstract(domain, input_cliques)
+      compiled = (
+          jax.jit(lambda p: marginal_oracle(p, 1.0)).lower(potentials).compile()
+      )
+      cost = compiled.cost_analysis()
+      if cost:
+        xla_kwargs["xla_flops"] = cost.get("flops", 0)
+        xla_kwargs["xla_transcendentals"] = cost.get("transcendentals", 0)
+        xla_kwargs["xla_bytes_accessed"] = int(cost.get("bytes accessed", 0))
+      try:
+        mem = compiled.memory_analysis()
+        xla_kwargs["xla_arg_bytes"] = mem.argument_size_in_bytes
+        xla_kwargs["xla_output_bytes"] = mem.output_size_in_bytes
+        xla_kwargs["xla_temp_bytes"] = mem.temp_size_in_bytes
+      except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    except Exception:  # pylint: disable=broad-exception-caught
+      pass
 
-    total_msg_cells = sum(s for _, s in messages) * 2
-
-    xla_kwargs: dict = {}
-    if compile:
-        try:
-            if marginal_oracle is None:
-                marginal_oracle = marginal_oracles.default_oracle(
-                    cliques=tuple(input_cliques), domain=domain
-                )
-            potentials = CliqueVector.abstract(domain, input_cliques)
-            compiled = (
-                jax.jit(lambda p: marginal_oracle(p, 1.0))
-                .lower(potentials)
-                .compile()
-            )
-            cost = compiled.cost_analysis()
-            if cost:
-                xla_kwargs["xla_flops"] = cost.get("flops", 0)
-                xla_kwargs["xla_transcendentals"] = cost.get(
-                    "transcendentals", 0
-                )
-                xla_kwargs["xla_bytes_accessed"] = int(
-                    cost.get("bytes accessed", 0)
-                )
-            try:
-                mem = compiled.memory_analysis()
-                xla_kwargs["xla_arg_bytes"] = mem.argument_size_in_bytes
-                xla_kwargs["xla_output_bytes"] = mem.output_size_in_bytes
-                xla_kwargs["xla_temp_bytes"] = mem.temp_size_in_bytes
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-
-    return ModelSummary(
-        num_attributes=len(domain),
-        domain_size=domain.size(),
-        num_cliques=len(input_cliques),
-        largest_clique=largest_clique,
-        largest_clique_size=clique_sizes[largest_clique],
-        total_clique_cells=sum(clique_sizes.values()),
-        treewidth=max(len(cl) for cl in jtree_nodes) - 1,
-        num_jtree_nodes=len(jtree_nodes),
-        largest_jtree_node=largest_node,
-        largest_jtree_node_size=node_sizes[largest_node],
-        total_jtree_cells=sum(node_sizes.values()),
-        num_messages=len(messages),
-        largest_message=largest_msg,
-        largest_message_size=largest_msg_size,
-        total_message_cells=total_msg_cells,
-        bytes_per_cell=bytes_per_cell,
-        **xla_kwargs,
-    )
+  return ModelSummary(
+      num_attributes=len(domain),
+      domain_size=domain.size(),
+      num_cliques=len(input_cliques),
+      largest_clique=largest_clique,
+      largest_clique_size=clique_sizes[largest_clique],
+      total_clique_cells=sum(clique_sizes.values()),
+      treewidth=max(len(cl) for cl in jtree_nodes) - 1,
+      num_jtree_nodes=len(jtree_nodes),
+      largest_jtree_node=largest_node,
+      largest_jtree_node_size=node_sizes[largest_node],
+      total_jtree_cells=sum(node_sizes.values()),
+      num_messages=len(messages),
+      largest_message=largest_msg,
+      largest_message_size=largest_msg_size,
+      total_message_cells=total_msg_cells,
+      bytes_per_cell=bytes_per_cell,
+      **xla_kwargs,
+  )

--- a/src/mbi/_serialization.py
+++ b/src/mbi/_serialization.py
@@ -17,51 +17,51 @@ import numpy as np
 
 
 def save(obj: Any, file: str | os.PathLike | io.IOBase) -> None:
-    """Save a JAX pytree to ``.npz`` format.
+  """Save a JAX pytree to ``.npz`` format.
 
-    The pytree leaves (arrays) are stored as named entries and the
-    tree structure (including all static / auxiliary data) is stored
-    as a pickled ``PyTreeDef``.
+  The pytree leaves (arrays) are stored as named entries and the
+  tree structure (including all static / auxiliary data) is stored
+  as a pickled ``PyTreeDef``.
 
-    Common pytrees include ``CliqueVector``, ``MarkovRandomField``,
-    and ``list[LinearMeasurement]``, but any JAX-compatible pytree
-    is accepted.
+  Common pytrees include ``CliqueVector``, ``MarkovRandomField``,
+  and ``list[LinearMeasurement]``, but any JAX-compatible pytree
+  is accepted.
 
-    Args:
-        obj: An arbitrary JAX pytree.
-        file: Path string or writable binary file-like object.
-    """
-    leaves, treedef = jax.tree.flatten(obj)
-    arrays = {f"leaf_{i}": np.asarray(leaf) for i, leaf in enumerate(leaves)}
-    arrays["_treedef"] = np.frombuffer(pickle.dumps(treedef), dtype=np.uint8)
-    buf = io.BytesIO()
-    np.savez_compressed(buf, **arrays)
-    data = buf.getvalue()
-    if isinstance(file, (str, os.PathLike)):
-        with open(file, "wb") as f:
-            f.write(data)
-    else:
-        file.write(data)
+  Args:
+      obj: An arbitrary JAX pytree.
+      file: Path string or writable binary file-like object.
+  """
+  leaves, treedef = jax.tree.flatten(obj)
+  arrays = {f"leaf_{i}": np.asarray(leaf) for i, leaf in enumerate(leaves)}
+  arrays["_treedef"] = np.frombuffer(pickle.dumps(treedef), dtype=np.uint8)
+  buf = io.BytesIO()
+  np.savez_compressed(buf, **arrays)
+  data = buf.getvalue()
+  if isinstance(file, (str, os.PathLike)):
+    with open(file, "wb") as f:
+      f.write(data)
+  else:
+    file.write(data)
 
 
 def load(file: str | os.PathLike | io.IOBase) -> Any:
-    """Load a JAX pytree from ``.npz`` format.
+  """Load a JAX pytree from ``.npz`` format.
 
-    Leaf values are returned as ``jax.Array`` so that JIT-compiled
-    functions see consistent types.
+  Leaf values are returned as ``jax.Array`` so that JIT-compiled
+  functions see consistent types.
 
-    Args:
-        file: Path string or readable binary file-like object.
+  Args:
+      file: Path string or readable binary file-like object.
 
-    Returns:
-        The reconstructed pytree.
-    """
-    if isinstance(file, (str, os.PathLike)):
-        with open(file, "rb") as f:
-            raw = f.read()
-    else:
-        raw = file.read()
-    npz = np.load(io.BytesIO(raw), allow_pickle=True)
-    treedef = pickle.loads(npz["_treedef"].tobytes())
-    leaves = [jnp.asarray(npz[f"leaf_{i}"]) for i in range(treedef.num_leaves)]
-    return jax.tree.unflatten(treedef, leaves)
+  Returns:
+      The reconstructed pytree.
+  """
+  if isinstance(file, (str, os.PathLike)):
+    with open(file, "rb") as f:
+      raw = f.read()
+  else:
+    raw = file.read()
+  npz = np.load(io.BytesIO(raw), allow_pickle=True)
+  treedef = pickle.loads(npz["_treedef"].tobytes())
+  leaves = [jnp.asarray(npz[f"leaf_{i}"]) for i in range(treedef.num_leaves)]
+  return jax.tree.unflatten(treedef, leaves)

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -36,38 +36,38 @@ from .marginal_loss import LinearMeasurement
 
 
 class StatefulMarginalOracle(Protocol):
-    """Defines the callable signature for stateful marginal oracle functions.
+  """Defines the callable signature for stateful marginal oracle functions.
 
-    A stateful marginal oracle computes (approximate) marginals from
-    log-space potentials while also managing an internal state, often
-    for optimization in iterative algorithms (e.g., preserving messages
-    in message passing).
+  A stateful marginal oracle computes (approximate) marginals from
+  log-space potentials while also managing an internal state, often
+  for optimization in iterative algorithms (e.g., preserving messages
+  in message passing).
+  """
+
+  def __call__(
+      self,
+      potentials: CliqueVector,
+      total: float = 1.0,
+      state: Any = None,
+      mesh: jax.sharding.Mesh | None = None,
+  ) -> tuple[CliqueVector, Any]:
+    """Computes marginals from log-space potentials and manages state.
+
+    Args:
+        potentials: A CliqueVector representing the log-space potentials
+            of a graphical model.
+        total: The normalization factor, typically the total number of
+            records or a probability sum. Defaults to 1.0.
+        state: An optional argument to pass state between calls.
+            The oracle may use this state and return an updated version.
+        mesh: Specifies how the computation will be sharded across devices.
+
+    Returns:
+        A tuple containing:
+            - CliqueVector: The computed marginals.
+            - Any: The updated state.
     """
-
-    def __call__(
-        self,
-        potentials: CliqueVector,
-        total: float = 1.0,
-        state: Any = None,
-        mesh: jax.sharding.Mesh | None = None,
-    ) -> tuple[CliqueVector, Any]:
-        """Computes marginals from log-space potentials and manages state.
-
-        Args:
-            potentials: A CliqueVector representing the log-space potentials
-                of a graphical model.
-            total: The normalization factor, typically the total number of
-                records or a probability sum. Defaults to 1.0.
-            state: An optional argument to pass state between calls.
-                The oracle may use this state and return an updated version.
-            mesh: Specifies how the computation will be sharded across devices.
-
-        Returns:
-            A tuple containing:
-                - CliqueVector: The computed marginals.
-                - Any: The updated state.
-        """
-        pass
+    pass
 
 
 def build_graph(domain: Domain, cliques: list[tuple[str, ...]]) -> tuple[
@@ -78,73 +78,73 @@ def build_graph(domain: Domain, cliques: list[tuple[str, ...]]) -> tuple[
     dict[Clique, list[Clique]],
     dict[Clique, list[Clique]],
 ]:
-    """Builds the region graph for convex generalized belief propagation."""
-    # Hard-code minimal=True, convex=True
-    # Counting numbers = 1 for all regions
-    # Alg 11.3 of Koller & Friedman
-    regions = set(cliques)
-    size = 0
-    while len(regions) > size:
-        size = len(regions)
-        for r1, r2 in itertools.combinations(regions, 2):
-            z = tuple(sorted(set(r1) & set(r2)))
-            if len(z) > 0 and not z in regions:
-                regions.update({z})
+  """Builds the region graph for convex generalized belief propagation."""
+  # Hard-code minimal=True, convex=True
+  # Counting numbers = 1 for all regions
+  # Alg 11.3 of Koller & Friedman
+  regions = set(cliques)
+  size = 0
+  while len(regions) > size:
+    size = len(regions)
+    for r1, r2 in itertools.combinations(regions, 2):
+      z = tuple(sorted(set(r1) & set(r2)))
+      if len(z) > 0 and not z in regions:
+        regions.update({z})
 
-    G = nx.DiGraph()
-    G.add_nodes_from(regions)
-    for r1 in regions:
-        for r2 in regions:
-            if set(r2) < set(r1) and not any(
-                set(r2) < set(r3) and set(r3) < set(r1) for r3 in regions
-            ):
-                G.add_edge(r1, r2)
+  G = nx.DiGraph()
+  G.add_nodes_from(regions)
+  for r1 in regions:
+    for r2 in regions:
+      if set(r2) < set(r1) and not any(
+          set(r2) < set(r3) and set(r3) < set(r1) for r3 in regions
+      ):
+        G.add_edge(r1, r2)
 
-    H = G.reverse()
-    G1, H1 = nx.transitive_closure(G), nx.transitive_closure(H)
+  H = G.reverse()
+  G1, H1 = nx.transitive_closure(G), nx.transitive_closure(H)
 
-    children = {r: list(G.neighbors(r)) for r in regions}
-    parents = {r: list(H.neighbors(r)) for r in regions}
-    descendants = {r: list(G1.neighbors(r)) for r in regions}
-    ancestors = {r: list(H1.neighbors(r)) for r in regions}
-    forebears = {r: set([r] + ancestors[r]) for r in regions}
-    downp = {r: set([r] + descendants[r]) for r in regions}
+  children = {r: list(G.neighbors(r)) for r in regions}
+  parents = {r: list(H.neighbors(r)) for r in regions}
+  descendants = {r: list(G1.neighbors(r)) for r in regions}
+  ancestors = {r: list(H1.neighbors(r)) for r in regions}
+  forebears = {r: set([r] + ancestors[r]) for r in regions}
+  downp = {r: set([r] + descendants[r]) for r in regions}
 
-    min_edges = []
-    for r in regions:
-        ds = DisjointSet()
-        for u in parents[r]:
-            ds.add(u)
-        for u, v in itertools.combinations(parents[r], 2):
-            uv = set(ancestors[u]) & set(ancestors[v])
-            if len(uv) > 0:
-                ds.merge(u, v)
-        canonical = set()
-        for u in parents[r]:
-            canonical.update({ds[u]})
-        min_edges.extend([(u, r) for u in canonical])
+  min_edges = []
+  for r in regions:
+    ds = DisjointSet()
+    for u in parents[r]:
+      ds.add(u)
+    for u, v in itertools.combinations(parents[r], 2):
+      uv = set(ancestors[u]) & set(ancestors[v])
+      if len(uv) > 0:
+        ds.merge(u, v)
+    canonical = set()
+    for u in parents[r]:
+      canonical.update({ds[u]})
+    min_edges.extend([(u, r) for u in canonical])
 
-    G = nx.DiGraph()
-    G.add_nodes_from(regions)
-    G.add_edges_from(min_edges)
+  G = nx.DiGraph()
+  G.add_nodes_from(regions)
+  G.add_edges_from(min_edges)
 
-    H = G.reverse()
-    G1, H1 = nx.transitive_closure(G), nx.transitive_closure(H)
+  H = G.reverse()
+  G1, H1 = nx.transitive_closure(G), nx.transitive_closure(H)
 
-    children = {r: list(G.neighbors(r)) for r in regions}
-    parents = {r: list(H.neighbors(r)) for r in regions}
+  children = {r: list(G.neighbors(r)) for r in regions}
+  parents = {r: list(H.neighbors(r)) for r in regions}
 
-    messages = {}
-    message_order = []
-    for ru in sorted(regions, key=len):
-        for rd in children[ru]:
-            message_order.append((ru, rd))
-            messages[ru, rd] = Factor.zeros(domain.project(rd))
-            messages[rd, ru] = Factor.zeros(
-                domain.project(rd)
-            )  # only for hazan et al
+  messages = {}
+  message_order = []
+  for ru in sorted(regions, key=len):
+    for rd in children[ru]:
+      message_order.append((ru, rd))
+      messages[ru, rd] = Factor.zeros(domain.project(rd))
+      messages[rd, ru] = Factor.zeros(
+          domain.project(rd)
+      )  # only for hazan et al
 
-    return regions, cliques, messages, message_order, parents, children
+  return regions, cliques, messages, message_order, parents, children
 
 
 _State = dict[tuple[Clique, Clique], Factor]
@@ -159,246 +159,244 @@ def convex_generalized_belief_propagation(
     iters: int = 1,
     damping: float = 0.5,
 ) -> tuple[CliqueVector, _State]:
-    """Convex generalized belief propagation for approximmate marginal inference.
+  """Convex generalized belief propagation for approximmate marginal inference.
 
-        The algorithms implements the Algorithm 2 in our paper
-        ["Relaxed Marginal Consistency for Differentially Private Query Answering"](https://arxiv.org/pdf/2109.06153), which itself is based on the paper titled
-        ["Tightening Fractional Covering Upper Bounds on the Partition
-    Function for High-Order Region Graphs"](https://arxiv.org/pdf/1210.4881).
+      The algorithms implements the Algorithm 2 in our paper
+      ["Relaxed Marginal Consistency for Differentially Private Query Answering"](https://arxiv.org/pdf/2109.06153), which itself is based on the paper titled
+      ["Tightening Fractional Covering Upper Bounds on the Partition
+  Function for High-Order Region Graphs"](https://arxiv.org/pdf/1210.4881).
 
-    Args:
-        potentials: A CliqueVector object containing the potentials of the graphical model.
-        total: The total number of records in the dataset.
-        state: The state of the message passing algorithm (i.e., the messages).  Useful when
-            calling this within an iterative procedure for warm starting purposes.
-        mesh: Specifies how the computation will be sharded across machines.
-        iters: The number of iterations to run the algorithm.
-        damping: The damping factor for the messages.
+  Args:
+      potentials: A CliqueVector object containing the potentials of the graphical model.
+      total: The total number of records in the dataset.
+      state: The state of the message passing algorithm (i.e., the messages).  Useful when
+          calling this within an iterative procedure for warm starting purposes.
+      mesh: Specifies how the computation will be sharded across machines.
+      iters: The number of iterations to run the algorithm.
+      damping: The damping factor for the messages.
 
-    Returns:
-        A CliqueVector of pseudo-marginals for the cliques in the graphical model.
-    """
-    potentials = potentials.apply_sharding(mesh)
-    domain, cliques = potentials.domain, potentials.cliques
-    # We might need or want a sharding constraint on messages here
-    regions, cliques, messages, message_order, parents, children = build_graph(
-        domain, cliques
-    )
-    if state is not None:
-        messages = state
+  Returns:
+      A CliqueVector of pseudo-marginals for the cliques in the graphical model.
+  """
+  potentials = potentials.apply_sharding(mesh)
+  domain, cliques = potentials.domain, potentials.cliques
+  # We might need or want a sharding constraint on messages here
+  regions, cliques, messages, message_order, parents, children = build_graph(
+      domain, cliques
+  )
+  if state is not None:
+    messages = state
 
-    # Hardcode assumption that counting numbers are 1.0 for all regions.
-    pot = potentials.expand(regions)
+  # Hardcode assumption that counting numbers are 1.0 for all regions.
+  pot = potentials.expand(regions)
 
-    cc = {}
+  cc = {}
+  for r in regions:
+    for p in parents[r]:
+      cc[p, r] = 1 / (1 + len(parents[r]))
+
+  for _ in range(iters):
+    new = {}
     for r in regions:
-        for p in parents[r]:
-            cc[p, r] = 1 / (1 + len(parents[r]))
-
-    for _ in range(iters):
-        new = {}
-        for r in regions:
-            for p in parents[r]:
-                new[p, r] = (
-                    (
-                        pot[p]
-                        + sum(messages[c, p] for c in children[p] if c != r)
-                        - sum(messages[p, p1] for p1 in parents[p])
-                    )
-                    .project(r, log=True)
-                    .normalize(log=True)
-                    .apply_sharding(mesh)
-                )
-
-        for r in regions:
-            for p in parents[r]:
-                new[r, p] = (
-                    (
-                        cc[p, r]
-                        * (
-                            pot[r]
-                            + sum(messages[c, r] for c in children[r])
-                            + sum(messages[p1, r] for p1 in parents[r])
-                        )
-                        - messages[p, r]
-                    )
-                    .normalize(log=True)
-                    .apply_sharding(mesh)
-                )
-
-        # Damping is not described in paper, but is needed to get convergence for dense graphs
-        rho = damping
-        for p in regions:
-            for r in children[p]:
-                messages[p, r] = rho * messages[p, r] + (1.0 - rho) * new[p, r]
-                messages[r, p] = rho * messages[r, p] + (1.0 - rho) * new[r, p]
-
-    mu = {}
-    for r in cliques:
-        mu[r] = (
+      for p in parents[r]:
+        new[p, r] = (
             (
-                pot[r]
-                + sum(messages[c, r] for c in children[r])
-                - sum(messages[r, p] for p in parents[r])
+                pot[p]
+                + sum(messages[c, p] for c in children[p] if c != r)
+                - sum(messages[p, p1] for p1 in parents[p])
             )
-            .normalize(total, log=True)
-            .exp()
+            .project(r, log=True)
+            .normalize(log=True)
             .apply_sharding(mesh)
         )
 
-    return CliqueVector(domain, cliques, mu), messages
+    for r in regions:
+      for p in parents[r]:
+        new[r, p] = (
+            (
+                cc[p, r]
+                * (
+                    pot[r]
+                    + sum(messages[c, r] for c in children[r])
+                    + sum(messages[p1, r] for p1 in parents[r])
+                )
+                - messages[p, r]
+            )
+            .normalize(log=True)
+            .apply_sharding(mesh)
+        )
+
+    # Damping is not described in paper, but is needed to get convergence for dense graphs
+    rho = damping
+    for p in regions:
+      for r in children[p]:
+        messages[p, r] = rho * messages[p, r] + (1.0 - rho) * new[p, r]
+        messages[r, p] = rho * messages[r, p] + (1.0 - rho) * new[r, p]
+
+  mu = {}
+  for r in cliques:
+    mu[r] = (
+        (
+            pot[r]
+            + sum(messages[c, r] for c in children[r])
+            - sum(messages[r, p] for p in parents[r])
+        )
+        .normalize(total, log=True)
+        .exp()
+        .apply_sharding(mesh)
+    )
+
+  return CliqueVector(domain, cliques, mu), messages
 
 
 class ApproxMirrorDescentState(NamedTuple):
-    """State for mirror descent with approximate marginal inference."""
+  """State for mirror descent with approximate marginal inference."""
 
-    potentials: CliqueVector
-    mu: CliqueVector
-    messages: Any
+  potentials: CliqueVector
+  mu: CliqueVector
+  messages: Any
 
 
 @dataclasses.dataclass(frozen=True)
 class ApproxMirrorDescent:
-    """Mirror descent estimator using approximate marginal inference.
+  """Mirror descent estimator using approximate marginal inference.
 
-    Uses ``convex_generalized_belief_propagation`` as the marginal oracle and
-    warm-starts messages between optimization iterations.  Unlike the exact
-    mirror descent in ``estimation.py``, this does not produce a
-    ``MarkovRandomField`` because approximate region graphs cannot generate
-    synthetic data.
+  Uses ``convex_generalized_belief_propagation`` as the marginal oracle and
+  warm-starts messages between optimization iterations.  Unlike the exact
+  mirror descent in ``estimation.py``, this does not produce a
+  ``MarkovRandomField`` because approximate region graphs cannot generate
+  synthetic data.
 
-    This class holds optimizer configuration only.  All data (loss function,
-    potentials, totals) is passed to methods as arguments.
+  This class holds optimizer configuration only.  All data (loss function,
+  potentials, totals) is passed to methods as arguments.
 
-    Example::
+  Example::
 
-        estimator = ApproxMirrorDescent(stepsize=1.0)
-        mu = estimator.estimate(domain, measurements)
+      estimator = ApproxMirrorDescent(stepsize=1.0)
+      mu = estimator.estimate(domain, measurements)
 
-    Attributes:
-        stepsize: Fixed step size (required; no line search).
-        oracle_iters: Belief propagation iterations per optimization step.
-        damping: Damping factor for belief propagation messages.
-        mesh: JAX sharding mesh.
+  Attributes:
+      stepsize: Fixed step size (required; no line search).
+      oracle_iters: Belief propagation iterations per optimization step.
+      damping: Damping factor for belief propagation messages.
+      mesh: JAX sharding mesh.
+  """
+
+  stepsize: float
+  oracle_iters: int = 1
+  damping: float = 0.5
+  mesh: jax.sharding.Mesh | None = None
+
+  def _init(
+      self,
+      potentials: CliqueVector,
+      total: float,
+  ) -> ApproxMirrorDescentState:
+    """Initialize the optimization state."""
+    # Initialize messages so jit sees a consistent pytree structure.
+    mu, messages = convex_generalized_belief_propagation(
+        potentials,
+        total,
+        state=None,
+        mesh=self.mesh,
+        iters=self.oracle_iters,
+        damping=self.damping,
+    )
+    return ApproxMirrorDescentState(potentials, mu, messages)
+
+  @functools.partial(jax.jit, static_argnames=["self"])
+  def _step(
+      self,
+      state: ApproxMirrorDescentState,
+      total: jax.Array | float,
+      loss_fn: marginal_loss.MarginalLossFn,
+  ) -> ApproxMirrorDescentState:
+    """Perform a single mirror descent step."""
+    mu, messages = convex_generalized_belief_propagation(
+        state.potentials,
+        total,
+        state=state.messages,
+        mesh=self.mesh,
+        iters=self.oracle_iters,
+        damping=self.damping,
+    )
+    dL = jax.grad(loss_fn)(mu)
+    potentials = state.potentials - self.stepsize * dL
+    return ApproxMirrorDescentState(potentials, mu, messages)
+
+  def estimate(
+      self,
+      domain: Domain,
+      loss_fn: marginal_loss.MarginalLossFn | list[LinearMeasurement],
+      *,
+      known_total: float | None = None,
+      potentials: CliqueVector | None = None,
+      iters: int = 1000,
+      callback_fn=lambda _: None,
+  ) -> CliqueVector:
+    """Run mirror descent and return pseudo-marginals.
+
+    Args:
+        domain: The domain over which the model is defined.
+        loss_fn: A ``MarginalLossFn`` or a list of ``LinearMeasurement``.
+        known_total: The known or estimated number of records.
+        potentials: Initial potentials.
+        iters: Number of optimization iterations.
+        callback_fn: Called with pseudo-marginals at each iteration.
+
+    Returns:
+        Pseudo-marginals as a ``CliqueVector``.
     """
+    loss_fn, known_total, potentials = estimation._initialize(
+        domain, loss_fn, known_total, potentials
+    )
+    state = self._init(potentials, known_total)
 
-    stepsize: float
-    oracle_iters: int = 1
-    damping: float = 0.5
-    mesh: jax.sharding.Mesh | None = None
+    for _ in range(iters):
+      state = self._step(state, known_total, loss_fn)
+      callback_fn(state.mu)
 
-    def _init(
-        self,
-        potentials: CliqueVector,
-        total: float,
-    ) -> ApproxMirrorDescentState:
-        """Initialize the optimization state."""
-        # Initialize messages so jit sees a consistent pytree structure.
-        mu, messages = convex_generalized_belief_propagation(
-            potentials,
-            total,
-            state=None,
-            mesh=self.mesh,
-            iters=self.oracle_iters,
-            damping=self.damping,
-        )
-        return ApproxMirrorDescentState(potentials, mu, messages)
+    # Final oracle call with warm-started messages.
+    mu, _ = convex_generalized_belief_propagation(
+        state.potentials,
+        known_total,
+        state=state.messages,
+        mesh=self.mesh,
+        iters=self.oracle_iters,
+        damping=self.damping,
+    )
+    return mu
 
-    @functools.partial(jax.jit, static_argnames=["self"])
-    def _step(
-        self,
-        state: ApproxMirrorDescentState,
-        total: jax.Array | float,
-        loss_fn: marginal_loss.MarginalLossFn,
-    ) -> ApproxMirrorDescentState:
-        """Perform a single mirror descent step."""
-        mu, messages = convex_generalized_belief_propagation(
-            state.potentials,
-            total,
-            state=state.messages,
-            mesh=self.mesh,
-            iters=self.oracle_iters,
-            damping=self.damping,
-        )
-        dL = jax.grad(loss_fn)(mu)
-        potentials = state.potentials - self.stepsize * dL
-        return ApproxMirrorDescentState(potentials, mu, messages)
+  def precompile(
+      self,
+      domain: Domain,
+      measurements: list[LinearMeasurement] | None = None,
+      *,
+      extra_cliques: list[tuple[str, ...]] | None = None,
+  ) -> None:
+    """Warm up the JIT cache for ``estimate``.
 
-    def estimate(
-        self,
-        domain: Domain,
-        loss_fn: marginal_loss.MarginalLossFn | list[LinearMeasurement],
-        *,
-        known_total: float | None = None,
-        potentials: CliqueVector | None = None,
-        iters: int = 1000,
-        callback_fn=lambda _: None,
-    ) -> CliqueVector:
-        """Run mirror descent and return pseudo-marginals.
+    Args:
+        domain: The domain over which the model is defined.
+        measurements: Optional list of ``LinearMeasurement`` objects.
+        extra_cliques: Optional additional cliques to compile for.
+    """
+    all_measurements = list(measurements or [])
+    for cl in extra_cliques or []:
+      shape = (domain.project(cl).size(),)
+      abstract_values = jax.ShapeDtypeStruct(shape, jnp.float32)
+      all_measurements.append(LinearMeasurement(abstract_values, cl))
+    all_measurements = jax.eval_shape(lambda x: x, all_measurements)
 
-        Args:
-            domain: The domain over which the model is defined.
-            loss_fn: A ``MarginalLossFn`` or a list of ``LinearMeasurement``.
-            known_total: The known or estimated number of records.
-            potentials: Initial potentials.
-            iters: Number of optimization iterations.
-            callback_fn: Called with pseudo-marginals at each iteration.
+    loss_fn = marginal_loss.from_linear_measurements(all_measurements, domain)
+    potentials = CliqueVector.abstract(domain, loss_fn.cliques)
 
-        Returns:
-            Pseudo-marginals as a ``CliqueVector``.
-        """
-        loss_fn, known_total, potentials = estimation._initialize(
-            domain, loss_fn, known_total, potentials
-        )
-        state = self._init(potentials, known_total)
+    # Use eval_shape to get the abstract state pytree without
+    # running any computation.
+    abstract_state = jax.eval_shape(self._init, potentials, 1.0)
 
-        for _ in range(iters):
-            state = self._step(state, known_total, loss_fn)
-            callback_fn(state.mu)
-
-        # Final oracle call with warm-started messages.
-        mu, _ = convex_generalized_belief_propagation(
-            state.potentials,
-            known_total,
-            state=state.messages,
-            mesh=self.mesh,
-            iters=self.oracle_iters,
-            damping=self.damping,
-        )
-        return mu
-
-    def precompile(
-        self,
-        domain: Domain,
-        measurements: list[LinearMeasurement] | None = None,
-        *,
-        extra_cliques: list[tuple[str, ...]] | None = None,
-    ) -> None:
-        """Warm up the JIT cache for ``estimate``.
-
-        Args:
-            domain: The domain over which the model is defined.
-            measurements: Optional list of ``LinearMeasurement`` objects.
-            extra_cliques: Optional additional cliques to compile for.
-        """
-        all_measurements = list(measurements or [])
-        for cl in extra_cliques or []:
-            shape = (domain.project(cl).size(),)
-            abstract_values = jax.ShapeDtypeStruct(shape, jnp.float32)
-            all_measurements.append(LinearMeasurement(abstract_values, cl))
-        all_measurements = jax.eval_shape(lambda x: x, all_measurements)
-
-        loss_fn = marginal_loss.from_linear_measurements(
-            all_measurements, domain
-        )
-        potentials = CliqueVector.abstract(domain, loss_fn.cliques)
-
-        # Use eval_shape to get the abstract state pytree without
-        # running any computation.
-        abstract_state = jax.eval_shape(self._init, potentials, 1.0)
-
-        # lower().compile() populates the jit cache without executing.
-        self._step.lower(self, abstract_state, 1.0, loss_fn).compile()
+    # lower().compile() populates the jit cache without executing.
+    self._step.lower(self, abstract_state, 1.0, loss_fn).compile()
 
 
 def mirror_descent(
@@ -414,36 +412,36 @@ def mirror_descent(
     callback_fn=lambda _: None,
     mesh=None,
 ) -> CliqueVector:
-    """Mirror descent with approximate marginal inference.
+  """Mirror descent with approximate marginal inference.
 
-    Convenience wrapper around :class:`ApproxMirrorDescent`.
+  Convenience wrapper around :class:`ApproxMirrorDescent`.
 
-    Args:
-        domain: The domain over which the model should be defined.
-        loss_fn: A ``MarginalLossFn`` or a list of ``LinearMeasurement``.
-        known_total: The known or estimated number of records.
-        potentials: Initial potentials.
-        stepsize: Fixed step size (required; no line search).
-        iters: Number of optimization iterations.
-        oracle_iters: Belief propagation iterations per optimization step.
-        damping: Damping factor for belief propagation messages.
-        callback_fn: Called with pseudo-marginals at each iteration.
-        mesh: JAX sharding mesh.
+  Args:
+      domain: The domain over which the model should be defined.
+      loss_fn: A ``MarginalLossFn`` or a list of ``LinearMeasurement``.
+      known_total: The known or estimated number of records.
+      potentials: Initial potentials.
+      stepsize: Fixed step size (required; no line search).
+      iters: Number of optimization iterations.
+      oracle_iters: Belief propagation iterations per optimization step.
+      damping: Damping factor for belief propagation messages.
+      callback_fn: Called with pseudo-marginals at each iteration.
+      mesh: JAX sharding mesh.
 
-    Returns:
-        Pseudo-marginals as a ``CliqueVector``.
-    """
-    estimator = ApproxMirrorDescent(
-        stepsize=stepsize,
-        oracle_iters=oracle_iters,
-        damping=damping,
-        mesh=mesh,
-    )
-    return estimator.estimate(
-        domain,
-        loss_fn,
-        known_total=known_total,
-        potentials=potentials,
-        iters=iters,
-        callback_fn=callback_fn,
-    )
+  Returns:
+      Pseudo-marginals as a ``CliqueVector``.
+  """
+  estimator = ApproxMirrorDescent(
+      stepsize=stepsize,
+      oracle_iters=oracle_iters,
+      damping=damping,
+      mesh=mesh,
+  )
+  return estimator.estimate(
+      domain,
+      loss_fn,
+      known_total=known_total,
+      potentials=potentials,
+      iters=iters,
+      callback_fn=callback_fn,
+  )

--- a/src/mbi/callbacks.py
+++ b/src/mbi/callbacks.py
@@ -18,50 +18,48 @@ _log_fn = print
 
 
 def set_log_fn(fn):
-    """Override the library-wide log function (default: print)."""
-    global _log_fn
-    _log_fn = fn
+  """Override the library-wide log function (default: print)."""
+  global _log_fn
+  _log_fn = fn
 
 
 def log(*args, **kwargs):
-    """Log a message using the configured log function."""
-    _log_fn(*args, **kwargs)
+  """Log a message using the configured log function."""
+  _log_fn(*args, **kwargs)
 
 
 def _pad(string: str, length: int):
-    """Pads a string with spaces on both sides to a target length."""
-    if len(string) > length:
-        return string[:length]
-    left_pad = (length - len(string)) // 2
-    right_pad = length - len(string) - left_pad
-    return " " * left_pad + string + " " * right_pad
+  """Pads a string with spaces on both sides to a target length."""
+  if len(string) > length:
+    return string[:length]
+  left_pad = (length - len(string)) // 2
+  right_pad = length - len(string) - left_pad
+  return " " * left_pad + string + " " * right_pad
 
 
 @dataclasses.dataclass
 class Callback:
-    loss_fns: dict[str, marginal_loss.MarginalLossFn]
-    _step: int = 0
-    _logs: list = dataclasses.field(default_factory=list)
+  loss_fns: dict[str, marginal_loss.MarginalLossFn]
+  _step: int = 0
+  _logs: list = dataclasses.field(default_factory=list)
 
-    def __call__(self, marginals: CliqueVector) -> None:
-        if self._step == 0:
-            header = "|".join(
-                [_pad(x, 12) for x in ["step", *self.loss_fns.keys()]]
-            )
-            log(header)
-            log("=" * len(header))
-        row = [self.loss_fns[key](marginals) for key in self.loss_fns]
-        self._logs.append([self._step] + row)
-        padded_step = str(self._step) + " " * (9 - len(str(self._step)))
-        log(padded_step, *[f"{v:.6f}"[:6] for v in row], sep="   |   ")
-        self._step += 1
+  def __call__(self, marginals: CliqueVector) -> None:
+    if self._step == 0:
+      header = "|".join([_pad(x, 12) for x in ["step", *self.loss_fns.keys()]])
+      log(header)
+      log("=" * len(header))
+    row = [self.loss_fns[key](marginals) for key in self.loss_fns]
+    self._logs.append([self._step] + row)
+    padded_step = str(self._step) + " " * (9 - len(str(self._step)))
+    log(padded_step, *[f"{v:.6f}"[:6] for v in row], sep="   |   ")
+    self._step += 1
 
-    @property
-    def summary(self) -> dict[str, list]:
-        return {
-            "columns": ["step"] + list(self.loss_fns.keys()),
-            "data": self._logs,
-        }
+  @property
+  def summary(self) -> dict[str, list]:
+    return {
+        "columns": ["step"] + list(self.loss_fns.keys()),
+        "data": self._logs,
+    }
 
 
 def default(
@@ -69,37 +67,37 @@ def default(
     domain: Domain,
     data: Projectable | None = None,
 ) -> Callback:
-    """Creates a default Callback with standard loss functions."""
-    loss_fns = {
-        "L2 Loss": marginal_loss.from_linear_measurements(
-            measurements, domain, norm="l2", normalize=True
-        ),
-        "L1 Loss": marginal_loss.from_linear_measurements(
-            measurements,
-            domain,
-            norm="l1",
-            normalize=True,
-        ),
-    }
+  """Creates a default Callback with standard loss functions."""
+  loss_fns = {
+      "L2 Loss": marginal_loss.from_linear_measurements(
+          measurements, domain, norm="l2", normalize=True
+      ),
+      "L1 Loss": marginal_loss.from_linear_measurements(
+          measurements,
+          domain,
+          norm="l1",
+          normalize=True,
+      ),
+  }
 
-    if data is not None:
-        ground_truth = [
-            LinearMeasurement(
-                M.query(data.project(M.clique)),
-                clique=M.clique,
-                stddev=1,
-                query=M.query,
-            )
-            for M in measurements
-        ]
-        loss_fns["L2 Error"] = marginal_loss.from_linear_measurements(
-            ground_truth, domain, norm="l2", normalize=True
+  if data is not None:
+    ground_truth = [
+        LinearMeasurement(
+            M.query(data.project(M.clique)),
+            clique=M.clique,
+            stddev=1,
+            query=M.query,
         )
-        loss_fns["L1 Error"] = marginal_loss.from_linear_measurements(
-            ground_truth, domain, norm="l1", normalize=True
-        )
+        for M in measurements
+    ]
+    loss_fns["L2 Error"] = marginal_loss.from_linear_measurements(
+        ground_truth, domain, norm="l2", normalize=True
+    )
+    loss_fns["L1 Error"] = marginal_loss.from_linear_measurements(
+        ground_truth, domain, norm="l1", normalize=True
+    )
 
-    loss_fns = {key: jax.jit(val.__call__) for key, val in loss_fns.items()}
-    loss_fns["Primal Feas"] = jax.jit(marginal_loss.primal_feasibility)
+  loss_fns = {key: jax.jit(val.__call__) for key, val in loss_fns.items()}
+  loss_fns["Primal Feas"] = jax.jit(marginal_loss.primal_feasibility)
 
-    return Callback(loss_fns)
+  return Callback(loss_fns)

--- a/src/mbi/clique_utils.py
+++ b/src/mbi/clique_utils.py
@@ -18,37 +18,37 @@ Clique: TypeAlias = tuple[str | int, ...]
 
 
 def powerset(iterable: Iterable) -> Iterator[tuple]:
-    """Powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)."""
-    s = list(iterable)
-    return itertools.chain.from_iterable(
-        itertools.combinations(s, r) for r in range(len(s) + 1)
-    )
+  """Powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)."""
+  s = list(iterable)
+  return itertools.chain.from_iterable(
+      itertools.combinations(s, r) for r in range(len(s) + 1)
+  )
 
 
 def downward_closure(
     cliques: Sequence[Clique], include_empty: bool = False
 ) -> list[Clique]:
-    """Returns the downward closure of the given cliques.
+  """Returns the downward closure of the given cliques.
 
-    Given a collection of sets, the downward closure is the set of all sets that
-    are subsets of any of the given sets.
+  Given a collection of sets, the downward closure is the set of all sets that
+  are subsets of any of the given sets.
 
-    Example Usage:
-    >>> downward_closure([('a', 'b'), ('a', 'c')])
-    [('a',), ('b',), ('c',), ('a', 'b'), ('a', 'c')]
+  Example Usage:
+  >>> downward_closure([('a', 'b'), ('a', 'c')])
+  [('a',), ('b',), ('c',), ('a', 'b'), ('a', 'c')]
 
-    Args:
-      cliques: The cliques to compute the downward closure of.
+  Args:
+    cliques: The cliques to compute the downward closure of.
 
-    Returns:
-      The downward closure of the given cliques, without the empty tuple.
-    """
-    ans = set()
-    for proj in cliques:
-        ans.update(powerset(proj))
-    if not include_empty:
-        ans = ans - {()}
-    return list(sorted(ans, key=lambda x: (len(x), x)))
+  Returns:
+    The downward closure of the given cliques, without the empty tuple.
+  """
+  ans = set()
+  for proj in cliques:
+    ans.update(powerset(proj))
+  if not include_empty:
+    ans = ans - {()}
+  return list(sorted(ans, key=lambda x: (len(x), x)))
 
 
 def reverse_clique_mapping(
@@ -56,55 +56,55 @@ def reverse_clique_mapping(
     all_cliques: Sequence[Clique],
     domain: Domain | None = None,
 ) -> dict[Clique, list[Clique]]:
-    """Creates a mapping from maximal cliques to a list of cliques they contain.
+  """Creates a mapping from maximal cliques to a list of cliques they contain.
 
-    Args:
-      maximal_cliques: A list of maximal cliques.
-      all_cliques: A list of all cliques.
-      domain: Optional Domain object. If provided, links cliques to the
-              supporting maximal clique with the smallest domain size.
-              Otherwise, links to the one with fewest elements.
+  Args:
+    maximal_cliques: A list of maximal cliques.
+    all_cliques: A list of all cliques.
+    domain: Optional Domain object. If provided, links cliques to the
+            supporting maximal clique with the smallest domain size.
+            Otherwise, links to the one with fewest elements.
 
-    Returns:
-      A mapping from maximal cliques to cliques they contain.
-    """
-    mapping = {cl: [] for cl in maximal_cliques}
-    for cl in all_cliques:
-        candidates = [m for m in maximal_cliques if set(cl) <= set(m)]
-        if not candidates:
-            continue
+  Returns:
+    A mapping from maximal cliques to cliques they contain.
+  """
+  mapping = {cl: [] for cl in maximal_cliques}
+  for cl in all_cliques:
+    candidates = [m for m in maximal_cliques if set(cl) <= set(m)]
+    if not candidates:
+      continue
 
-        if domain is None:
-            best = min(candidates, key=len)
-        else:
-            best = min(candidates, key=lambda m: domain.size(m))
+    if domain is None:
+      best = min(candidates, key=len)
+    else:
+      best = min(candidates, key=lambda m: domain.size(m))
 
-        mapping[best].append(cl)
-    return mapping
+    mapping[best].append(cl)
+  return mapping
 
 
 def maximal_subset(cliques: Sequence[Clique]) -> list[Clique]:
-    """Given a list of cliques, finds a maximal subset of non-nested cliques.
+  """Given a list of cliques, finds a maximal subset of non-nested cliques.
 
-    A clique is considered nested in another if all its vertices are a subset
-    of the other's vertices.
+  A clique is considered nested in another if all its vertices are a subset
+  of the other's vertices.
 
-    Example Usage:
-    >>> maximal_subset([('A', 'B'), ('B',), ('C',), ('B', 'A')])
-    [('A', 'B'), ('C',)]
+  Example Usage:
+  >>> maximal_subset([('A', 'B'), ('B',), ('C',), ('B', 'A')])
+  [('A', 'B'), ('C',)]
 
-    Args:
-      cliques: A list of cliques.
+  Args:
+    cliques: A list of cliques.
 
-    Returns:
-      A new list containing a maximal subset of non-nested cliques.
-    """
-    cliques = sorted(cliques, key=len, reverse=True)
-    result = []
-    for cl in cliques:
-        if not any(set(cl) <= set(cl2) for cl2 in result):
-            result.append(cl)
-    return result
+  Returns:
+    A new list containing a maximal subset of non-nested cliques.
+  """
+  cliques = sorted(cliques, key=len, reverse=True)
+  result = []
+  for cl in cliques:
+    if not any(set(cl) <= set(cl2) for cl2 in result):
+      result.append(cl)
+  return result
 
 
 def clique_mapping(
@@ -112,36 +112,36 @@ def clique_mapping(
     all_cliques: Sequence[Clique],
     domain: Domain | None = None,
 ) -> dict[Clique, Clique]:
-    """Creates a mapping from cliques to their corresponding maximal clique.
+  """Creates a mapping from cliques to their corresponding maximal clique.
 
-    Example Usage:
-    >>> maximal_cliques = [('A', 'B'), ('B', 'C')]
-    >>> all_cliques = [('B', 'A'), ('B',), ('C',), ('B', 'C')]
-    >>> mapping = clique_mapping(maximal_cliques, all_cliques)
-    >>> print(mapping)
-    {('B', 'A'): ('A', 'B'), ('B',): ('A', 'B'), ('C',): ('B', 'C'), ('B', 'C'): ('B', 'C')}
+  Example Usage:
+  >>> maximal_cliques = [('A', 'B'), ('B', 'C')]
+  >>> all_cliques = [('B', 'A'), ('B',), ('C',), ('B', 'C')]
+  >>> mapping = clique_mapping(maximal_cliques, all_cliques)
+  >>> print(mapping)
+  {('B', 'A'): ('A', 'B'), ('B',): ('A', 'B'), ('C',): ('B', 'C'), ('B', 'C'): ('B', 'C')}
 
-    Args:
-      maximal_cliques: A list of maximal cliques.
-      all_cliques: A list of all cliques.
-      domain: Optional Domain object. If provided, links cliques to the
-              supporting maximal clique with the smallest domain size.
-              Otherwise, links to the one with fewest elements.
+  Args:
+    maximal_cliques: A list of maximal cliques.
+    all_cliques: A list of all cliques.
+    domain: Optional Domain object. If provided, links cliques to the
+            supporting maximal clique with the smallest domain size.
+            Otherwise, links to the one with fewest elements.
 
-    Returns:
-      A mapping from cliques to their maximal clique.
+  Returns:
+    A mapping from cliques to their maximal clique.
 
-    """
-    mapping = {}
-    for cl in all_cliques:
-        candidates = [m for m in maximal_cliques if set(cl) <= set(m)]
-        if not candidates:
-            continue
+  """
+  mapping = {}
+  for cl in all_cliques:
+    candidates = [m for m in maximal_cliques if set(cl) <= set(m)]
+    if not candidates:
+      continue
 
-        if domain is None:
-            best = min(candidates, key=len)
-        else:
-            best = min(candidates, key=lambda m: domain.size(m))
+    if domain is None:
+      best = min(candidates, key=len)
+    else:
+      best = min(candidates, key=lambda m: domain.size(m))
 
-        mapping[cl] = best
-    return mapping
+    mapping[cl] = best
+  return mapping

--- a/src/mbi/clique_vector.py
+++ b/src/mbi/clique_vector.py
@@ -27,208 +27,200 @@ from .factor import Factor, Projectable
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass  # pytype: disable=invalid-function-definition
 class CliqueVector:
-    """Manages a collection of factors, each associated with a clique.
+  """Manages a collection of factors, each associated with a clique.
 
-    This class provides a structure for holding and operating on multiple
-    `Factor` objects, where each factor corresponds to a clique (a subset of
-    attributes) within a larger domain. It's particularly useful in the context
-    of graphical models for representing sets of potentials or marginals.
+  This class provides a structure for holding and operating on multiple
+  `Factor` objects, where each factor corresponds to a clique (a subset of
+  attributes) within a larger domain. It's particularly useful in the context
+  of graphical models for representing sets of potentials or marginals.
 
-    Attributes:
-        domain (Domain): The overall domain that encompasses all cliques.
-        cliques (Sequence[Clique]): A tuple of cliques (tuples of attribute names)
-            for which factors are stored.
-        tables (dict[Clique, Factor]): A dictionary mapping each clique in
-            `cliques` to its corresponding `Factor` object.
+  Attributes:
+      domain (Domain): The overall domain that encompasses all cliques.
+      cliques (Sequence[Clique]): A tuple of cliques (tuples of attribute names)
+          for which factors are stored.
+      tables (dict[Clique, Factor]): A dictionary mapping each clique in
+          `cliques` to its corresponding `Factor` object.
+  """
+
+  domain: Domain = jax.tree.static()
+  cliques: Sequence[Clique] = jax.tree.static()
+  tables: dict[Clique, Factor]
+
+  def __post_init__(self):
+    self.cliques = tuple(self.cliques)
+    if set(self.cliques) != set(self.tables):
+      raise ValueError("Cliques must be equal to keys of tables.")
+    if len(self.cliques) != len(set(self.cliques)):
+      raise ValueError("Cliques must be unique.")
+
+  @property
+  def arrays(self) -> dict[Clique, Factor]:
+    """Deprecated: use ``tables`` instead."""
+    warnings.warn(
+        "CliqueVector.arrays is deprecated, use .tables instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return self.tables
+
+  @classmethod
+  def zeros(cls, domain: Domain, cliques: Sequence[Clique]) -> CliqueVector:
+    """Creates a CliqueVector initialized with zero factors for each clique."""
+    tables = {cl: Factor.zeros(domain.project(cl)) for cl in cliques}
+    return cls(domain, cliques, tables)
+
+  @classmethod
+  def ones(cls, domain: Domain, cliques: Sequence[Clique]) -> CliqueVector:
+    """Creates a CliqueVector initialized with one factors for each clique."""
+    tables = {cl: Factor.ones(domain.project(cl)) for cl in cliques}
+    return cls(domain, cliques, tables)
+
+  @classmethod
+  def random(cls, domain: Domain, cliques: Sequence[Clique]) -> CliqueVector:
+    """Creates a CliqueVector initialized with random factors for each clique."""
+    tables = {cl: Factor.random(domain.project(cl)) for cl in cliques}
+    return cls(domain, cliques, tables)
+
+  @classmethod
+  def abstract(cls, domain: Domain, cliques: Sequence[Clique]) -> CliqueVector:
+    tables = {cl: Factor.abstract(domain.project(cl)) for cl in cliques}
+    return cls(domain, cliques, tables)
+
+  @classmethod
+  def from_projectable(
+      cls, data: Projectable, cliques: Sequence[Clique]
+  ) -> CliqueVector:
+    """Creates a CliqueVector by projecting a data source onto the specified cliques."""
+    tables = {cl: data.project(cl) for cl in cliques}
+    return cls(data.domain, cliques, tables)
+
+  @functools.cached_property
+  def active_domain(self) -> Domain:
+    """Returns the merged domain encompassing all attributes across all cliques."""
+    domains = [self.domain.project(cl) for cl in self.cliques]
+    return functools.reduce(lambda a, b: a.merge(b), domains, Domain([], []))
+
+  # @functools.lru_cache(maxsize=None)
+  def parent(self, clique: Clique) -> Clique | None:
+    """Finds a clique in this vector that is a superset of the given clique."""
+    for result in self.cliques:
+      if set(clique) <= set(result):
+        return result
+
+  def supports(self, clique: Clique) -> bool:
+    """Checks if the given clique is supported (is a subset of any clique in the vector)."""
+    return self.parent(clique) is not None
+
+  def project(self, clique: Clique, log: bool = False) -> Factor:
+    clique = tuple(clique)
+    if clique in self.tables:
+      return self[clique]
+    if self.supports(clique):
+      return self[self.parent(clique)].project(clique, log=log)
+    raise ValueError(f"Cannot project onto unsupported clique {clique}.")
+
+  def expand(self, cliques: Sequence[Clique]) -> CliqueVector:
+    """Re-expresses this CliqueVector over an expanded set of cliques.
+
+    If the original CliqueVector represents the potentials of a Graphical Model,
+    the given cliques support the cliques in the original CliqueVector, then
+    the distribution represented by the new CliqueVector will be identical.
+
+    Args:
+        cliques: The new cliques the clique vector will be defined over.
+
+    Returns:
+        An expanded CliqueVector defined over the given set of cliques.
     """
+    mapping = reverse_clique_mapping(cliques, self.cliques, domain=self.domain)
+    tables = {}
+    for cl in cliques:
+      dom = self.domain.project(cl)
+      if len(mapping[cl]) == 0:
+        tables[cl] = Factor.zeros(dom)
+      else:
+        tables[cl] = sum(self[cl2] for cl2 in mapping[cl]).expand(dom)
+    return CliqueVector(self.domain, cliques, tables)
 
-    domain: Domain = jax.tree.static()
-    cliques: Sequence[Clique] = jax.tree.static()
-    tables: dict[Clique, Factor]
+  def contract(
+      self, cliques: Sequence[Clique], log: bool = False
+  ) -> CliqueVector:
+    """Computes a new CliqueVector by projecting this one onto a smaller set of cliques."""
+    tables = {cl: self.project(cl, log=log) for cl in cliques}
+    return CliqueVector(self.domain, cliques, tables)
 
-    def __post_init__(self):
-        self.cliques = tuple(self.cliques)
-        if set(self.cliques) != set(self.tables):
-            raise ValueError("Cliques must be equal to keys of tables.")
-        if len(self.cliques) != len(set(self.cliques)):
-            raise ValueError("Cliques must be unique.")
+  def normalize(self, total: float = 1, log: bool = True) -> CliqueVector:
+    """Normalizes each factor within the CliqueVector."""
+    return jax.tree.map(
+        lambda f: f.normalize(total, log),
+        self,
+        is_leaf=Factor.__instancecheck__,
+    )
 
-    @property
-    def arrays(self) -> dict[Clique, Factor]:
-        """Deprecated: use ``tables`` instead."""
-        warnings.warn(
-            "CliqueVector.arrays is deprecated, use .tables instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.tables
+  def __mul__(self, const: chex.Numeric) -> CliqueVector:
+    """Multiplies each factor in the vector by a constant."""
+    return jax.tree.map(lambda f: f * const, self)
 
-    @classmethod
-    def zeros(cls, domain: Domain, cliques: Sequence[Clique]) -> CliqueVector:
-        """Creates a CliqueVector initialized with zero factors for each clique."""
-        tables = {cl: Factor.zeros(domain.project(cl)) for cl in cliques}
-        return cls(domain, cliques, tables)
+  def __rmul__(self, const: chex.Numeric) -> CliqueVector:
+    """Right-multiplies each factor in the vector by a constant."""
+    return self.__mul__(const)
 
-    @classmethod
-    def ones(cls, domain: Domain, cliques: Sequence[Clique]) -> CliqueVector:
-        """Creates a CliqueVector initialized with one factors for each clique."""
-        tables = {cl: Factor.ones(domain.project(cl)) for cl in cliques}
-        return cls(domain, cliques, tables)
+  def __truediv__(self, const: chex.Numeric) -> CliqueVector:
+    """Divides each factor in the vector by a constant."""
+    return self.__mul__(1 / const)
 
-    @classmethod
-    def random(cls, domain: Domain, cliques: Sequence[Clique]) -> CliqueVector:
-        """Creates a CliqueVector initialized with random factors for each clique."""
-        tables = {cl: Factor.random(domain.project(cl)) for cl in cliques}
-        return cls(domain, cliques, tables)
+  def __add__(self, other: chex.Numeric | CliqueVector) -> CliqueVector:
+    """Adds another CliqueVector or a constant to this vector elementwise."""
+    if isinstance(other, CliqueVector):
+      return jax.tree.map(jnp.add, self, other)
+    return jax.tree.map(lambda f: f + other, self)
 
-    @classmethod
-    def abstract(
-        cls, domain: Domain, cliques: Sequence[Clique]
-    ) -> CliqueVector:
-        tables = {cl: Factor.abstract(domain.project(cl)) for cl in cliques}
-        return cls(domain, cliques, tables)
+  def __sub__(self, other: chex.Numeric | CliqueVector) -> CliqueVector:
+    """Subtracts another CliqueVector or a constant from this vector elementwise."""
+    return self + -1 * other
 
-    @classmethod
-    def from_projectable(
-        cls, data: Projectable, cliques: Sequence[Clique]
-    ) -> CliqueVector:
-        """Creates a CliqueVector by projecting a data source onto the specified cliques."""
-        tables = {cl: data.project(cl) for cl in cliques}
-        return cls(data.domain, cliques, tables)
+  def exp(self) -> CliqueVector:
+    """Applies elementwise exponentiation (jnp.exp) to each factor."""
+    return jax.tree.map(jnp.exp, self)
 
-    @functools.cached_property
-    def active_domain(self) -> Domain:
-        """Returns the merged domain encompassing all attributes across all cliques."""
-        domains = [self.domain.project(cl) for cl in self.cliques]
-        return functools.reduce(
-            lambda a, b: a.merge(b), domains, Domain([], [])
-        )
+  def log(self) -> CliqueVector:
+    """Applies elementwise logarithm (jnp.log) to each factor."""
+    return jax.tree.map(jnp.log, self)
 
-    # @functools.lru_cache(maxsize=None)
-    def parent(self, clique: Clique) -> Clique | None:
-        """Finds a clique in this vector that is a superset of the given clique."""
-        for result in self.cliques:
-            if set(clique) <= set(result):
-                return result
+  def dot(self, other: CliqueVector) -> chex.Numeric:
+    """Computes the dot product between this CliqueVector and another."""
+    dots = jax.tree.map(
+        Factor.dot, self, other, is_leaf=Factor.__instancecheck__
+    )
+    return jax.tree.reduce(operator.add, dots, 0)
 
-    def supports(self, clique: Clique) -> bool:
-        """Checks if the given clique is supported (is a subset of any clique in the vector)."""
-        return self.parent(clique) is not None
+  def size(self) -> int:
+    """Calculates the total number of parameters across all factors in the vector."""
+    return sum(self.domain.size(cl) for cl in self.cliques)
 
-    def project(self, clique: Clique, log: bool = False) -> Factor:
-        clique = tuple(clique)
-        if clique in self.tables:
-            return self[clique]
-        if self.supports(clique):
-            return self[self.parent(clique)].project(clique, log=log)
-        raise ValueError(f"Cannot project onto unsupported clique {clique}.")
+  def __getitem__(self, clique: Clique) -> Factor:
+    """Retrieves the factor associated with the given clique."""
+    return self.tables[clique]
 
-    def expand(self, cliques: Sequence[Clique]) -> CliqueVector:
-        """Re-expresses this CliqueVector over an expanded set of cliques.
+  def __setitem__(self, clique: Clique, value: Factor):
+    """Sets the factor for a given clique, replacing the existing one if present."""
+    if clique in self.cliques:
+      self.tables[clique] = value
+    else:
+      raise ValueError(f"Clique {clique} not in CliqueVector.")
 
-        If the original CliqueVector represents the potentials of a Graphical Model,
-        the given cliques support the cliques in the original CliqueVector, then
-        the distribution represented by the new CliqueVector will be identical.
+  def apply_sharding(self, mesh: jax.sharding.Mesh | None) -> CliqueVector:
+    """Apply sharding constraint to each factor in the CliqueVector.
 
-        Args:
-            cliques: The new cliques the clique vector will be defined over.
+    The sharding strategy is automatically determined based on the provided
+    mesh and the factor domains.
 
-        Returns:
-            An expanded CliqueVector defined over the given set of cliques.
-        """
-        mapping = reverse_clique_mapping(
-            cliques, self.cliques, domain=self.domain
-        )
-        tables = {}
-        for cl in cliques:
-            dom = self.domain.project(cl)
-            if len(mapping[cl]) == 0:
-                tables[cl] = Factor.zeros(dom)
-            else:
-                tables[cl] = sum(self[cl2] for cl2 in mapping[cl]).expand(dom)
-        return CliqueVector(self.domain, cliques, tables)
+    Args:
+        mesh: The mesh over which the factors should be sharded.
 
-    def contract(
-        self, cliques: Sequence[Clique], log: bool = False
-    ) -> CliqueVector:
-        """Computes a new CliqueVector by projecting this one onto a smaller set of cliques."""
-        tables = {cl: self.project(cl, log=log) for cl in cliques}
-        return CliqueVector(self.domain, cliques, tables)
-
-    def normalize(self, total: float = 1, log: bool = True) -> CliqueVector:
-        """Normalizes each factor within the CliqueVector."""
-        return jax.tree.map(
-            lambda f: f.normalize(total, log),
-            self,
-            is_leaf=Factor.__instancecheck__,
-        )
-
-    def __mul__(self, const: chex.Numeric) -> CliqueVector:
-        """Multiplies each factor in the vector by a constant."""
-        return jax.tree.map(lambda f: f * const, self)
-
-    def __rmul__(self, const: chex.Numeric) -> CliqueVector:
-        """Right-multiplies each factor in the vector by a constant."""
-        return self.__mul__(const)
-
-    def __truediv__(self, const: chex.Numeric) -> CliqueVector:
-        """Divides each factor in the vector by a constant."""
-        return self.__mul__(1 / const)
-
-    def __add__(self, other: chex.Numeric | CliqueVector) -> CliqueVector:
-        """Adds another CliqueVector or a constant to this vector elementwise."""
-        if isinstance(other, CliqueVector):
-            return jax.tree.map(jnp.add, self, other)
-        return jax.tree.map(lambda f: f + other, self)
-
-    def __sub__(self, other: chex.Numeric | CliqueVector) -> CliqueVector:
-        """Subtracts another CliqueVector or a constant from this vector elementwise."""
-        return self + -1 * other
-
-    def exp(self) -> CliqueVector:
-        """Applies elementwise exponentiation (jnp.exp) to each factor."""
-        return jax.tree.map(jnp.exp, self)
-
-    def log(self) -> CliqueVector:
-        """Applies elementwise logarithm (jnp.log) to each factor."""
-        return jax.tree.map(jnp.log, self)
-
-    def dot(self, other: CliqueVector) -> chex.Numeric:
-        """Computes the dot product between this CliqueVector and another."""
-        dots = jax.tree.map(
-            Factor.dot, self, other, is_leaf=Factor.__instancecheck__
-        )
-        return jax.tree.reduce(operator.add, dots, 0)
-
-    def size(self) -> int:
-        """Calculates the total number of parameters across all factors in the vector."""
-        return sum(self.domain.size(cl) for cl in self.cliques)
-
-    def __getitem__(self, clique: Clique) -> Factor:
-        """Retrieves the factor associated with the given clique."""
-        return self.tables[clique]
-
-    def __setitem__(self, clique: Clique, value: Factor):
-        """Sets the factor for a given clique, replacing the existing one if present."""
-        if clique in self.cliques:
-            self.tables[clique] = value
-        else:
-            raise ValueError(f"Clique {clique} not in CliqueVector.")
-
-    def apply_sharding(self, mesh: jax.sharding.Mesh | None) -> CliqueVector:
-        """Apply sharding constraint to each factor in the CliqueVector.
-
-        The sharding strategy is automatically determined based on the provided
-        mesh and the factor domains.
-
-        Args:
-            mesh: The mesh over which the factors should be sharded.
-
-        Returns:
-            A new CliqueVector identical to self with sharding constraints applied to
-            the underlying factors.
-        """
-        tables = {
-            cl: self.tables[cl].apply_sharding(mesh) for cl in self.cliques
-        }
-        return CliqueVector(self.domain, self.cliques, tables)
+    Returns:
+        A new CliqueVector identical to self with sharding constraints applied to
+        the underlying factors.
+    """
+    tables = {cl: self.tables[cl].apply_sharding(mesh) for cl in self.cliques}
+    return CliqueVector(self.domain, self.cliques, tables)

--- a/src/mbi/constraint.py
+++ b/src/mbi/constraint.py
@@ -18,89 +18,85 @@ from .factor import Factor
 
 
 def _validate_combos(arr, n_attrs, name):
-    shape = np.shape(arr)
-    if len(shape) != 2 or shape[1] != n_attrs:
-        raise ValueError(f"{name} must have shape (*, {n_attrs}), got {shape}.")
+  shape = np.shape(arr)
+  if len(shape) != 2 or shape[1] != n_attrs:
+    raise ValueError(f"{name} must have shape (*, {n_attrs}), got {shape}.")
 
 
 def _validate_mapping(mapping, domain):
-    if len(domain.attributes) != 2:
-        raise ValueError(
-            "mapping requires exactly 2 attributes (fine, coarse)."
-        )
-    shape = np.shape(mapping)
-    if len(shape) != 1 or shape[0] != domain.shape[0]:
-        raise ValueError(
-            f"mapping must have shape ({domain.shape[0]},), got {shape}."
-        )
+  if len(domain.attributes) != 2:
+    raise ValueError("mapping requires exactly 2 attributes (fine, coarse).")
+  shape = np.shape(mapping)
+  if len(shape) != 1 or shape[0] != domain.shape[0]:
+    raise ValueError(
+        f"mapping must have shape ({domain.shape[0]},), got {shape}."
+    )
 
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class Constraint:
-    """A structural constraint on allowed value combinations.
+  """A structural constraint on allowed value combinations.
 
-    Exactly one of ``valid``, ``invalid``, or ``mapping`` must be specified.
+  Exactly one of ``valid``, ``invalid``, or ``mapping`` must be specified.
 
-    Attributes:
-        domain: The sub-domain this constraint covers.
-        valid: Array of shape ``(n, len(domain))`` listing allowed combos.
-        invalid: Array of shape ``(n, len(domain))`` listing forbidden combos.
-        mapping: Array of shape ``(domain.shape[0],)`` defining a functional
-            dependency from the first attribute (fine) to the second (coarse).
-            Requires exactly two attributes in the domain.
-    """
+  Attributes:
+      domain: The sub-domain this constraint covers.
+      valid: Array of shape ``(n, len(domain))`` listing allowed combos.
+      invalid: Array of shape ``(n, len(domain))`` listing forbidden combos.
+      mapping: Array of shape ``(domain.shape[0],)`` defining a functional
+          dependency from the first attribute (fine) to the second (coarse).
+          Requires exactly two attributes in the domain.
+  """
 
-    domain: Domain = jax.tree.static()
-    valid: np.ndarray | None = None
-    invalid: np.ndarray | None = None
-    mapping: np.ndarray | None = None
+  domain: Domain = jax.tree.static()
+  valid: np.ndarray | None = None
+  invalid: np.ndarray | None = None
+  mapping: np.ndarray | None = None
 
-    def __post_init__(self):
-        # During JAX pytree reconstruction, fields are tracers.
-        for f in ("valid", "invalid", "mapping"):
-            if isinstance(getattr(self, f), jax.Array):
-                return
+  def __post_init__(self):
+    # During JAX pytree reconstruction, fields are tracers.
+    for f in ("valid", "invalid", "mapping"):
+      if isinstance(getattr(self, f), jax.Array):
+        return
 
-        n_set = sum(
-            x is not None for x in (self.valid, self.invalid, self.mapping)
-        )
-        if n_set != 1:
-            raise ValueError(
-                "Specify exactly one of 'valid', 'invalid', or 'mapping'."
-            )
+    n_set = sum(x is not None for x in (self.valid, self.invalid, self.mapping))
+    if n_set != 1:
+      raise ValueError(
+          "Specify exactly one of 'valid', 'invalid', or 'mapping'."
+      )
 
-        n = len(self.domain.attributes)
-        if self.valid is not None:
-            _validate_combos(self.valid, n, "valid")
-        elif self.invalid is not None:
-            _validate_combos(self.invalid, n, "invalid")
-        else:
-            _validate_mapping(self.mapping, self.domain)
+    n = len(self.domain.attributes)
+    if self.valid is not None:
+      _validate_combos(self.valid, n, "valid")
+    elif self.invalid is not None:
+      _validate_combos(self.invalid, n, "invalid")
+    else:
+      _validate_mapping(self.mapping, self.domain)
 
-    @property
-    def clique(self) -> tuple[str, ...]:
-        """Sorted attribute names, for junction tree construction."""
-        return tuple(sorted(self.domain.attributes))
+  @property
+  def clique(self) -> tuple[str, ...]:
+    """Sorted attribute names, for junction tree construction."""
+    return tuple(sorted(self.domain.attributes))
 
-    @property
-    def is_deterministic(self) -> bool:
-        """Whether this constraint is a functional dependency."""
-        return self.mapping is not None
+  @property
+  def is_deterministic(self) -> bool:
+    """Whether this constraint is a functional dependency."""
+    return self.mapping is not None
 
-    @property
-    def potential(self) -> Factor:
-        """Return a log-space potential: 0 for allowed, -inf for forbidden."""
-        if self.mapping is not None:
-            values = jnp.full(self.domain.shape, -jnp.inf)
-            fine_idx = jnp.arange(self.domain.shape[0])
-            values = values.at[fine_idx, self.mapping].set(0.0)
-        elif self.valid is not None:
-            valid = jnp.asarray(self.valid)
-            idx = tuple(valid[:, i] for i in range(valid.shape[1]))
-            values = jnp.full(self.domain.shape, -jnp.inf).at[idx].set(0.0)
-        else:
-            invalid = jnp.asarray(self.invalid)
-            idx = tuple(invalid[:, i] for i in range(invalid.shape[1]))
-            values = jnp.zeros(self.domain.shape).at[idx].set(-jnp.inf)
-        return Factor(self.domain, values)
+  @property
+  def potential(self) -> Factor:
+    """Return a log-space potential: 0 for allowed, -inf for forbidden."""
+    if self.mapping is not None:
+      values = jnp.full(self.domain.shape, -jnp.inf)
+      fine_idx = jnp.arange(self.domain.shape[0])
+      values = values.at[fine_idx, self.mapping].set(0.0)
+    elif self.valid is not None:
+      valid = jnp.asarray(self.valid)
+      idx = tuple(valid[:, i] for i in range(valid.shape[1]))
+      values = jnp.full(self.domain.shape, -jnp.inf).at[idx].set(0.0)
+    else:
+      invalid = jnp.asarray(self.invalid)
+      idx = tuple(invalid[:, i] for i in range(invalid.shape[1]))
+      values = jnp.zeros(self.domain.shape).at[idx].set(-jnp.inf)
+    return Factor(self.domain, values)

--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -25,431 +25,415 @@ from .factor import Factor
 
 
 def _validate_column_meta(data: np.ndarray, attr: str):
-    """Validate shape and dtype of a single column (no value checks)."""
-    if data.ndim != 1:
-        raise ValueError(f"Column '{attr}' must be 1D, got shape {data.shape}")
-    if not np.issubdtype(data.dtype, np.integer):
-        raise ValueError(
-            f"Column '{attr}' must have integer dtype, got {data.dtype}"
-        )
+  """Validate shape and dtype of a single column (no value checks)."""
+  if data.ndim != 1:
+    raise ValueError(f"Column '{attr}' must be 1D, got shape {data.shape}")
+  if not np.issubdtype(data.dtype, np.integer):
+    raise ValueError(
+        f"Column '{attr}' must have integer dtype, got {data.dtype}"
+    )
 
 
 def _validate_data(data: dict[str, np.ndarray], domain: Domain):
-    if set(data.keys()) != set(domain.attributes):
-        raise ValueError("Keys in data dictionary must match domain attributes")
-    n = None
-    for col in data:
-        _validate_column_meta(data[col], col)
-        if n is None:
-            n = data[col].shape[0]
-        if n != data[col].shape[0]:
-            raise ValueError("All columns must have the same length.")
+  if set(data.keys()) != set(domain.attributes):
+    raise ValueError("Keys in data dictionary must match domain attributes")
+  n = None
+  for col in data:
+    _validate_column_meta(data[col], col)
+    if n is None:
+      n = data[col].shape[0]
+    if n != data[col].shape[0]:
+      raise ValueError("All columns must have the same length.")
 
 
 def _validate_mapping(map_array: np.ndarray, attr: str):
-    if map_array.ndim != 1:
-        raise ValueError(f"Mapping for {attr} must be 1D array")
-    if not np.issubdtype(map_array.dtype, np.integer):
-        raise ValueError(f"Mapping for {attr} must be integers")
-    if np.any(map_array < 0):
-        raise ValueError(f"Mapping for {attr} must be non-negative")
+  if map_array.ndim != 1:
+    raise ValueError(f"Mapping for {attr} must be 1D array")
+  if not np.issubdtype(map_array.dtype, np.integer):
+    raise ValueError(f"Mapping for {attr} must be integers")
+  if np.any(map_array < 0):
+    raise ValueError(f"Mapping for {attr} must be non-negative")
 
 
 def _group_labels(orig_labels, mapping):
-    """Group labels into tuples according to a compression mapping."""
-    grouped = [[] for _ in range(int(mapping.max()) + 1)]
-    for i, b in enumerate(mapping):
-        grouped[b].append(orig_labels[i])
-    return tuple(tuple(g) for g in grouped)
+  """Group labels into tuples according to a compression mapping."""
+  grouped = [[] for _ in range(int(mapping.max()) + 1)]
+  for i, b in enumerate(mapping):
+    grouped[b].append(orig_labels[i])
+  return tuple(tuple(g) for g in grouped)
 
 
 def _compress_labels(domain, mapping, new_domain_config, labels=None):
-    """Build compressed label tuples from a domain and mapping."""
-    if domain.labels is None:
-        return None
-    lc = dict(domain.labels_config)
-    for attr, m in mapping.items():
-        if attr not in lc:
-            continue
-        if labels and attr in labels:
-            lc[attr] = labels[attr]
-        else:
-            lc[attr] = _group_labels(lc[attr], m)
-    return tuple(lc[a] for a in new_domain_config)
+  """Build compressed label tuples from a domain and mapping."""
+  if domain.labels is None:
+    return None
+  lc = dict(domain.labels_config)
+  for attr, m in mapping.items():
+    if attr not in lc:
+      continue
+    if labels and attr in labels:
+      lc[attr] = labels[attr]
+    else:
+      lc[attr] = _group_labels(lc[attr], m)
+  return tuple(lc[a] for a in new_domain_config)
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
 class Dataset:
-    """A discrete tabular dataset backed by a dictionary of 1D numpy arrays.
+  """A discrete tabular dataset backed by a dictionary of 1D numpy arrays.
+
+  Args:
+      data: Dictionary mapping attribute names to 1D integer arrays.
+      domain: A Domain describing the attributes and their sizes.
+      weights: Optional per-row weights (defaults to all ones).
+  """
+
+  data: dict[str, ArrayLike]
+  domain: Domain
+  weights: ArrayLike | None = dataclasses.field(default=None)
+
+  def __post_init__(self):
+    object.__setattr__(
+        self,
+        "data",
+        {k: np.asarray(v) for k, v in self.data.items()},
+    )
+    if self.weights is not None:
+      object.__setattr__(self, "weights", np.asarray(self.weights))
+
+    _validate_data(self.data, self.domain)
+
+    if self.data:
+      n = next(iter(self.data.values())).shape[0]
+    elif self.weights is not None:
+      n = self.weights.size
+    else:
+      raise ValueError(
+          "Weights must be provided if data is empty (cannot infer N)"
+      )
+
+    if self.weights is None:
+      object.__setattr__(self, "weights", np.ones(n))
+    elif self.weights.size != n:
+      raise ValueError(
+          f"Weights length ({self.weights.size}) does not match "
+          f"data length ({n})"
+      )
+
+  def to_dict(self) -> dict[str, np.ndarray]:
+    return self.data
+
+  @staticmethod
+  def synthetic(domain: Domain, N: int) -> Dataset:
+    """Generate random data conforming to the given domain.
 
     Args:
-        data: Dictionary mapping attribute names to 1D integer arrays.
-        domain: A Domain describing the attributes and their sizes.
-        weights: Optional per-row weights (defaults to all ones).
+        domain: The domain object.
+        N: The number of rows.
     """
+    data = {
+        attr: np.random.randint(low=0, high=n, size=N)
+        for attr, n in zip(domain.attributes, domain.shape)
+    }
+    return Dataset(data, domain)
 
-    data: dict[str, ArrayLike]
-    domain: Domain
-    weights: ArrayLike | None = dataclasses.field(default=None)
+  @staticmethod
+  def load(path: str, domain: str | Domain) -> Dataset:
+    """Load data from a CSV file.
 
-    def __post_init__(self):
-        object.__setattr__(
-            self,
-            "data",
-            {k: np.asarray(v) for k, v in self.data.items()},
+    .. deprecated::
+        ``Dataset.load`` will be removed in a future release.
+        Load the CSV yourself, convert columns to a
+        ``dict[str, np.ndarray]``, and pass it to ``Dataset`` directly.
+
+    Args:
+        path: Path to csv file.
+        domain: Path to json file encoding the domain, or a Domain.
+    """
+    warnings.warn(
+        "Dataset.load is deprecated. Load your data, convert columns "
+        "to a dict of numpy arrays, and instantiate Dataset directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if isinstance(domain, str):
+      with open(domain, "r", encoding="utf-8") as f:
+        config = json.load(f)
+      domain_obj = Domain(config.keys(), config.values())
+    else:
+      domain_obj = domain
+
+    with open(path, "r", encoding="utf-8") as f:
+      reader = csv.reader(f)
+      header = next(reader)
+      header_map = {name: i for i, name in enumerate(header)}
+
+      if not set(domain_obj.attributes) <= set(header):
+        raise ValueError("data must contain domain attributes")
+
+      indices = [header_map[attr] for attr in domain_obj.attributes]
+      rows = []
+      for row in reader:
+        try:
+          mapped_row = [int(float(row[i])) for i in indices]
+        except ValueError:
+          mapped_row = [int(row[i]) for i in indices]
+        rows.append(mapped_row)
+
+    arr = np.array(rows)
+    data = {attr: arr[:, i] for i, attr in enumerate(domain_obj.attributes)}
+    return Dataset(data, domain_obj)
+
+  def project(self, cols: int | str | Sequence[str] | Sequence[int]) -> Factor:
+    """Project dataset onto a subset of columns."""
+    if isinstance(cols, (str, int)):
+      cols = [cols]
+
+    domain = self.domain.project(cols)
+    data = {col: self.data[col] for col in domain.attributes}
+    sub = Dataset(data, domain, self.weights)
+    return Factor(sub.domain, jnp.asarray(sub.datavector(flatten=False)))
+
+  def supports(self, cols: str | Sequence[str]) -> bool:
+    return self.domain.supports(cols)
+
+  def drop(self, cols: Sequence[str]) -> Factor:
+    """Returns a Factor with the specified columns marginalized out."""
+    proj = [c for c in self.domain if c not in cols]
+    return self.project(proj)
+
+  @property
+  def records(self) -> int:
+    """Returns the number of records (rows) in the dataset."""
+    if not self.data:
+      return self.weights.size
+    return next(iter(self.data.values())).shape[0]
+
+  def datavector(self, flatten: bool = True) -> NDArray:
+    """Return the database in vector-of-counts form."""
+    dims = self.domain.shape
+    if len(dims) == 0:
+      result = self.weights.sum()
+      return np.array([result]) if flatten else result
+    multi_index = tuple(self.data[a] for a in self.domain.attributes)
+    linear_indices = np.ravel_multi_index(multi_index, dims, order="C")
+    counts = np.bincount(
+        linear_indices, minlength=math.prod(dims), weights=self.weights
+    )
+    return counts if flatten else counts.reshape(dims)
+
+  def compress(
+      self,
+      mapping: dict[str, np.ndarray],
+      labels: dict[str, tuple] | None = None,
+  ) -> Dataset:
+    """Compress the dataset by mapping domain elements to a smaller domain.
+
+    Args:
+        mapping: A dictionary where keys are attribute names and values
+            are 1D arrays.  ``mapping[attr][i]`` gives the new value
+            for original value ``i``.
+        labels: Optional explicit labels for the compressed domain.
+            If not provided and the domain has labels, the original
+            labels are grouped into tuples (e.g. compressing
+            ``("cat", "dog", "bird")`` with mapping ``[0, 0, 1]``
+            gives ``(("cat", "dog"), ("bird",))``).
+
+    Returns:
+        A new Dataset with transformed values and updated domain.
+    """
+    new_data = dict(self.data)
+    new_domain_config = self.domain.config.copy()
+
+    for attr, map_array in mapping.items():
+      if attr not in self.domain:
+        continue
+
+      _validate_mapping(map_array, attr)
+      if map_array.shape[0] != self.domain[attr]:
+        raise ValueError(
+            f"Mapping size {map_array.shape[0]} does not match domain"
+            f" size {self.domain[attr]} for attribute {attr}"
         )
-        if self.weights is not None:
-            object.__setattr__(self, "weights", np.asarray(self.weights))
 
-        _validate_data(self.data, self.domain)
+      new_col = map_array[self.data[attr]]
+      new_data[attr] = new_col.astype(np.min_scalar_type(np.max(map_array)))
+      new_domain_config[attr] = int(np.max(map_array) + 1)
 
-        if self.data:
-            n = next(iter(self.data.values())).shape[0]
-        elif self.weights is not None:
-            n = self.weights.size
-        else:
-            raise ValueError(
-                "Weights must be provided if data is empty (cannot infer N)"
-            )
+    new_domain = Domain(
+        new_domain_config.keys(),
+        new_domain_config.values(),
+        labels=_compress_labels(
+            self.domain, mapping, new_domain_config, labels
+        ),
+    )
+    return Dataset(new_data, new_domain, self.weights)
 
-        if self.weights is None:
-            object.__setattr__(self, "weights", np.ones(n))
-        elif self.weights.size != n:
-            raise ValueError(
-                f"Weights length ({self.weights.size}) does not match "
-                f"data length ({n})"
-            )
+  def decompress(self, mapping: dict[str, np.ndarray]) -> Dataset:
+    """Decompress the dataset by reversing the mapping.
 
-    def to_dict(self) -> dict[str, np.ndarray]:
-        return self.data
+    Since the mapping is surjective, the reverse mapping is one-to-many.
+    We sample uniformly from the possible original values.
 
-    @staticmethod
-    def synthetic(domain: Domain, N: int) -> Dataset:
-        """Generate random data conforming to the given domain.
+    Args:
+        mapping: The same mapping dictionary used for compression.
 
-        Args:
-            domain: The domain object.
-            N: The number of rows.
-        """
-        data = {
-            attr: np.random.randint(low=0, high=n, size=N)
-            for attr, n in zip(domain.attributes, domain.shape)
-        }
-        return Dataset(data, domain)
+    Returns:
+        A new Dataset with restored domain size and sampled values.
+    """
+    new_data = dict(self.data)
+    new_domain_config = self.domain.config.copy()
 
-    @staticmethod
-    def load(path: str, domain: str | Domain) -> Dataset:
-        """Load data from a CSV file.
+    for attr, map_array in mapping.items():
+      if attr not in self.domain:
+        continue
 
-        .. deprecated::
-            ``Dataset.load`` will be removed in a future release.
-            Load the CSV yourself, convert columns to a
-            ``dict[str, np.ndarray]``, and pass it to ``Dataset`` directly.
+      _validate_mapping(map_array, attr)
 
-        Args:
-            path: Path to csv file.
-            domain: Path to json file encoding the domain, or a Domain.
-        """
-        warnings.warn(
-            "Dataset.load is deprecated. Load your data, convert columns "
-            "to a dict of numpy arrays, and instantiate Dataset directly.",
-            DeprecationWarning,
-            stacklevel=2,
+      permutation = np.argsort(map_array)
+      sorted_map = map_array[permutation]
+
+      compressed_domain_size = int(np.max(map_array) + 1)
+      counts = np.bincount(sorted_map, minlength=compressed_domain_size)
+
+      starts = np.zeros(compressed_domain_size + 1, dtype=int)
+      starts[1:] = np.cumsum(counts)
+      starts = starts[:-1]
+
+      current_col = self.data[attr]
+
+      col_counts = counts[current_col]
+      if np.any(col_counts == 0):
+        raise ValueError(
+            f"Data contains values for {attr} that have no preimage"
+            " in the mapping."
         )
-        if isinstance(domain, str):
-            with open(domain, "r", encoding="utf-8") as f:
-                config = json.load(f)
-            domain_obj = Domain(config.keys(), config.values())
-        else:
-            domain_obj = domain
 
-        with open(path, "r", encoding="utf-8") as f:
-            reader = csv.reader(f)
-            header = next(reader)
-            header_map = {name: i for i, name in enumerate(header)}
+      random_offsets = np.floor(
+          np.random.rand(len(current_col)) * col_counts
+      ).astype(int)
 
-            if not set(domain_obj.attributes) <= set(header):
-                raise ValueError("data must contain domain attributes")
+      lookup_indices = starts[current_col] + random_offsets
 
-            indices = [header_map[attr] for attr in domain_obj.attributes]
-            rows = []
-            for row in reader:
-                try:
-                    mapped_row = [int(float(row[i])) for i in indices]
-                except ValueError:
-                    mapped_row = [int(row[i]) for i in indices]
-                rows.append(mapped_row)
+      new_col = permutation[lookup_indices]
+      new_data[attr] = new_col.astype(np.min_scalar_type(len(map_array) - 1))
 
-        arr = np.array(rows)
-        data = {attr: arr[:, i] for i, attr in enumerate(domain_obj.attributes)}
-        return Dataset(data, domain_obj)
+      new_domain_config[attr] = len(map_array)
 
-    def project(
-        self, cols: int | str | Sequence[str] | Sequence[int]
-    ) -> Factor:
-        """Project dataset onto a subset of columns."""
-        if isinstance(cols, (str, int)):
-            cols = [cols]
-
-        domain = self.domain.project(cols)
-        data = {col: self.data[col] for col in domain.attributes}
-        sub = Dataset(data, domain, self.weights)
-        return Factor(sub.domain, jnp.asarray(sub.datavector(flatten=False)))
-
-    def supports(self, cols: str | Sequence[str]) -> bool:
-        return self.domain.supports(cols)
-
-    def drop(self, cols: Sequence[str]) -> Factor:
-        """Returns a Factor with the specified columns marginalized out."""
-        proj = [c for c in self.domain if c not in cols]
-        return self.project(proj)
-
-    @property
-    def records(self) -> int:
-        """Returns the number of records (rows) in the dataset."""
-        if not self.data:
-            return self.weights.size
-        return next(iter(self.data.values())).shape[0]
-
-    def datavector(self, flatten: bool = True) -> NDArray:
-        """Return the database in vector-of-counts form."""
-        dims = self.domain.shape
-        if len(dims) == 0:
-            result = self.weights.sum()
-            return np.array([result]) if flatten else result
-        multi_index = tuple(self.data[a] for a in self.domain.attributes)
-        linear_indices = np.ravel_multi_index(multi_index, dims, order="C")
-        counts = np.bincount(
-            linear_indices, minlength=math.prod(dims), weights=self.weights
-        )
-        return counts if flatten else counts.reshape(dims)
-
-    def compress(
-        self,
-        mapping: dict[str, np.ndarray],
-        labels: dict[str, tuple] | None = None,
-    ) -> Dataset:
-        """Compress the dataset by mapping domain elements to a smaller domain.
-
-        Args:
-            mapping: A dictionary where keys are attribute names and values
-                are 1D arrays.  ``mapping[attr][i]`` gives the new value
-                for original value ``i``.
-            labels: Optional explicit labels for the compressed domain.
-                If not provided and the domain has labels, the original
-                labels are grouped into tuples (e.g. compressing
-                ``("cat", "dog", "bird")`` with mapping ``[0, 0, 1]``
-                gives ``(("cat", "dog"), ("bird",))``).
-
-        Returns:
-            A new Dataset with transformed values and updated domain.
-        """
-        new_data = dict(self.data)
-        new_domain_config = self.domain.config.copy()
-
-        for attr, map_array in mapping.items():
-            if attr not in self.domain:
-                continue
-
-            _validate_mapping(map_array, attr)
-            if map_array.shape[0] != self.domain[attr]:
-                raise ValueError(
-                    f"Mapping size {map_array.shape[0]} does not match domain"
-                    f" size {self.domain[attr]} for attribute {attr}"
-                )
-
-            new_col = map_array[self.data[attr]]
-            new_data[attr] = new_col.astype(
-                np.min_scalar_type(np.max(map_array))
-            )
-            new_domain_config[attr] = int(np.max(map_array) + 1)
-
-        new_domain = Domain(
-            new_domain_config.keys(),
-            new_domain_config.values(),
-            labels=_compress_labels(
-                self.domain, mapping, new_domain_config, labels
-            ),
-        )
-        return Dataset(new_data, new_domain, self.weights)
-
-    def decompress(self, mapping: dict[str, np.ndarray]) -> Dataset:
-        """Decompress the dataset by reversing the mapping.
-
-        Since the mapping is surjective, the reverse mapping is one-to-many.
-        We sample uniformly from the possible original values.
-
-        Args:
-            mapping: The same mapping dictionary used for compression.
-
-        Returns:
-            A new Dataset with restored domain size and sampled values.
-        """
-        new_data = dict(self.data)
-        new_domain_config = self.domain.config.copy()
-
-        for attr, map_array in mapping.items():
-            if attr not in self.domain:
-                continue
-
-            _validate_mapping(map_array, attr)
-
-            permutation = np.argsort(map_array)
-            sorted_map = map_array[permutation]
-
-            compressed_domain_size = int(np.max(map_array) + 1)
-            counts = np.bincount(sorted_map, minlength=compressed_domain_size)
-
-            starts = np.zeros(compressed_domain_size + 1, dtype=int)
-            starts[1:] = np.cumsum(counts)
-            starts = starts[:-1]
-
-            current_col = self.data[attr]
-
-            col_counts = counts[current_col]
-            if np.any(col_counts == 0):
-                raise ValueError(
-                    f"Data contains values for {attr} that have no preimage"
-                    " in the mapping."
-                )
-
-            random_offsets = np.floor(
-                np.random.rand(len(current_col)) * col_counts
-            ).astype(int)
-
-            lookup_indices = starts[current_col] + random_offsets
-
-            new_col = permutation[lookup_indices]
-            new_data[attr] = new_col.astype(
-                np.min_scalar_type(len(map_array) - 1)
-            )
-
-            new_domain_config[attr] = len(map_array)
-
-        new_domain = Domain(
-            new_domain_config.keys(), new_domain_config.values()
-        )
-        return Dataset(new_data, new_domain, self.weights)
+    new_domain = Domain(new_domain_config.keys(), new_domain_config.values())
+    return Dataset(new_data, new_domain, self.weights)
 
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class JaxDataset:
-    """Represents a discrete dataset backed by JAX Arrays.
+  """Represents a discrete dataset backed by JAX Arrays.
 
-    Attributes:
-        data (dict[str, jax.Array]): A dictionary of 1D JAX arrays where keys are attributes
-            and values are columns of data.
-        domain (Domain): A `Domain` object describing the attributes and their
-            possible discrete values.
-        weights (jax.Array | None): An optional 1D JAX array representing the
-            weight for each record in the dataset. If None, all records are
-            assumed to have a weight of 1.
+  Attributes:
+      data (dict[str, jax.Array]): A dictionary of 1D JAX arrays where keys are attributes
+          and values are columns of data.
+      domain (Domain): A `Domain` object describing the attributes and their
+          possible discrete values.
+      weights (jax.Array | None): An optional 1D JAX array representing the
+          weight for each record in the dataset. If None, all records are
+          assumed to have a weight of 1.
+  """
+
+  data: dict[str, jax.Array]
+  domain: Domain = jax.tree.static()
+  weights: jax.Array | None = None
+
+  @staticmethod
+  def synthetic(domain: Domain, records: int) -> JaxDataset:
+    """Generate synthetic data conforming to the given domain.
+
+    Args:
+        domain: The domain object.
+        records: The number of individuals.
     """
+    data = {}
+    for attr, n in zip(domain.attributes, domain.shape):
+      data[attr] = jnp.array(np.random.randint(low=0, high=n, size=records))
 
-    data: dict[str, jax.Array]
-    domain: Domain = jax.tree.static()
-    weights: jax.Array | None = None
+    return JaxDataset(data, domain)
 
-    @staticmethod
-    def synthetic(domain: Domain, records: int) -> JaxDataset:
-        """Generate synthetic data conforming to the given domain.
+  def project(self, cols: str | Sequence[str]) -> Factor:
+    """Project dataset onto a subset of columns."""
+    if isinstance(cols, (str, int)):
+      cols = [cols]
 
-        Args:
-            domain: The domain object.
-            records: The number of individuals.
-        """
-        data = {}
-        for attr, n in zip(domain.attributes, domain.shape):
-            data[attr] = jnp.array(
-                np.random.randint(low=0, high=n, size=records)
-            )
+    domain = self.domain.project(cols)
 
-        return JaxDataset(data, domain)
+    dims = domain.shape
+    if not dims:
+      w = self.weights if self.weights is not None else jnp.ones(self.records)
+      result = w.sum()
+      return Factor(domain, jnp.array([result]))
 
-    def project(self, cols: str | Sequence[str]) -> Factor:
-        """Project dataset onto a subset of columns."""
-        if isinstance(cols, (str, int)):
-            cols = [cols]
+    length = math.prod(dims)
+    dtype = np.min_scalar_type(length - 1)
+    multi_index = [self.data[a] for a in domain.attributes]
+    multi_index[0] = multi_index[0].astype(dtype)
+    linear_indices = jnp.ravel_multi_index(
+        tuple(multi_index), dims, mode="wrap", order="C"
+    )
 
-        domain = self.domain.project(cols)
+    counts = jnp.bincount(linear_indices, weights=self.weights, length=length)
 
-        dims = domain.shape
-        if not dims:
-            w = (
-                self.weights
-                if self.weights is not None
-                else jnp.ones(self.records)
-            )
-            result = w.sum()
-            return Factor(domain, jnp.array([result]))
+    return Factor(domain, counts.reshape(dims))
 
-        length = math.prod(dims)
-        dtype = np.min_scalar_type(length - 1)
-        multi_index = [self.data[a] for a in domain.attributes]
-        multi_index[0] = multi_index[0].astype(dtype)
-        linear_indices = jnp.ravel_multi_index(
-            tuple(multi_index), dims, mode="wrap", order="C"
-        )
+  def supports(self, cols: str | Sequence[str]) -> bool:
+    return self.domain.supports(cols)
 
-        counts = jnp.bincount(
-            linear_indices, weights=self.weights, length=length
-        )
+  @property
+  def records(self) -> int:
+    """Returns the number of records (rows) in the dataset."""
+    if not self.data:
+      raise ValueError("Dataset is empty (no columns).")
+    return list(self.data.values())[0].shape[0]
 
-        return Factor(domain, counts.reshape(dims))
+  def apply_sharding(self, mesh: jax.sharding.Mesh) -> JaxDataset:
+    pspec = jax.sharding.PartitionSpec(mesh.axis_names)
+    sharding = jax.sharding.NamedSharding(mesh, pspec)
 
-    def supports(self, cols: str | Sequence[str]) -> bool:
-        return self.domain.supports(cols)
+    new_data = {}
+    for k, v in self.data.items():
+      new_data[k] = jax.lax.with_sharding_constraint(v, sharding)
 
-    @property
-    def records(self) -> int:
-        """Returns the number of records (rows) in the dataset."""
-        if not self.data:
-            raise ValueError("Dataset is empty (no columns).")
-        return list(self.data.values())[0].shape[0]
+    weights = (
+        self.weights
+        if self.weights is None
+        else jax.lax.with_sharding_constraint(self.weights, sharding)
+    )
+    return JaxDataset(new_data, self.domain, weights)
 
-    def apply_sharding(self, mesh: jax.sharding.Mesh) -> JaxDataset:
-        pspec = jax.sharding.PartitionSpec(mesh.axis_names)
-        sharding = jax.sharding.NamedSharding(mesh, pspec)
+  def synthetic_data(self, rows: int | None = None) -> Dataset:
+    """Generate synthetic data via randomized rounding of weights.
 
-        new_data = {}
-        for k, v in self.data.items():
-            new_data[k] = jax.lax.with_sharding_constraint(v, sharding)
+    Args:
+        rows: Number of rows to generate.  Defaults to the sum of weights.
 
-        weights = (
-            self.weights
-            if self.weights is None
-            else jax.lax.with_sharding_constraint(self.weights, sharding)
-        )
-        return JaxDataset(new_data, self.domain, weights)
-
-    def synthetic_data(self, rows: int | None = None) -> Dataset:
-        """Generate synthetic data via randomized rounding of weights.
-
-        Args:
-            rows: Number of rows to generate.  Defaults to the sum of weights.
-
-        Returns:
-            A Dataset with integer-valued rows.
-        """
-        weights = np.asarray(
-            self.weights if self.weights is not None else np.ones(self.records)
-        )
-        total = max(1, int(rows or weights.sum()))
-        rng = np.random.default_rng()
-        counts = weights * total / weights.sum()
-        frac, integ = np.modf(counts)
-        integ = integ.astype(int)
-        extra = total - integ.sum()
-        if extra > 0:
-            p = frac / frac.sum()
-            idx = rng.choice(len(counts), extra, replace=False, p=p)
-            integ[idx] += 1
-        row_indices = np.repeat(np.arange(len(counts)), integ)
-        rng.shuffle(row_indices)
-        row_indices = row_indices[:total]
-        data = {
-            col: np.asarray(self.data[col])[row_indices]
-            for col in self.domain.attributes
-        }
-        return Dataset(data, self.domain)
+    Returns:
+        A Dataset with integer-valued rows.
+    """
+    weights = np.asarray(
+        self.weights if self.weights is not None else np.ones(self.records)
+    )
+    total = max(1, int(rows or weights.sum()))
+    rng = np.random.default_rng()
+    counts = weights * total / weights.sum()
+    frac, integ = np.modf(counts)
+    integ = integ.astype(int)
+    extra = total - integ.sum()
+    if extra > 0:
+      p = frac / frac.sum()
+      idx = rng.choice(len(counts), extra, replace=False, p=p)
+      integ[idx] += 1
+    row_indices = np.repeat(np.arange(len(counts)), integ)
+    rng.shuffle(row_indices)
+    row_indices = row_indices[:total]
+    data = {
+        col: np.asarray(self.data[col])[row_indices]
+        for col in self.domain.attributes
+    }
+    return Dataset(data, self.domain)

--- a/src/mbi/domain.py
+++ b/src/mbi/domain.py
@@ -17,243 +17,237 @@ import attr
 
 @attr.dataclass(frozen=True)
 class Domain:
-    """Represents a discrete domain defined by attributes and their sizes.
+  """Represents a discrete domain defined by attributes and their sizes.
 
-    This class encapsulates a set of named attributes and their corresponding
-    discrete sizes (shapes). It provides methods for common domain operations.
+  This class encapsulates a set of named attributes and their corresponding
+  discrete sizes (shapes). It provides methods for common domain operations.
 
-    Attributes:
-        attributes (tuple[str, ...]): A tuple containing the names of the
-            attributes in the domain.
-        shape (tuple[int, ...]): A tuple containing the integer sizes
-            (number of discrete values) for each corresponding attribute in
-            the `attributes` tuple.
-        labels (tuple[tuple[Any, ...], ...] | None): An optional tuple of tuples
-            containing semantic information (labels) for each attribute's values.
-            Must be the same length as attributes, and each inner tuple must have
-            length corresponding to the attribute's size.
+  Attributes:
+      attributes (tuple[str, ...]): A tuple containing the names of the
+          attributes in the domain.
+      shape (tuple[int, ...]): A tuple containing the integer sizes
+          (number of discrete values) for each corresponding attribute in
+          the `attributes` tuple.
+      labels (tuple[tuple[Any, ...], ...] | None): An optional tuple of tuples
+          containing semantic information (labels) for each attribute's values.
+          Must be the same length as attributes, and each inner tuple must have
+          length corresponding to the attribute's size.
 
-    Supported Operations:
-        - Projection (`project`): Creates a new domain with a subset of attributes.
-        - Marginalization (`marginalize`): Creates a new domain excluding specified attributes.
-        - Intersection (`intersect`): Creates a new domain containing only common attributes.
-        - Merging (`merge`): Combines two domains into a larger one.
-        - Size Calculation (`size`): Computes the total number of configurations in the domain or a subset.
+  Supported Operations:
+      - Projection (`project`): Creates a new domain with a subset of attributes.
+      - Marginalization (`marginalize`): Creates a new domain excluding specified attributes.
+      - Intersection (`intersect`): Creates a new domain containing only common attributes.
+      - Merging (`merge`): Combines two domains into a larger one.
+      - Size Calculation (`size`): Computes the total number of configurations in the domain or a subset.
 
-    Example Usage (using fromdict):
-        >>> domain = Domain.fromdict({'a': 2, 'b': 3})
-        >>> print(domain)
-        Domain(a: 2, b: 3)
+  Example Usage (using fromdict):
+      >>> domain = Domain.fromdict({'a': 2, 'b': 3})
+      >>> print(domain)
+      Domain(a: 2, b: 3)
+  """
+
+  attributes: tuple[str, ...] = attr.field(converter=tuple)
+  shape: tuple[int, ...] = attr.field(
+      converter=lambda sh: tuple(int(n) for n in sh)
+  )
+  labels: tuple[tuple[Any, ...], ...] | None = attr.field(
+      default=None,
+      eq=False,
+      hash=False,
+      converter=lambda l: tuple(tuple(x) for x in l) if l is not None else None,
+  )
+
+  def __attrs_post_init__(self):
+    if len(self.attributes) != len(self.shape):
+      raise ValueError("Dimensions must be equal.")
+    if len(self.attributes) != len(set(self.attributes)):
+      raise ValueError("Attributes must be unique.")
+    if self.labels is not None:
+      if len(self.labels) != len(self.attributes):
+        raise ValueError("Labels must be same length as attributes.")
+      for i, l in enumerate(self.labels):
+        if len(l) != self.shape[i]:
+          raise ValueError(
+              f"Labels for {self.attributes[i]} must have length"
+              f" {self.shape[i]}."
+          )
+
+  @functools.cached_property
+  def config(self) -> dict[str, int]:
+    """Returns a dictionary of { attr : size } values."""
+    return dict(zip(self.attributes, self.shape))
+
+  @functools.cached_property
+  def labels_config(self) -> dict[str, tuple[Any, ...]] | None:
+    """Returns a dictionary of { attr : labels } values."""
+    if self.labels is None:
+      return None
+    return dict(zip(self.attributes, self.labels))
+
+  @staticmethod
+  def fromdict(config: dict[str, int]) -> "Domain":
+    """Construct a Domain object from a dictionary of { attr : size } values.
+
+    Example Usage:
+        >>> print(Domain.fromdict({'a': 10, 'b': 20}))
+        Domain(a: 10, b: 20)
+
+    Args:
+      config: a dictionary of { attr : size } values
+    Returns:
+      the Domain object
     """
+    return Domain(config.keys(), config.values())
 
-    attributes: tuple[str, ...] = attr.field(converter=tuple)
-    shape: tuple[int, ...] = attr.field(
-        converter=lambda sh: tuple(int(n) for n in sh)
+  def project(self, attributes: str | Sequence[str]) -> "Domain":
+    """Project the domain onto a subset of attributes.
+
+    Args:
+      attributes: the attributes to project onto
+    Returns:
+      the projected Domain object
+    """
+    if isinstance(attributes, str):
+      attributes = [attributes]
+    if not set(attributes) <= set(self.attributes):
+      raise ValueError(f"Cannot project {self} onto {attributes}.")
+    shape = tuple(self.config[a] for a in attributes)
+    labels = None
+    if self.labels is not None:
+      labels = tuple(self.labels_config[a] for a in attributes)
+    return Domain(attributes, shape, labels=labels)
+
+  def marginalize(self, attrs: Sequence[str]) -> "Domain":
+    """Marginalize out some attributes from the domain (opposite of project).
+
+    Example Usage:
+        >>> D1 = Domain(['a','b'], [10,20])
+        >>> print(D1.marginalize(['a']))
+        Domain(b: 20)
+
+    Args:
+      attrs: the attributes to marginalize out.
+
+    Returns:
+      the marginalized Domain object
+    """
+    proj = [a for a in self.attributes if a not in attrs]
+    return self.project(proj)
+
+  def contains(self, other: "Domain") -> bool:
+    """Checks if this domain contains all attributes present in another domain."""
+    return set(other.attributes) <= set(self.attributes)
+
+  def canonical(self, attrs: Sequence[str]) -> tuple[str, ...]:
+    """Returns attributes common to the domain and input, maintaining the domain's order."""
+    return tuple(a for a in self.attributes if a in attrs)
+
+  def invert(self, attrs: Sequence[str]) -> list[str]:
+    """Returns attributes present in the domain but not in the provided list."""
+    return [a for a in self.attributes if a not in attrs]
+
+  def intersect(self, other: "Domain") -> "Domain":
+    """Intersect this Domain object with another.
+
+    Example Usage:
+        >>> D1 = Domain(['a','b'], [10,20])
+        >>> D2 = Domain(['b','c'], [20,30])
+        >>> print(D1.intersect(D2))
+        Domain(b: 20)
+
+    Args:
+      other: another Domain object
+    Returns:
+      the intersection of the two domains
+    """
+    return self.project([a for a in self.attributes if a in other.attributes])
+
+  def axes(self, attrs: Sequence[str]) -> tuple[int, ...]:
+    """Return the axes tuple for the given attributes.
+
+    Args:
+      attrs: the attributes
+    Returns:
+      a tuple with the corresponding axes
+    """
+    return tuple(self.attributes.index(a) for a in attrs)
+
+  def merge(self, other: "Domain") -> "Domain":
+    """Merge this Domain object with another.
+
+    Example:
+        >>> D1 = Domain(['a','b'], [10,20])
+        >>> D2 = Domain(['b','c'], [20,30])
+        >>> print(D1.merge(D2))
+        Domain(a: 10, b: 20, c: 30)
+
+    Args:
+      other: another Domain object
+    Returns:
+      a new domain object covering the combined domain.
+    """
+    extra = other.marginalize(self.attributes)
+    new_labels = None
+    if self.labels is not None and other.labels is not None:
+      new_labels = self.labels + extra.labels
+    return Domain(
+        self.attributes + extra.attributes,
+        self.shape + extra.shape,
+        labels=new_labels,
     )
-    labels: tuple[tuple[Any, ...], ...] | None = attr.field(
-        default=None,
-        eq=False,
-        hash=False,
-        converter=lambda l: tuple(tuple(x) for x in l)
-        if l is not None
-        else None,
+
+  def size(self, attributes: Sequence[str] | None = None) -> int:
+    """Return the total size of the domain.
+
+    Example:
+        >>> D1 = Domain(['a','b'], [10,20])
+        >>> D1.size()
+        200
+        >>> D1.size(['a'])
+        10
+
+    Args:
+      attributes: A subset of attributes whose total size should be returned.
+
+    Returns:
+      the total size of the domain
+    """
+    if attributes is None:
+      return math.prod(self.shape)
+    return self.project(attributes).size()
+
+  @property
+  def attrs(self) -> tuple[str, ...]:
+    """Alias for the `attributes` tuple.
+
+    .. deprecated::
+        Use :attr:`attributes` instead.
+    """
+    warnings.warn(
+        "Domain.attrs is deprecated. Use Domain.attributes instead.",
+        DeprecationWarning,
+        stacklevel=2,
     )
+    return self.attributes
 
-    def __attrs_post_init__(self):
-        if len(self.attributes) != len(self.shape):
-            raise ValueError("Dimensions must be equal.")
-        if len(self.attributes) != len(set(self.attributes)):
-            raise ValueError("Attributes must be unique.")
-        if self.labels is not None:
-            if len(self.labels) != len(self.attributes):
-                raise ValueError("Labels must be same length as attributes.")
-            for i, l in enumerate(self.labels):
-                if len(l) != self.shape[i]:
-                    raise ValueError(
-                        f"Labels for {self.attributes[i]} must have length"
-                        f" {self.shape[i]}."
-                    )
+  def supports(self, attrs: str | Sequence[str]) -> bool:
+    if isinstance(attrs, str):
+      attrs = [attrs]
+    return set(attrs) <= set(self.attributes)
 
-    @functools.cached_property
-    def config(self) -> dict[str, int]:
-        """Returns a dictionary of { attr : size } values."""
-        return dict(zip(self.attributes, self.shape))
+  def __contains__(self, name: str) -> bool:
+    """Check if the given attribute is in the domain."""
+    return name in self.attributes
 
-    @functools.cached_property
-    def labels_config(self) -> dict[str, tuple[Any, ...]] | None:
-        """Returns a dictionary of { attr : labels } values."""
-        if self.labels is None:
-            return None
-        return dict(zip(self.attributes, self.labels))
+  def __getitem__(self, a: str) -> int:
+    return self.config[a]
 
-    @staticmethod
-    def fromdict(config: dict[str, int]) -> "Domain":
-        """Construct a Domain object from a dictionary of { attr : size } values.
+  def __iter__(self) -> Iterator[str]:
+    return self.attributes.__iter__()
 
-        Example Usage:
-            >>> print(Domain.fromdict({'a': 10, 'b': 20}))
-            Domain(a: 10, b: 20)
+  def __len__(self) -> int:
+    return len(self.attributes)
 
-        Args:
-          config: a dictionary of { attr : size } values
-        Returns:
-          the Domain object
-        """
-        return Domain(config.keys(), config.values())
-
-    def project(self, attributes: str | Sequence[str]) -> "Domain":
-        """Project the domain onto a subset of attributes.
-
-        Args:
-          attributes: the attributes to project onto
-        Returns:
-          the projected Domain object
-        """
-        if isinstance(attributes, str):
-            attributes = [attributes]
-        if not set(attributes) <= set(self.attributes):
-            raise ValueError(f"Cannot project {self} onto {attributes}.")
-        shape = tuple(self.config[a] for a in attributes)
-        labels = None
-        if self.labels is not None:
-            labels = tuple(self.labels_config[a] for a in attributes)
-        return Domain(attributes, shape, labels=labels)
-
-    def marginalize(self, attrs: Sequence[str]) -> "Domain":
-        """Marginalize out some attributes from the domain (opposite of project).
-
-        Example Usage:
-            >>> D1 = Domain(['a','b'], [10,20])
-            >>> print(D1.marginalize(['a']))
-            Domain(b: 20)
-
-        Args:
-          attrs: the attributes to marginalize out.
-
-        Returns:
-          the marginalized Domain object
-        """
-        proj = [a for a in self.attributes if a not in attrs]
-        return self.project(proj)
-
-    def contains(self, other: "Domain") -> bool:
-        """Checks if this domain contains all attributes present in another domain."""
-        return set(other.attributes) <= set(self.attributes)
-
-    def canonical(self, attrs: Sequence[str]) -> tuple[str, ...]:
-        """Returns attributes common to the domain and input, maintaining the domain's order."""
-        return tuple(a for a in self.attributes if a in attrs)
-
-    def invert(self, attrs: Sequence[str]) -> list[str]:
-        """Returns attributes present in the domain but not in the provided list."""
-        return [a for a in self.attributes if a not in attrs]
-
-    def intersect(self, other: "Domain") -> "Domain":
-        """Intersect this Domain object with another.
-
-        Example Usage:
-            >>> D1 = Domain(['a','b'], [10,20])
-            >>> D2 = Domain(['b','c'], [20,30])
-            >>> print(D1.intersect(D2))
-            Domain(b: 20)
-
-        Args:
-          other: another Domain object
-        Returns:
-          the intersection of the two domains
-        """
-        return self.project(
-            [a for a in self.attributes if a in other.attributes]
-        )
-
-    def axes(self, attrs: Sequence[str]) -> tuple[int, ...]:
-        """Return the axes tuple for the given attributes.
-
-        Args:
-          attrs: the attributes
-        Returns:
-          a tuple with the corresponding axes
-        """
-        return tuple(self.attributes.index(a) for a in attrs)
-
-    def merge(self, other: "Domain") -> "Domain":
-        """Merge this Domain object with another.
-
-        Example:
-            >>> D1 = Domain(['a','b'], [10,20])
-            >>> D2 = Domain(['b','c'], [20,30])
-            >>> print(D1.merge(D2))
-            Domain(a: 10, b: 20, c: 30)
-
-        Args:
-          other: another Domain object
-        Returns:
-          a new domain object covering the combined domain.
-        """
-        extra = other.marginalize(self.attributes)
-        new_labels = None
-        if self.labels is not None and other.labels is not None:
-            new_labels = self.labels + extra.labels
-        return Domain(
-            self.attributes + extra.attributes,
-            self.shape + extra.shape,
-            labels=new_labels,
-        )
-
-    def size(self, attributes: Sequence[str] | None = None) -> int:
-        """Return the total size of the domain.
-
-        Example:
-            >>> D1 = Domain(['a','b'], [10,20])
-            >>> D1.size()
-            200
-            >>> D1.size(['a'])
-            10
-
-        Args:
-          attributes: A subset of attributes whose total size should be returned.
-
-        Returns:
-          the total size of the domain
-        """
-        if attributes is None:
-            return math.prod(self.shape)
-        return self.project(attributes).size()
-
-    @property
-    def attrs(self) -> tuple[str, ...]:
-        """Alias for the `attributes` tuple.
-
-        .. deprecated::
-            Use :attr:`attributes` instead.
-        """
-        warnings.warn(
-            "Domain.attrs is deprecated. Use Domain.attributes instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.attributes
-
-    def supports(self, attrs: str | Sequence[str]) -> bool:
-        if isinstance(attrs, str):
-            attrs = [attrs]
-        return set(attrs) <= set(self.attributes)
-
-    def __contains__(self, name: str) -> bool:
-        """Check if the given attribute is in the domain."""
-        return name in self.attributes
-
-    def __getitem__(self, a: str) -> int:
-        return self.config[a]
-
-    def __iter__(self) -> Iterator[str]:
-        return self.attributes.__iter__()
-
-    def __len__(self) -> int:
-        return len(self.attributes)
-
-    def __str__(self) -> str:
-        inner = ", ".join(
-            ["%s: %d" % x for x in zip(self.attributes, self.shape)]
-        )
-        return "Domain(%s)" % inner
+  def __str__(self) -> str:
+    inner = ", ".join(["%s: %d" % x for x in zip(self.attributes, self.shape)])
+    return "Domain(%s)" % inner

--- a/src/mbi/einsum.py
+++ b/src/mbi/einsum.py
@@ -18,138 +18,132 @@ def custom_dot_general(
     combine_fn: Callable[[jax.Array, jax.Array], jax.Array] = jnp.multiply,
     reduce_fn: Callable[[jax.Array, int | Sequence[int]], jax.Array] = jnp.sum,
 ) -> jax.Array:
-    """Computes a generalized dot product of two arrays.
+  """Computes a generalized dot product of two arrays.
 
-    This function extends the concept of `jax.numpy.dot_general` by allowing
-    custom functions for combining elements and reducing along contracting
-    dimensions. Specifically, this function works by making lhs and rhs
-    broadcast-compatible, calling combine_fn on them to merge them into a single
-    Array, then calling reduce_fn, to marginalize over the contracting dimensions.
+  This function extends the concept of `jax.numpy.dot_general` by allowing
+  custom functions for combining elements and reducing along contracting
+  dimensions. Specifically, this function works by making lhs and rhs
+  broadcast-compatible, calling combine_fn on them to merge them into a single
+  Array, then calling reduce_fn, to marginalize over the contracting dimensions.
 
-    Without JIT compilation, this implementation requires materializing the
-    potentially large intermediate obtained after calling combine_fn, but before
-    calling reduce_fn.  Under JIT, especially with XLA:GPU or XLA:TPU compilers,
-    these operations will often be fused to save memory.
+  Without JIT compilation, this implementation requires materializing the
+  potentially large intermediate obtained after calling combine_fn, but before
+  calling reduce_fn.  Under JIT, especially with XLA:GPU or XLA:TPU compilers,
+  these operations will often be fused to save memory.
 
-    Examples:
-    - combine_fn=jnp.add, reduce_fn=jax.scipy.special.logsumexp gives a
-      numerically stable implementations of dot_general that works in logspace.
-    - combine_fn=jnp.add, reduce_fn=jnp.max gives a method for finding the maximum
-      element along contracting dimensions in a broadcasted sum.
+  Examples:
+  - combine_fn=jnp.add, reduce_fn=jax.scipy.special.logsumexp gives a
+    numerically stable implementations of dot_general that works in logspace.
+  - combine_fn=jnp.add, reduce_fn=jnp.max gives a method for finding the maximum
+    element along contracting dimensions in a broadcasted sum.
 
-    Args:
-      lhs: The left-hand side array-like input.
-      rhs: The right-hand side array-like input.
-      dimension_numbers: See jax.lax.dot_general for details.
-      precision: Currently unused by this implementation.
-      preferred_element_type: Optional. This argument is from the JAX API. If
-        provided, `lhs` and `rhs` inputs are cast to this `jax.numpy.dtype`.
-      combine_fn: A callable (default: `jnp.multiply`) that takes two arrays (the
-        broadcast-compatible expanded `lhs` and `rhs`) and returns an array.
-        This function is applied element-wise before reduction.
-        Example: `jnp.add` for log-space style combination.
-      reduce_fn: A callable (default: `jnp.sum`) that takes an array and an `axis`
-        argument. It may optionally accept `keepdims`. It's used to reduce results
-        along the contracting dimensions. `keepdims=False` behavior is expected.
-        Example: `jax.scipy.special.logsumexp` for log-space style reduction.
-      out_sharding: Ignored.
+  Args:
+    lhs: The left-hand side array-like input.
+    rhs: The right-hand side array-like input.
+    dimension_numbers: See jax.lax.dot_general for details.
+    precision: Currently unused by this implementation.
+    preferred_element_type: Optional. This argument is from the JAX API. If
+      provided, `lhs` and `rhs` inputs are cast to this `jax.numpy.dtype`.
+    combine_fn: A callable (default: `jnp.multiply`) that takes two arrays (the
+      broadcast-compatible expanded `lhs` and `rhs`) and returns an array.
+      This function is applied element-wise before reduction.
+      Example: `jnp.add` for log-space style combination.
+    reduce_fn: A callable (default: `jnp.sum`) that takes an array and an `axis`
+      argument. It may optionally accept `keepdims`. It's used to reduce results
+      along the contracting dimensions. `keepdims=False` behavior is expected.
+      Example: `jax.scipy.special.logsumexp` for log-space style reduction.
+    out_sharding: Ignored.
 
-    Returns:
-      An array containing the result of the generalized dot product.
-    """
+  Returns:
+    An array containing the result of the generalized dot product.
+  """
 
-    del precision, preferred_element_type  # unused
+  del precision, preferred_element_type  # unused
 
-    (lhs_contract, rhs_contract), (lhs_batch, rhs_batch) = dimension_numbers
+  (lhs_contract, rhs_contract), (lhs_batch, rhs_batch) = dimension_numbers
 
-    lhs_used_dims = set(list(lhs_contract) + list(lhs_batch))
-    lhs_other_dims = sorted(
-        [i for i in range(lhs.ndim) if i not in lhs_used_dims]
-    )
+  lhs_used_dims = set(list(lhs_contract) + list(lhs_batch))
+  lhs_other_dims = sorted(
+      [i for i in range(lhs.ndim) if i not in lhs_used_dims]
+  )
 
-    rhs_used_dims = set(list(rhs_contract) + list(rhs_batch))
-    rhs_other_dims = sorted(
-        [i for i in range(rhs.ndim) if i not in rhs_used_dims]
-    )
+  rhs_used_dims = set(list(rhs_contract) + list(rhs_batch))
+  rhs_other_dims = sorted(
+      [i for i in range(rhs.ndim) if i not in rhs_used_dims]
+  )
 
-    lhs_permutation = (
-        list(lhs_batch) + list(lhs_other_dims) + list(lhs_contract)
-    )
-    rhs_permutation = (
-        list(rhs_batch) + list(rhs_other_dims) + list(rhs_contract)
-    )
+  lhs_permutation = list(lhs_batch) + list(lhs_other_dims) + list(lhs_contract)
+  rhs_permutation = list(rhs_batch) + list(rhs_other_dims) + list(rhs_contract)
 
-    lhs_permuted = jnp.transpose(lhs, axes=lhs_permutation)
-    rhs_permuted = jnp.transpose(rhs, axes=rhs_permutation)
+  lhs_permuted = jnp.transpose(lhs, axes=lhs_permutation)
+  rhs_permuted = jnp.transpose(rhs, axes=rhs_permutation)
 
-    batch_dims = len(lhs_batch)
-    lhs_other_dims = len(lhs_other_dims)
-    rhs_other_dims = len(rhs_other_dims)
-    contract_dims = len(lhs_contract)
+  batch_dims = len(lhs_batch)
+  lhs_other_dims = len(lhs_other_dims)
+  rhs_other_dims = len(rhs_other_dims)
+  contract_dims = len(lhs_contract)
 
-    # Make broadcast compatible
-    new_axes = tuple(
-        batch_dims + lhs_other_dims + i for i in range(rhs_other_dims)
-    )
-    lhs_expanded = jnp.expand_dims(lhs_permuted, axis=new_axes)
+  # Make broadcast compatible
+  new_axes = tuple(
+      batch_dims + lhs_other_dims + i for i in range(rhs_other_dims)
+  )
+  lhs_expanded = jnp.expand_dims(lhs_permuted, axis=new_axes)
 
-    rhs_axes = tuple(batch_dims + i for i in range(lhs_other_dims))
-    rhs_expanded = jnp.expand_dims(rhs_permuted, axis=rhs_axes)
+  rhs_axes = tuple(batch_dims + i for i in range(lhs_other_dims))
+  rhs_expanded = jnp.expand_dims(rhs_permuted, axis=rhs_axes)
 
-    combined = combine_fn(lhs_expanded, rhs_expanded)
-    contract_axes = tuple(range(combined.ndim - contract_dims, combined.ndim))
-    return reduce_fn(combined, contract_axes)
+  combined = combine_fn(lhs_expanded, rhs_expanded)
+  contract_axes = tuple(range(combined.ndim - contract_dims, combined.ndim))
+  return reduce_fn(combined, contract_axes)
 
 
 def _axis_name_to_dim(axis_names: str, axis_name: str) -> int | None:
-    """Returns the index of axis_name in axis_names, or None if not found."""
-    if axis_name in axis_names:
-        return axis_names.index(axis_name)
-    return None
+  """Returns the index of axis_name in axis_names, or None if not found."""
+  if axis_name in axis_names:
+    return axis_names.index(axis_name)
+  return None
 
 
 def _get_subarrays(
     arrays: tuple[jax.Array, ...], ax_dims: list[int | None], index: int
 ) -> tuple[jax.Array, ...]:
-    """Return a slice of each array along the given axis at the given index.
+  """Return a slice of each array along the given axis at the given index.
 
-    Example:
-      >>> A = jnp.arange(6).reshape(2, 3)
-      >>> B = jnp.arange(8).reshape(2, 4)
-      >>> C = jnp.arange(12).reshape(3, 4)
-      >>> X, Y, Z = _get_subarrays([A, B, C], [1, None, 0], 2)
-      >>> jnp.allclose(A[:,2], X) & jnp.allclose(B, Y) & jnp.allclose(C[2,:], Z)
-      Array(True, dtype=bool)
+  Example:
+    >>> A = jnp.arange(6).reshape(2, 3)
+    >>> B = jnp.arange(8).reshape(2, 4)
+    >>> C = jnp.arange(12).reshape(3, 4)
+    >>> X, Y, Z = _get_subarrays([A, B, C], [1, None, 0], 2)
+    >>> jnp.allclose(A[:,2], X) & jnp.allclose(B, Y) & jnp.allclose(C[2,:], Z)
+    Array(True, dtype=bool)
 
-    Args:
-      arrays: A list of arrays.
-      ax_dims: A list of axis dimensions to slice along, or None if no slicing is
-        needed.
-      index: The index to slice at.
+  Args:
+    arrays: A list of arrays.
+    ax_dims: A list of axis dimensions to slice along, or None if no slicing is
+      needed.
+    index: The index to slice at.
 
-    Returns:
-      A list of arrays, each of which is a slice of the corresponding input array.
-    """
-    ans = []
-    for array, dim in zip(arrays, ax_dims):
-        if dim is None:
-            ans.append(array)
-        else:
-            idx = tuple(
-                slice(None) if i != dim else index for i in range(array.ndim)
-            )
-            ans.append(array[idx])
-    return tuple(ans)
+  Returns:
+    A list of arrays, each of which is a slice of the corresponding input array.
+  """
+  ans = []
+  for array, dim in zip(arrays, ax_dims):
+    if dim is None:
+      ans.append(array)
+    else:
+      idx = tuple(slice(None) if i != dim else index for i in range(array.ndim))
+      ans.append(array[idx])
+  return tuple(ans)
 
 
 def _infer_shapes(
     input_axes_names: list[str], arrays: tuple[jax.Array]
 ) -> dict[str, int]:
-    """Infer the shapes of the arrays given the input axes names."""
-    ans = {}
-    for axis_names, arr in zip(input_axes_names, arrays):
-        ans.update(**dict(zip(axis_names, arr.shape)))
-    return ans
+  """Infer the shapes of the arrays given the input axes names."""
+  ans = {}
+  for axis_names, arr in zip(input_axes_names, arrays):
+    ans.update(**dict(zip(axis_names, arr.shape)))
+  return ans
 
 
 def scan_einsum(
@@ -159,141 +153,139 @@ def scan_einsum(
     einsum_fn: Callable = jnp.einsum,
     **kwargs,
 ) -> jax.Array:
-    """Einsum implementation that allows sequential execution across any axes.
+  """Einsum implementation that allows sequential execution across any axes.
 
-    Can be more time and memory efficient than jnp.einsum when there are more
-    than 2 operands, and even run in settings where jnp.einsum would not.
+  Can be more time and memory efficient than jnp.einsum when there are more
+  than 2 operands, and even run in settings where jnp.einsum would not.
 
-    Args:
-      formula: The einsum formula.
-      *arrays: The arrays to einsum.
-      sequential: A string of axes to sequentially einsum across.
-      When sequential is empty, jnp.einsum is used.  When sequential is a single
-        axis name, the smaller einsums are executed sequentially along that axis,
-        and the results are accumulated.  When sequential is a string with
-        multiple axis names, sequential einsums are executed along all axis
-        names given.
-      einsum_fn: The underlying einsum function to use (defaults to jnp.einsum).
-      **kwargs: Keyword arguments to pass to the underlying einsum function.
+  Args:
+    formula: The einsum formula.
+    *arrays: The arrays to einsum.
+    sequential: A string of axes to sequentially einsum across.
+    When sequential is empty, jnp.einsum is used.  When sequential is a single
+      axis name, the smaller einsums are executed sequentially along that axis,
+      and the results are accumulated.  When sequential is a string with
+      multiple axis names, sequential einsums are executed along all axis
+      names given.
+    einsum_fn: The underlying einsum function to use (defaults to jnp.einsum).
+    **kwargs: Keyword arguments to pass to the underlying einsum function.
 
-    Returns:
-      The einsum result.
-    """
-    if not sequential:
-        return einsum_fn(formula, *arrays, **kwargs)
+  Returns:
+    The einsum result.
+  """
+  if not sequential:
+    return einsum_fn(formula, *arrays, **kwargs)
 
-    ax = sequential[0]
-    if ax not in formula:
-        raise ValueError(f"Sequential axis '{ax}' not found.")
+  ax = sequential[0]
+  if ax not in formula:
+    raise ValueError(f"Sequential axis '{ax}' not found.")
 
-    input_axes, output_axes = formula.split("->")
-    input_axes = input_axes.split(",")
-    shapes = _infer_shapes(input_axes, arrays)
+  input_axes, output_axes = formula.split("->")
+  input_axes = input_axes.split(",")
+  shapes = _infer_shapes(input_axes, arrays)
 
-    ax_dims = [_axis_name_to_dim(names, ax) for names in input_axes]
+  ax_dims = [_axis_name_to_dim(names, ax) for names in input_axes]
 
-    # We compute smaller einsums sequentially by looping over the ax dimension.
-    loop = jnp.arange(shapes[ax])
-    new_formula = formula.replace(ax, "")
+  # We compute smaller einsums sequentially by looping over the ax dimension.
+  loop = jnp.arange(shapes[ax])
+  new_formula = formula.replace(ax, "")
 
-    def small_einsum(i):
-        new_arrays = _get_subarrays(arrays, ax_dims, i)
-        return scan_einsum(
-            new_formula,
-            *new_arrays,
-            sequential=sequential[1:],
-            einsum_fn=einsum_fn,
-            **kwargs,
-        )
+  def small_einsum(i):
+    new_arrays = _get_subarrays(arrays, ax_dims, i)
+    return scan_einsum(
+        new_formula,
+        *new_arrays,
+        sequential=sequential[1:],
+        einsum_fn=einsum_fn,
+        **kwargs,
+    )
 
-    if ax in output_axes:
-        # Each smaller einsum is independent.
-        return jax.lax.map(small_einsum, loop).swapaxes(
-            0, output_axes.index(ax)
-        )
+  if ax in output_axes:
+    # Each smaller einsum is independent.
+    return jax.lax.map(small_einsum, loop).swapaxes(0, output_axes.index(ax))
 
-    # Each smaller einsum contributes to the global einsum.
-    init = jnp.zeros(tuple(shapes[i] for i in output_axes))
-    return jax.lax.scan(
-        lambda carry, i: (carry + small_einsum(i), ()), init, loop
-    )[0]
+  # Each smaller einsum contributes to the global einsum.
+  init = jnp.zeros(tuple(shapes[i] for i in output_axes))
+  return jax.lax.scan(
+      lambda carry, i: (carry + small_einsum(i), ()), init, loop
+  )[0]
 
 
 def custom_einsum(
     subscripts, *operands, combine_fn=jnp.multiply, reduce_fn=jnp.sum
 ):
-    """Custom einsum function that uses the given combine and reduce functions.
+  """Custom einsum function that uses the given combine and reduce functions.
 
-    This function acts like jnp.einsum, but intercepts the reduction operations and
-    replaces them with the provided `reduce_fn`. The `combine_fn` replaces the
-    standard multiplication. This allows for einsum operations over arbitrary
-    semirings like (+, max), (+, logsumexp), etc.
+  This function acts like jnp.einsum, but intercepts the reduction operations and
+  replaces them with the provided `reduce_fn`. The `combine_fn` replaces the
+  standard multiplication. This allows for einsum operations over arbitrary
+  semirings like (+, max), (+, logsumexp), etc.
 
-    Args:
-        subscripts: The einsum subscripts string.
-        *operands: The arrays to compute the einsum over.
-        combine_fn: A callable that combines two arrays.
-        reduce_fn: A callable that reduces an array along a given axis.
+  Args:
+      subscripts: The einsum subscripts string.
+      *operands: The arrays to compute the einsum over.
+      combine_fn: A callable that combines two arrays.
+      reduce_fn: A callable that reduces an array along a given axis.
 
-    Returns:
-        The result of the custom einsum operation.
-    """
+  Returns:
+      The result of the custom einsum operation.
+  """
 
-    def f(*args):
-        return jnp.einsum(
-            subscripts,
-            *args,
-            _dot_general=functools.partial(
-                custom_dot_general,
-                combine_fn=combine_fn,
-                # We must use jnp.sum here instead of reduce_fn because if reduce_fn contains
-                # a reduce_sum internally (like logsumexp), it would cause problems.
-                reduce_fn=jnp.sum,
-            ),
-        )
+  def f(*args):
+    return jnp.einsum(
+        subscripts,
+        *args,
+        _dot_general=functools.partial(
+            custom_dot_general,
+            combine_fn=combine_fn,
+            # We must use jnp.sum here instead of reduce_fn because if reduce_fn contains
+            # a reduce_sum internally (like logsumexp), it would cause problems.
+            reduce_fn=jnp.sum,
+        ),
+    )
 
-    closed_jaxpr = jax.make_jaxpr(f)(*operands)
+  closed_jaxpr = jax.make_jaxpr(f)(*operands)
 
-    def eval_rewritten(*args):
-        env = {}
-        for invar, arg in zip(closed_jaxpr.jaxpr.invars, args):
-            env[invar] = arg
-        for constvar, const in zip(
-            closed_jaxpr.jaxpr.constvars, closed_jaxpr.consts
-        ):
-            env[constvar] = const
+  def eval_rewritten(*args):
+    env = {}
+    for invar, arg in zip(closed_jaxpr.jaxpr.invars, args):
+      env[invar] = arg
+    for constvar, const in zip(
+        closed_jaxpr.jaxpr.constvars, closed_jaxpr.consts
+    ):
+      env[constvar] = const
 
-        for eqn in closed_jaxpr.jaxpr.eqns:
-            invals = [
-                var.val if isinstance(var, Literal) else env[var]
-                for var in eqn.invars
-            ]
-            if eqn.primitive.name == "reduce_sum":
-                axes = eqn.params["axes"]
-                outvals = [reduce_fn(invals[0], axis=axes)]
-            else:
-                # Many JAX primitives do not implement get_bind_params
-                try:
-                    bind_params = eqn.primitive.get_bind_params(eqn.params)
-                    if isinstance(bind_params, tuple) and len(bind_params) == 2:
-                        subfuns, bind_params = bind_params
-                    else:
-                        subfuns = []
-                except AttributeError:
-                    subfuns = []
-                    bind_params = eqn.params
-                ans = eqn.primitive.bind(*subfuns, *invals, **bind_params)
-                if eqn.primitive.multiple_results:
-                    outvals = ans
-                else:
-                    outvals = [ans]
-            for outvar, outval in zip(eqn.outvars, outvals):
-                env[outvar] = outval
+    for eqn in closed_jaxpr.jaxpr.eqns:
+      invals = [
+          var.val if isinstance(var, Literal) else env[var]
+          for var in eqn.invars
+      ]
+      if eqn.primitive.name == "reduce_sum":
+        axes = eqn.params["axes"]
+        outvals = [reduce_fn(invals[0], axis=axes)]
+      else:
+        # Many JAX primitives do not implement get_bind_params
+        try:
+          bind_params = eqn.primitive.get_bind_params(eqn.params)
+          if isinstance(bind_params, tuple) and len(bind_params) == 2:
+            subfuns, bind_params = bind_params
+          else:
+            subfuns = []
+        except AttributeError:
+          subfuns = []
+          bind_params = eqn.params
+        ans = eqn.primitive.bind(*subfuns, *invals, **bind_params)
+        if eqn.primitive.multiple_results:
+          outvals = ans
+        else:
+          outvals = [ans]
+      for outvar, outval in zip(eqn.outvars, outvals):
+        env[outvar] = outval
 
-        ans = [
-            var.val if isinstance(var, Literal) else env[var]
-            for var in closed_jaxpr.jaxpr.outvars
-        ]
-        return ans[0] if len(ans) == 1 else tuple(ans)
+    ans = [
+        var.val if isinstance(var, Literal) else env[var]
+        for var in closed_jaxpr.jaxpr.outvars
+    ]
+    return ans[0] if len(ans) == 1 else tuple(ans)
 
-    return eval_rewritten(*operands)
+  return eval_rewritten(*operands)

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -44,239 +44,233 @@ CALLBACK_EVERY = 50
 
 
 class Estimator(ABC):
-    """An object that estimates a Model from a marginal-based loss function.
+  """An object that estimates a Model from a marginal-based loss function.
 
-    Subclasses implement ``_init``, ``_step``, and ``_finalize``.  The ABC
-    provides a default ``estimate`` loop and a shared asynchronous
-    ``precompile`` that works for any estimator with a jitted ``_step``.
+  Subclasses implement ``_init``, ``_step``, and ``_finalize``.  The ABC
+  provides a default ``estimate`` loop and a shared asynchronous
+  ``precompile`` that works for any estimator with a jitted ``_step``.
 
-    **State convention:** the first element of the state tuple returned by
-    ``_init`` / ``_step`` is the current solution (passed to ``callback_fn``).
-    Override ``_callback_value`` only if the callback needs a transformation.
+  **State convention:** the first element of the state tuple returned by
+  ``_init`` / ``_step`` is the current solution (passed to ``callback_fn``).
+  Override ``_callback_value`` only if the callback needs a transformation.
 
-    Attributes:
-        marginal_oracle: Callable for computing marginals from potentials.
-            If ``None``, auto-selected via ``default_oracle()``.
+  Attributes:
+      marginal_oracle: Callable for computing marginals from potentials.
+          If ``None``, auto-selected via ``default_oracle()``.
 
-    Examples of subclasses:
-        * ``MirrorDescent``
-        * ``DualAveraging``
-        * ``InteriorGradient``
-        * ``extensions.MixtureOfProductsEstimator``
-        * ``extensions.ReweightedDatasetEstimator``
+  Examples of subclasses:
+      * ``MirrorDescent``
+      * ``DualAveraging``
+      * ``InteriorGradient``
+      * ``extensions.MixtureOfProductsEstimator``
+      * ``extensions.ReweightedDatasetEstimator``
+  """
+
+  marginal_oracle: marginal_oracles.MarginalOracle | None = None
+
+  # ------------------------------------------------------------------
+  # Abstract interface — subclasses must implement
+  # ------------------------------------------------------------------
+
+  @abstractmethod
+  def _init(
+      self,
+      domain: Domain,
+      loss_fn: MarginalLossFn,
+      known_total: float,
+      **kwargs: Any,
+  ) -> Any:
+    """Initialize the optimization state."""
+
+  @abstractmethod
+  def _step(
+      self,
+      state: Any,
+      loss_fn: MarginalLossFn,
+      known_total: float,
+      constraints: Sequence[Constraint] = (),
+  ) -> Any:
+    """Perform one optimization step (or one scan block)."""
+
+  @abstractmethod
+  def _finalize(self, state: Any, known_total: float, constraints=()) -> Model:
+    """Convert the final optimization state into a Model."""
+
+  # ------------------------------------------------------------------
+  # Overridable hooks
+  # ------------------------------------------------------------------
+
+  def _callback_value(self, state: Any, known_total: float, constraints=()) -> Any:  # pylint: disable=unused-argument
+    """Extract the value to pass to ``callback_fn``.
+
+    Default: ``state[0]`` (first element of the state tuple).
     """
+    return state[0]
 
-    marginal_oracle: marginal_oracles.MarginalOracle | None = None
+  def _oracle(self, cliques, domain, constraints=()):
+    """Return the marginal oracle, falling back to ``default_oracle``."""
+    oracle = self.marginal_oracle or marginal_oracles.default_oracle(
+        cliques, domain, has_constraints=bool(constraints)
+    )
+    return functools.partial(oracle, constraints=constraints)
 
-    # ------------------------------------------------------------------
-    # Abstract interface — subclasses must implement
-    # ------------------------------------------------------------------
+  # ------------------------------------------------------------------
+  # Default implementations
+  # ------------------------------------------------------------------
 
-    @abstractmethod
-    def _init(
-        self,
-        domain: Domain,
-        loss_fn: MarginalLossFn,
-        known_total: float,
-        **kwargs: Any,
-    ) -> Any:
-        """Initialize the optimization state."""
+  def estimate(
+      self,
+      domain: Domain,
+      loss_fn: MarginalLossFn | list[LinearMeasurement],
+      known_total: float | None = None,
+      constraints: Sequence[Constraint] = (),
+      iters: int = 1000,
+      callback_fn: Callable | None = None,
+      warm_start: Model | None = None,
+      **kwargs: Any,
+  ) -> Model:
+    """Estimate a Model from noisy marginal measurements.
 
-    @abstractmethod
-    def _step(
-        self,
-        state: Any,
-        loss_fn: MarginalLossFn,
-        known_total: float,
-        constraints: Sequence[Constraint] = (),
-    ) -> Any:
-        """Perform one optimization step (or one scan block)."""
+    If ``warm_start`` is provided, the estimator initializes from a
+    previously estimated model instead of from scratch.  For potential-based
+    estimators the model's potentials are expanded to cover any new cliques;
+    for MixtureOfProducts the model is used directly.
+    """
+    constraints = tuple(constraints)
+    if isinstance(loss_fn, list):
+      if known_total is None:
+        known_total = minimum_variance_unbiased_total(loss_fn)
+      loss_fn = marginal_loss.from_linear_measurements(loss_fn, domain)
+    if known_total is None:
+      known_total = 1.0
 
-    @abstractmethod
-    def _finalize(
-        self, state: Any, known_total: float, constraints=()
-    ) -> Model:
-        """Convert the final optimization state into a Model."""
+    # Nothing to optimize when there are no cliques.
+    if not loss_fn.cliques:
+      potentials = CliqueVector.zeros(domain, ())
+      oracle = self._oracle((), domain, constraints=constraints)
+      return MarkovRandomField(
+          potentials=potentials,
+          marginals=oracle(potentials, known_total),
+          total=known_total,
+      )
 
-    # ------------------------------------------------------------------
-    # Overridable hooks
-    # ------------------------------------------------------------------
+    if "potentials" in kwargs:
+      import warnings
 
-    def _callback_value(self, state: Any, known_total: float, constraints=()) -> Any:  # pylint: disable=unused-argument
-        """Extract the value to pass to ``callback_fn``.
+      warnings.warn(
+          "Passing potentials= directly is deprecated. Use"
+          " warm_start=model instead, where model is a previously"
+          " estimated Model.",
+          DeprecationWarning,
+          stacklevel=2,
+      )
 
-        Default: ``state[0]`` (first element of the state tuple).
-        """
-        return state[0]
+    state = self._init(
+        domain,
+        loss_fn,
+        known_total,
+        constraints=constraints,
+        warm_start=warm_start,
+        **kwargs,
+    )
+    # De-alias so that donate_argnames in _multi_step is safe.
+    state = jax.tree.map(jnp.copy, state)
+    for _ in range(math.ceil(iters / CALLBACK_EVERY)):
+      state = self._multi_step(state, loss_fn, known_total, constraints)
+      if callback_fn is not None:
+        callback_fn(self._callback_value(state, known_total, constraints))
+    return self._finalize(state, known_total, constraints=constraints)
 
-    def _oracle(self, cliques, domain, constraints=()):
-        """Return the marginal oracle, falling back to ``default_oracle``."""
-        oracle = self.marginal_oracle or marginal_oracles.default_oracle(
-            cliques, domain, has_constraints=bool(constraints)
-        )
-        return functools.partial(oracle, constraints=constraints)
+  @jax.jit(static_argnames=["self"], donate_argnames=["state"])
+  def _multi_step(self, state, loss_fn, known_total, constraints=()):
+    """Run ``CALLBACK_EVERY`` optimization steps as a fused scan."""
 
-    # ------------------------------------------------------------------
-    # Default implementations
-    # ------------------------------------------------------------------
+    def step(s, _):
+      return self._step(s, loss_fn, known_total, constraints), None
 
-    def estimate(
-        self,
-        domain: Domain,
-        loss_fn: MarginalLossFn | list[LinearMeasurement],
-        known_total: float | None = None,
-        constraints: Sequence[Constraint] = (),
-        iters: int = 1000,
-        callback_fn: Callable | None = None,
-        warm_start: Model | None = None,
-        **kwargs: Any,
-    ) -> Model:
-        """Estimate a Model from noisy marginal measurements.
+    return jax.lax.scan(step, state, None, length=CALLBACK_EVERY)[0]
 
-        If ``warm_start`` is provided, the estimator initializes from a
-        previously estimated model instead of from scratch.  For potential-based
-        estimators the model's potentials are expanded to cover any new cliques;
-        for MixtureOfProducts the model is used directly.
-        """
-        constraints = tuple(constraints)
-        if isinstance(loss_fn, list):
-            if known_total is None:
-                known_total = minimum_variance_unbiased_total(loss_fn)
-            loss_fn = marginal_loss.from_linear_measurements(loss_fn, domain)
-        if known_total is None:
-            known_total = 1.0
+  def precompile(
+      self,
+      domain: Domain,
+      measurements: list[LinearMeasurement] | None = None,
+      *,
+      extra_cliques: list[tuple[str, ...]] | None = None,
+      constraints: Sequence[Constraint] = (),
+  ) -> concurrent.futures.Future:
+    """Warm up the JIT cache for ``estimate`` asynchronously.
 
-        # Nothing to optimize when there are no cliques.
-        if not loss_fn.cliques:
-            potentials = CliqueVector.zeros(domain, ())
-            oracle = self._oracle((), domain, constraints=constraints)
-            return MarkovRandomField(
-                potentials=potentials,
-                marginals=oracle(potentials, known_total),
-                total=known_total,
-            )
+    Returns a ``Future`` that completes when compilation finishes.
+    Callers may ignore the return value (fire-and-forget) or call
+    ``future.result()`` to block until compilation is done.
+    """
+    constraints = tuple(constraints)
+    all_measurements = list(measurements or [])
+    for cl in extra_cliques or []:
+      shape = (domain.project(cl).size(),)
+      abstract_values = jax.ShapeDtypeStruct(shape, jnp.float32)
+      all_measurements.append(
+          marginal_loss.LinearMeasurement(abstract_values, cl)
+      )
+    all_measurements = jax.eval_shape(lambda x: x, all_measurements)
 
-        if "potentials" in kwargs:
-            import warnings
-
-            warnings.warn(
-                "Passing potentials= directly is deprecated. Use"
-                " warm_start=model instead, where model is a previously"
-                " estimated Model.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        state = self._init(
-            domain,
-            loss_fn,
-            known_total,
-            constraints=constraints,
-            warm_start=warm_start,
-            **kwargs,
-        )
-        # De-alias so that donate_argnames in _multi_step is safe.
-        state = jax.tree.map(jnp.copy, state)
-        for _ in range(math.ceil(iters / CALLBACK_EVERY)):
-            state = self._multi_step(state, loss_fn, known_total, constraints)
-            if callback_fn is not None:
-                callback_fn(
-                    self._callback_value(state, known_total, constraints)
-                )
-        return self._finalize(state, known_total, constraints=constraints)
-
-    @jax.jit(static_argnames=["self"], donate_argnames=["state"])
-    def _multi_step(self, state, loss_fn, known_total, constraints=()):
-        """Run ``CALLBACK_EVERY`` optimization steps as a fused scan."""
-
-        def step(s, _):
-            return self._step(s, loss_fn, known_total, constraints), None
-
-        return jax.lax.scan(step, state, None, length=CALLBACK_EVERY)[0]
-
-    def precompile(
-        self,
-        domain: Domain,
-        measurements: list[LinearMeasurement] | None = None,
-        *,
-        extra_cliques: list[tuple[str, ...]] | None = None,
-        constraints: Sequence[Constraint] = (),
-    ) -> concurrent.futures.Future:
-        """Warm up the JIT cache for ``estimate`` asynchronously.
-
-        Returns a ``Future`` that completes when compilation finishes.
-        Callers may ignore the return value (fire-and-forget) or call
-        ``future.result()`` to block until compilation is done.
-        """
-        constraints = tuple(constraints)
-        all_measurements = list(measurements or [])
-        for cl in extra_cliques or []:
-            shape = (domain.project(cl).size(),)
-            abstract_values = jax.ShapeDtypeStruct(shape, jnp.float32)
-            all_measurements.append(
-                marginal_loss.LinearMeasurement(abstract_values, cl)
-            )
-        all_measurements = jax.eval_shape(lambda x: x, all_measurements)
-
-        loss_fn = marginal_loss.from_linear_measurements(
-            all_measurements, domain
-        )
-        abstract_state = jax.eval_shape(
-            functools.partial(self._init, domain),
-            loss_fn,
-            1.0,
-            constraints=constraints,
-        )
-        abstract_constraints = jax.eval_shape(lambda x: x, constraints)
-        lowered = self._multi_step.lower(
-            self, abstract_state, loss_fn, 1.0, abstract_constraints
-        )
-        return _COMPILE_POOL.submit(lowered.compile)
+    loss_fn = marginal_loss.from_linear_measurements(all_measurements, domain)
+    abstract_state = jax.eval_shape(
+        functools.partial(self._init, domain),
+        loss_fn,
+        1.0,
+        constraints=constraints,
+    )
+    abstract_constraints = jax.eval_shape(lambda x: x, constraints)
+    lowered = self._multi_step.lower(
+        self, abstract_state, loss_fn, 1.0, abstract_constraints
+    )
+    return _COMPILE_POOL.submit(lowered.compile)
 
 
 def minimum_variance_unbiased_total(
     measurements: list[LinearMeasurement],
 ) -> float:
-    """Estimates the total count from measurements with identity queries."""
-    # find the minimum variance estimate of the total given the measurements
-    estimates, variances = [], []
-    for M in measurements:
-        y = M.noisy_measurement
-        try:
-            # TODO: generalize to support any linear measurement that supports total query
-            if isinstance(M.query, DatavectorQuery):  # query = Identity
-                estimates.append(y.sum())
-                variances.append(M.stddev**2 * y.size)
-        except Exception:  # pylint: disable=broad-exception-caught
-            continue
-    estimates, variances = np.array(estimates), np.array(variances)
-    if len(estimates) == 0:
-        return 1.0
-    else:
-        weights = 1.0 / variances
-        return max(1, float(np.average(estimates, weights=weights)))
+  """Estimates the total count from measurements with identity queries."""
+  # find the minimum variance estimate of the total given the measurements
+  estimates, variances = [], []
+  for M in measurements:
+    y = M.noisy_measurement
+    try:
+      # TODO: generalize to support any linear measurement that supports total query
+      if isinstance(M.query, DatavectorQuery):  # query = Identity
+        estimates.append(y.sum())
+        variances.append(M.stddev**2 * y.size)
+    except Exception:  # pylint: disable=broad-exception-caught
+      continue
+  estimates, variances = np.array(estimates), np.array(variances)
+  if len(estimates) == 0:
+    return 1.0
+  else:
+    weights = 1.0 / variances
+    return max(1, float(np.average(estimates, weights=weights)))
 
 
 def _initialize(domain, loss_fn, known_total, potentials):
-    """Normalize inputs for estimation functions.
+  """Normalize inputs for estimation functions.
 
-    Converts a list of ``LinearMeasurement`` objects to a ``MarginalLossFn``,
-    estimates the total if not given, and creates zero potentials if needed.
-    """
-    if isinstance(loss_fn, list):
-        if known_total is None:
-            known_total = minimum_variance_unbiased_total(loss_fn)
-        loss_fn = marginal_loss.from_linear_measurements(loss_fn, domain)
-
+  Converts a list of ``LinearMeasurement`` objects to a ``MarginalLossFn``,
+  estimates the total if not given, and creates zero potentials if needed.
+  """
+  if isinstance(loss_fn, list):
     if known_total is None:
-        known_total = 1.0
+      known_total = minimum_variance_unbiased_total(loss_fn)
+    loss_fn = marginal_loss.from_linear_measurements(loss_fn, domain)
 
-    if potentials is not None:
-        potentials = potentials.expand(loss_fn.cliques)
-    else:
-        potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+  if known_total is None:
+    known_total = 1.0
 
-    return loss_fn, known_total, potentials
+  if potentials is not None:
+    potentials = potentials.expand(loss_fn.cliques)
+  else:
+    potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+
+  return loss_fn, known_total, potentials
 
 
 # ---------------------------------------------------------------------------
@@ -285,64 +279,64 @@ def _initialize(domain, loss_fn, known_total, potentials):
 
 
 class MirrorDescentState(NamedTuple):
-    """State for Algorithm 1 of https://arxiv.org/pdf/1901.09136."""
+  """State for Algorithm 1 of https://arxiv.org/pdf/1901.09136."""
 
-    mu: CliqueVector
-    potentials: CliqueVector
-    alpha: jax.Array | float
-    loss: jax.Array | float
+  mu: CliqueVector
+  potentials: CliqueVector
+  alpha: jax.Array | float
+  loss: jax.Array | float
 
 
 class DualAveragingState(NamedTuple):
-    """State for Regularized Dual Averaging (https://proceedings.neurips.cc/paper_files/paper/2009/file/7cce53cf90577442771720a370c3c723-Paper.pdf)."""
+  """State for Regularized Dual Averaging (https://proceedings.neurips.cc/paper_files/paper/2009/file/7cce53cf90577442771720a370c3c723-Paper.pdf)."""
 
-    w: CliqueVector
-    v: CliqueVector
-    gbar: CliqueVector
-    loss: jax.Array | float
-    lipschitz: jax.Array | float
-    gamma: jax.Array | float
-    t: jax.Array | int
+  w: CliqueVector
+  v: CliqueVector
+  gbar: CliqueVector
+  loss: jax.Array | float
+  lipschitz: jax.Array | float
+  gamma: jax.Array | float
+  t: jax.Array | int
 
 
 class InteriorGradientState(NamedTuple):
-    """State for Interior Gradient (https://doi.org/10.1137/S1052623403427823)."""
+  """State for Interior Gradient (https://doi.org/10.1137/S1052623403427823)."""
 
-    x: CliqueVector
-    potentials: CliqueVector
-    c: jax.Array | float
-    y: CliqueVector
-    z: CliqueVector
-    loss: jax.Array | float
-    inv_lipschitz: jax.Array | float
+  x: CliqueVector
+  potentials: CliqueVector
+  c: jax.Array | float
+  y: CliqueVector
+  z: CliqueVector
+  loss: jax.Array | float
+  inv_lipschitz: jax.Array | float
 
 
 class LBFGSState(NamedTuple):
-    """State for L-BFGS optimization on potentials."""
+  """State for L-BFGS optimization on potentials."""
 
-    potentials: CliqueVector
-    opt_state: Any
+  potentials: CliqueVector
+  opt_state: Any
 
 
 class _AcceleratedStepSearchState(NamedTuple):
-    """State for Universal Accelerated Method step search.
+  """State for Universal Accelerated Method step search.
 
-    References:
-        Nesterov, `Universal Gradient Methods for Convex Optimization
-        Problems <https://optimization-online.org/wp-content/uploads/2013/04/3833.pdf>`_
+  References:
+      Nesterov, `Universal Gradient Methods for Convex Optimization
+      Problems <https://optimization-online.org/wp-content/uploads/2013/04/3833.pdf>`_
 
-        Roulet and d'Aspremont, `Sharpness, Restart and
-        Acceleration <https://arxiv.org/pdf/1702.03828>`_
-    """
+      Roulet and d'Aspremont, `Sharpness, Restart and
+      Acceleration <https://arxiv.org/pdf/1702.03828>`_
+  """
 
-    x: CliqueVector
-    z: CliqueVector
-    u: CliqueVector
-    prev_stepsize: jax.Array | float
-    stepsize: jax.Array | float
-    prev_theta: jax.Array | float
-    accept: jax.Array | bool
-    iter_search: jax.Array | int
+  x: CliqueVector
+  z: CliqueVector
+  u: CliqueVector
+  prev_stepsize: jax.Array | float
+  stepsize: jax.Array | float
+  prev_theta: jax.Array | float
+  accept: jax.Array | bool
+  iter_search: jax.Array | int
 
 
 # ---------------------------------------------------------------------------
@@ -352,545 +346,535 @@ class _AcceleratedStepSearchState(NamedTuple):
 
 @dataclasses.dataclass(frozen=True)
 class MirrorDescent(Estimator):
-    """Mirror descent estimator for graphical models.
+  """Mirror descent estimator for graphical models.
 
-    This is a first-order proximal optimization algorithm for solving
-    a (possibly nonsmooth) convex optimization problem over the marginal polytope.
-    This is an implementation of Algorithm 1 from the paper
-    `"Graphical-model based estimation and inference for differential privacy"
-    <https://arxiv.org/pdf/1901.09136>`_.
+  This is a first-order proximal optimization algorithm for solving
+  a (possibly nonsmooth) convex optimization problem over the marginal polytope.
+  This is an implementation of Algorithm 1 from the paper
+  `"Graphical-model based estimation and inference for differential privacy"
+  <https://arxiv.org/pdf/1901.09136>`_.
 
-    Attributes:
-        stepsize: Fixed step size, or ``None`` (default) to use Armijo line
-            search.
-        marginal_oracle: The function to compute marginals from potentials.
-            If ``None`` (default), uses ``default_oracle()`` to auto-select.
-        mesh: JAX sharding mesh.
-    """
+  Attributes:
+      stepsize: Fixed step size, or ``None`` (default) to use Armijo line
+          search.
+      marginal_oracle: The function to compute marginals from potentials.
+          If ``None`` (default), uses ``default_oracle()`` to auto-select.
+      mesh: JAX sharding mesh.
+  """
 
-    stepsize: float | None = None
-    marginal_oracle: marginal_oracles.MarginalOracle | None = None
-    mesh: jax.sharding.Mesh | None = None
+  stepsize: float | None = None
+  marginal_oracle: marginal_oracles.MarginalOracle | None = None
+  mesh: jax.sharding.Mesh | None = None
 
-    def _init(
-        self,
-        domain: Domain,
-        loss_fn: marginal_loss.MarginalLossFn,
-        known_total: float,
-        *,
-        potentials: CliqueVector | None = None,
-        warm_start=None,
-        constraints=(),
-    ) -> MirrorDescentState:
-        """Initialize the optimization state."""
-        if warm_start is not None and potentials is None:
-            potentials = warm_start.potentials
-        if potentials is None:
-            potentials = CliqueVector.zeros(domain, loss_fn.cliques)
-        else:
-            potentials = potentials.expand(loss_fn.cliques)
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, domain, constraints=constraints
-        )
-        # Theory suggests the initial learning rate should be inversely
-        # proportional to L. We also divide by scaling factor to account for
-        # the fact that gradients are scaled up by a factor of known_total.
-        # See Eq 75. of https://www.cs.uic.edu/~zhangx/teaching/bregman.pdf.
-        L = loss_fn.lipschitz or 1.0
-        alpha = (
-            2.0 / (L * known_total) if self.stepsize is None else self.stepsize
-        )
-        mu = marginal_oracle(potentials, known_total)
-        initial_loss = loss_fn(mu)
-        return MirrorDescentState(mu, potentials, alpha, initial_loss)
+  def _init(
+      self,
+      domain: Domain,
+      loss_fn: marginal_loss.MarginalLossFn,
+      known_total: float,
+      *,
+      potentials: CliqueVector | None = None,
+      warm_start=None,
+      constraints=(),
+  ) -> MirrorDescentState:
+    """Initialize the optimization state."""
+    if warm_start is not None and potentials is None:
+      potentials = warm_start.potentials
+    if potentials is None:
+      potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+    else:
+      potentials = potentials.expand(loss_fn.cliques)
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, domain, constraints=constraints
+    )
+    # Theory suggests the initial learning rate should be inversely
+    # proportional to L. We also divide by scaling factor to account for
+    # the fact that gradients are scaled up by a factor of known_total.
+    # See Eq 75. of https://www.cs.uic.edu/~zhangx/teaching/bregman.pdf.
+    L = loss_fn.lipschitz or 1.0
+    alpha = 2.0 / (L * known_total) if self.stepsize is None else self.stepsize
+    mu = marginal_oracle(potentials, known_total)
+    initial_loss = loss_fn(mu)
+    return MirrorDescentState(mu, potentials, alpha, initial_loss)
 
-    def _step(
-        self,
-        state: MirrorDescentState,
-        loss_fn: marginal_loss.MarginalLossFn,
-        known_total: jax.Array | float,
-        constraints=(),
-    ) -> MirrorDescentState:
-        """Perform a single mirror descent step."""
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, state.potentials.domain, constraints=constraints
-        )
-        mu = marginal_oracle(state.potentials, known_total)
-        loss, dL = jax.value_and_grad(loss_fn)(mu)
-        theta2 = state.potentials - state.alpha * dL
+  def _step(
+      self,
+      state: MirrorDescentState,
+      loss_fn: marginal_loss.MarginalLossFn,
+      known_total: jax.Array | float,
+      constraints=(),
+  ) -> MirrorDescentState:
+    """Perform a single mirror descent step."""
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, state.potentials.domain, constraints=constraints
+    )
+    mu = marginal_oracle(state.potentials, known_total)
+    loss, dL = jax.value_and_grad(loss_fn)(mu)
+    theta2 = state.potentials - state.alpha * dL
 
-        if self.stepsize is not None:
-            # Fixed step size — no line search.
-            return MirrorDescentState(mu, theta2, state.alpha, loss)
+    if self.stepsize is not None:
+      # Fixed step size — no line search.
+      return MirrorDescentState(mu, theta2, state.alpha, loss)
 
-        # Armijo line search.
-        mu2 = marginal_oracle(theta2, known_total)
-        loss2 = loss_fn(mu2)
+    # Armijo line search.
+    mu2 = marginal_oracle(theta2, known_total)
+    loss2 = loss_fn(mu2)
 
-        sufficient_decrease = loss - loss2 >= 0.5 * state.alpha * dL.dot(
-            mu - mu2
-        )
-        alpha = jax.lax.select(
-            sufficient_decrease, 1.01 * state.alpha, 0.5 * state.alpha
-        )
-        potentials = jax.lax.cond(
-            sufficient_decrease, lambda: theta2, lambda: state.potentials
-        )
-        accepted_loss = jax.lax.select(sufficient_decrease, loss2, loss)
-        return MirrorDescentState(mu, potentials, alpha, accepted_loss)
+    sufficient_decrease = loss - loss2 >= 0.5 * state.alpha * dL.dot(mu - mu2)
+    alpha = jax.lax.select(
+        sufficient_decrease, 1.01 * state.alpha, 0.5 * state.alpha
+    )
+    potentials = jax.lax.cond(
+        sufficient_decrease, lambda: theta2, lambda: state.potentials
+    )
+    accepted_loss = jax.lax.select(sufficient_decrease, loss2, loss)
+    return MirrorDescentState(mu, potentials, alpha, accepted_loss)
 
-    def _finalize(
-        self,
-        state: MirrorDescentState,
-        known_total: float,
-        constraints=(),
-    ) -> MarkovRandomField:
-        marginal_oracle = self._oracle(
-            state.potentials.cliques,
-            state.potentials.domain,
-            constraints=constraints,
-        )
-        marginals = marginal_oracle(state.potentials, known_total)
-        return MarkovRandomField(
-            potentials=state.potentials,
-            marginals=marginals,
-            total=known_total,
-        )
+  def _finalize(
+      self,
+      state: MirrorDescentState,
+      known_total: float,
+      constraints=(),
+  ) -> MarkovRandomField:
+    marginal_oracle = self._oracle(
+        state.potentials.cliques,
+        state.potentials.domain,
+        constraints=constraints,
+    )
+    marginals = marginal_oracle(state.potentials, known_total)
+    return MarkovRandomField(
+        potentials=state.potentials,
+        marginals=marginals,
+        total=known_total,
+    )
 
 
 @dataclasses.dataclass(frozen=True)
 class DualAveraging(Estimator):
-    """Regularized Dual Averaging estimator for graphical models.
+  """Regularized Dual Averaging estimator for graphical models.
 
-    RDA is an accelerated proximal algorithm for solving a smooth convex
-    optimization problem over the marginal polytope.  This algorithm requires
-    knowledge of the Lipschitz constant of the gradient of the loss function.
+  RDA is an accelerated proximal algorithm for solving a smooth convex
+  optimization problem over the marginal polytope.  This algorithm requires
+  knowledge of the Lipschitz constant of the gradient of the loss function.
 
-    Attributes:
-        marginal_oracle: The function to compute marginals from potentials.
-            If ``None`` (default), uses ``default_oracle()`` to auto-select.
-        mesh: JAX sharding mesh.
-    """
+  Attributes:
+      marginal_oracle: The function to compute marginals from potentials.
+          If ``None`` (default), uses ``default_oracle()`` to auto-select.
+      mesh: JAX sharding mesh.
+  """
 
-    marginal_oracle: marginal_oracles.MarginalOracle | None = None
-    mesh: jax.sharding.Mesh | None = None
+  marginal_oracle: marginal_oracles.MarginalOracle | None = None
+  mesh: jax.sharding.Mesh | None = None
 
-    def _init(
-        self,
-        domain: Domain,
-        loss_fn: marginal_loss.MarginalLossFn,
-        known_total: float,
-        *,
-        potentials: CliqueVector | None = None,
-        warm_start=None,
-        constraints=(),
-    ) -> DualAveragingState:
-        """Initialize the optimization state."""
-        if warm_start is not None and potentials is None:
-            potentials = warm_start.potentials
-        if potentials is None:
-            potentials = CliqueVector.zeros(domain, loss_fn.cliques)
-        else:
-            potentials = potentials.expand(loss_fn.cliques)
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, domain, constraints=constraints
-        )
+  def _init(
+      self,
+      domain: Domain,
+      loss_fn: marginal_loss.MarginalLossFn,
+      known_total: float,
+      *,
+      potentials: CliqueVector | None = None,
+      warm_start=None,
+      constraints=(),
+  ) -> DualAveragingState:
+    """Initialize the optimization state."""
+    if warm_start is not None and potentials is None:
+      potentials = warm_start.potentials
+    if potentials is None:
+      potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+    else:
+      potentials = potentials.expand(loss_fn.cliques)
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, domain, constraints=constraints
+    )
 
-        D = np.sqrt(
-            domain.size() * math.log(domain.size())
-        )  # upper bound on entropy
-        Q = 0  # upper bound on variance of stochastic gradients
-        gamma = Q / D
-        L = (loss_fn.lipschitz or 1.0) / known_total
+    D = np.sqrt(
+        domain.size() * math.log(domain.size())
+    )  # upper bound on entropy
+    Q = 0  # upper bound on variance of stochastic gradients
+    gamma = Q / D
+    L = (loss_fn.lipschitz or 1.0) / known_total
 
-        w = v = marginal_oracle(potentials, known_total)
-        gbar = CliqueVector.zeros(domain, loss_fn.cliques)
-        initial_loss = loss_fn(w)
-        return DualAveragingState(w, v, gbar, initial_loss, L, gamma, 1)
+    w = v = marginal_oracle(potentials, known_total)
+    gbar = CliqueVector.zeros(domain, loss_fn.cliques)
+    initial_loss = loss_fn(w)
+    return DualAveragingState(w, v, gbar, initial_loss, L, gamma, 1)
 
-    def _step(
-        self,
-        state: DualAveragingState,
-        loss_fn: marginal_loss.MarginalLossFn,
-        known_total: jax.Array | float,
-        constraints=(),
-    ) -> DualAveragingState:
-        """Perform a single dual averaging step."""
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, state.w.domain, constraints=constraints
-        )
-        t = state.t
-        c = 2.0 / (t + 1)
-        beta = state.gamma * (t + 1) ** 1.5 / 2
-        u = (1 - c) * state.w + c * state.v
-        loss, g = jax.value_and_grad(loss_fn)(u)
-        g = g / known_total
-        gbar = (1 - c) * state.gbar + c * g
-        theta = -t * (t + 1) / (4 * state.lipschitz + beta) * gbar
-        v = marginal_oracle(theta, known_total)
-        w = (1 - c) * state.w + c * v
-        return DualAveragingState(
-            w, v, gbar, loss, state.lipschitz, state.gamma, t + 1
-        )
+  def _step(
+      self,
+      state: DualAveragingState,
+      loss_fn: marginal_loss.MarginalLossFn,
+      known_total: jax.Array | float,
+      constraints=(),
+  ) -> DualAveragingState:
+    """Perform a single dual averaging step."""
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, state.w.domain, constraints=constraints
+    )
+    t = state.t
+    c = 2.0 / (t + 1)
+    beta = state.gamma * (t + 1) ** 1.5 / 2
+    u = (1 - c) * state.w + c * state.v
+    loss, g = jax.value_and_grad(loss_fn)(u)
+    g = g / known_total
+    gbar = (1 - c) * state.gbar + c * g
+    theta = -t * (t + 1) / (4 * state.lipschitz + beta) * gbar
+    v = marginal_oracle(theta, known_total)
+    w = (1 - c) * state.w + c * v
+    return DualAveragingState(
+        w, v, gbar, loss, state.lipschitz, state.gamma, t + 1
+    )
 
-    def _finalize(
-        self,
-        state: DualAveragingState,
-        known_total: float,
-        constraints=(),
-    ) -> MarkovRandomField:
-        # Recover potentials from the weighted-average marginals via MLE.
-        # NOTE: warm_start from DA (and IG/UAM) uses these recovered
-        # potentials, not the internal averaging state — so it seeds a
-        # reasonable initial guess rather than exactly continuing.
-        loss = marginal_loss.mle_loss_fn(state.w)
-        est = LBFGS(marginal_oracle=self.marginal_oracle)
-        return est.estimate(state.w.domain, loss, known_total, constraints)
+  def _finalize(
+      self,
+      state: DualAveragingState,
+      known_total: float,
+      constraints=(),
+  ) -> MarkovRandomField:
+    # Recover potentials from the weighted-average marginals via MLE.
+    # NOTE: warm_start from DA (and IG/UAM) uses these recovered
+    # potentials, not the internal averaging state — so it seeds a
+    # reasonable initial guess rather than exactly continuing.
+    loss = marginal_loss.mle_loss_fn(state.w)
+    est = LBFGS(marginal_oracle=self.marginal_oracle)
+    return est.estimate(state.w.domain, loss, known_total, constraints)
 
 
 @dataclasses.dataclass(frozen=True)
 class InteriorGradient(Estimator):
-    """Interior Gradient estimator for graphical models.
+  """Interior Gradient estimator for graphical models.
 
-    Interior Gradient is an accelerated proximal algorithm for solving a smooth
-    convex optimization problem over the marginal polytope.  This algorithm
-    requires knowledge of the Lipschitz constant of the gradient of the loss
-    function.  Based on the paper
-    `"Interior Gradient and Proximal Methods for Convex and Conic Optimization"
-    <https://epubs.siam.org/doi/abs/10.1137/S1052623403427823>`_.
+  Interior Gradient is an accelerated proximal algorithm for solving a smooth
+  convex optimization problem over the marginal polytope.  This algorithm
+  requires knowledge of the Lipschitz constant of the gradient of the loss
+  function.  Based on the paper
+  `"Interior Gradient and Proximal Methods for Convex and Conic Optimization"
+  <https://epubs.siam.org/doi/abs/10.1137/S1052623403427823>`_.
 
-    Attributes:
-        marginal_oracle: The function to compute marginals from potentials.
-            If ``None`` (default), uses ``default_oracle()`` to auto-select.
-        mesh: JAX sharding mesh.
-    """
+  Attributes:
+      marginal_oracle: The function to compute marginals from potentials.
+          If ``None`` (default), uses ``default_oracle()`` to auto-select.
+      mesh: JAX sharding mesh.
+  """
 
-    marginal_oracle: marginal_oracles.MarginalOracle | None = None
-    mesh: jax.sharding.Mesh | None = None
+  marginal_oracle: marginal_oracles.MarginalOracle | None = None
+  mesh: jax.sharding.Mesh | None = None
 
-    def _init(
-        self,
-        domain: Domain,
-        loss_fn: marginal_loss.MarginalLossFn,
-        known_total: float,
-        *,
-        potentials: CliqueVector | None = None,
-        warm_start=None,
-        constraints=(),
-    ) -> InteriorGradientState:
-        """Initialize the optimization state."""
-        if warm_start is not None and potentials is None:
-            potentials = warm_start.potentials
-        if potentials is None:
-            potentials = CliqueVector.zeros(domain, loss_fn.cliques)
-        else:
-            potentials = potentials.expand(loss_fn.cliques)
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, domain, constraints=constraints
-        )
+  def _init(
+      self,
+      domain: Domain,
+      loss_fn: marginal_loss.MarginalLossFn,
+      known_total: float,
+      *,
+      potentials: CliqueVector | None = None,
+      warm_start=None,
+      constraints=(),
+  ) -> InteriorGradientState:
+    """Initialize the optimization state."""
+    if warm_start is not None and potentials is None:
+      potentials = warm_start.potentials
+    if potentials is None:
+      potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+    else:
+      potentials = potentials.expand(loss_fn.cliques)
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, domain, constraints=constraints
+    )
 
-        inv_lipschitz = 1.0 / (loss_fn.lipschitz or 1.0)
-        x = y = z = marginal_oracle(potentials, known_total)
-        initial_loss = loss_fn(x)
-        return InteriorGradientState(
-            x, potentials, 1.0, y, z, initial_loss, inv_lipschitz
-        )
+    inv_lipschitz = 1.0 / (loss_fn.lipschitz or 1.0)
+    x = y = z = marginal_oracle(potentials, known_total)
+    initial_loss = loss_fn(x)
+    return InteriorGradientState(
+        x, potentials, 1.0, y, z, initial_loss, inv_lipschitz
+    )
 
-    def _step(
-        self,
-        state: InteriorGradientState,
-        loss_fn: marginal_loss.MarginalLossFn,
-        known_total: jax.Array | float,
-        constraints=(),
-    ) -> InteriorGradientState:
-        """Perform a single interior gradient step."""
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, state.potentials.domain, constraints=constraints
-        )
-        l = state.inv_lipschitz
-        a = (((state.c * l) ** 2 + 4 * state.c * l) ** 0.5 - l * state.c) / 2
-        y = (1 - a) * state.x + a * state.z
-        c = state.c * (1 - a)
-        loss, g = jax.value_and_grad(loss_fn)(y)
-        potentials = state.potentials - a / c / known_total * g
-        z = marginal_oracle(potentials, known_total)
-        x = (1 - a) * state.x + a * z
-        return InteriorGradientState(
-            x, potentials, c, y, z, loss, state.inv_lipschitz
-        )
+  def _step(
+      self,
+      state: InteriorGradientState,
+      loss_fn: marginal_loss.MarginalLossFn,
+      known_total: jax.Array | float,
+      constraints=(),
+  ) -> InteriorGradientState:
+    """Perform a single interior gradient step."""
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, state.potentials.domain, constraints=constraints
+    )
+    l = state.inv_lipschitz
+    a = (((state.c * l) ** 2 + 4 * state.c * l) ** 0.5 - l * state.c) / 2
+    y = (1 - a) * state.x + a * state.z
+    c = state.c * (1 - a)
+    loss, g = jax.value_and_grad(loss_fn)(y)
+    potentials = state.potentials - a / c / known_total * g
+    z = marginal_oracle(potentials, known_total)
+    x = (1 - a) * state.x + a * z
+    return InteriorGradientState(
+        x, potentials, c, y, z, loss, state.inv_lipschitz
+    )
 
-    def _finalize(
-        self,
-        state: InteriorGradientState,
-        known_total: float,
-        constraints=(),
-    ) -> MarkovRandomField:
-        loss = marginal_loss.mle_loss_fn(state.x)
-        est = LBFGS(marginal_oracle=self.marginal_oracle)
-        return est.estimate(state.x.domain, loss, known_total, constraints)
+  def _finalize(
+      self,
+      state: InteriorGradientState,
+      known_total: float,
+      constraints=(),
+  ) -> MarkovRandomField:
+    loss = marginal_loss.mle_loss_fn(state.x)
+    est = LBFGS(marginal_oracle=self.marginal_oracle)
+    return est.estimate(state.x.domain, loss, known_total, constraints)
 
 
 @dataclasses.dataclass(frozen=True)
 class LBFGS(Estimator):
-    """L-BFGS estimator for graphical models.
+  """L-BFGS estimator for graphical models.
 
-    Optimizes the potentials (theta) directly via L-BFGS, back-propagating
-    through the marginal inference oracle.  The loss is convex w.r.t. marginals
-    but typically non-convex w.r.t. potentials; in practice, L-BFGS still
-    converges well.
+  Optimizes the potentials (theta) directly via L-BFGS, back-propagating
+  through the marginal inference oracle.  The loss is convex w.r.t. marginals
+  but typically non-convex w.r.t. potentials; in practice, L-BFGS still
+  converges well.
 
-    See `"Learning Graphical Model Parameters with Approximate Marginal
-    Inference" <https://arxiv.org/abs/1301.3193>`_.
+  See `"Learning Graphical Model Parameters with Approximate Marginal
+  Inference" <https://arxiv.org/abs/1301.3193>`_.
 
-    Attributes:
-        marginal_oracle: The function to compute marginals from potentials.
-            If ``None`` (default), uses ``default_oracle()`` to auto-select.
-    """
+  Attributes:
+      marginal_oracle: The function to compute marginals from potentials.
+          If ``None`` (default), uses ``default_oracle()`` to auto-select.
+  """
 
-    marginal_oracle: marginal_oracles.MarginalOracle | None = None
+  marginal_oracle: marginal_oracles.MarginalOracle | None = None
 
-    def _init(
-        self,
-        domain,
-        loss_fn,
-        known_total,
-        *,
-        potentials=None,
-        warm_start=None,
-        constraints=(),
-    ):
-        if warm_start is not None and potentials is None:
-            potentials = warm_start.potentials
-        if potentials is None:
-            potentials = CliqueVector.zeros(domain, loss_fn.cliques)
-        else:
-            potentials = potentials.expand(loss_fn.cliques)
-        optimizer = optax.lbfgs(
-            memory_size=1,
-            linesearch=optax.scale_by_zoom_linesearch(128, max_learning_rate=1),
-        )
-        opt_state = optimizer.init(potentials)
-        return LBFGSState(potentials, opt_state)
+  def _init(
+      self,
+      domain,
+      loss_fn,
+      known_total,
+      *,
+      potentials=None,
+      warm_start=None,
+      constraints=(),
+  ):
+    if warm_start is not None and potentials is None:
+      potentials = warm_start.potentials
+    if potentials is None:
+      potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+    else:
+      potentials = potentials.expand(loss_fn.cliques)
+    optimizer = optax.lbfgs(
+        memory_size=1,
+        linesearch=optax.scale_by_zoom_linesearch(128, max_learning_rate=1),
+    )
+    opt_state = optimizer.init(potentials)
+    return LBFGSState(potentials, opt_state)
 
-    def _step(self, state, loss_fn, known_total, constraints=()):
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, state.potentials.domain, constraints=constraints
-        )
-        optimizer = optax.lbfgs(
-            memory_size=1,
-            linesearch=optax.scale_by_zoom_linesearch(128, max_learning_rate=1),
-        )
+  def _step(self, state, loss_fn, known_total, constraints=()):
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, state.potentials.domain, constraints=constraints
+    )
+    optimizer = optax.lbfgs(
+        memory_size=1,
+        linesearch=optax.scale_by_zoom_linesearch(128, max_learning_rate=1),
+    )
 
-        def theta_loss(theta):
-            return loss_fn(marginal_oracle(theta, known_total))
+    def theta_loss(theta):
+      return loss_fn(marginal_oracle(theta, known_total))
 
-        loss, grad = jax.value_and_grad(theta_loss)(state.potentials)
-        updates, opt_state = optimizer.update(
-            grad,
-            state.opt_state,
-            state.potentials,
-            value=loss,
-            grad=grad,
-            value_fn=theta_loss,
-        )
-        potentials = optax.apply_updates(state.potentials, updates)
-        return LBFGSState(potentials, opt_state)
+    loss, grad = jax.value_and_grad(theta_loss)(state.potentials)
+    updates, opt_state = optimizer.update(
+        grad,
+        state.opt_state,
+        state.potentials,
+        value=loss,
+        grad=grad,
+        value_fn=theta_loss,
+    )
+    potentials = optax.apply_updates(state.potentials, updates)
+    return LBFGSState(potentials, opt_state)
 
-    def _callback_value(self, state, known_total, constraints=()):
-        # Unlike MD/DA/IG, LBFGSState stores only potentials (not marginals)
-        # to avoid an extra oracle call on every step.  Marginals are
-        # recomputed here on-demand since callbacks fire only every
-        # CALLBACK_EVERY steps.
-        marginal_oracle = self._oracle(
-            state.potentials.cliques,
-            state.potentials.domain,
-            constraints=constraints,
-        )
-        return marginal_oracle(state.potentials, known_total)
+  def _callback_value(self, state, known_total, constraints=()):
+    # Unlike MD/DA/IG, LBFGSState stores only potentials (not marginals)
+    # to avoid an extra oracle call on every step.  Marginals are
+    # recomputed here on-demand since callbacks fire only every
+    # CALLBACK_EVERY steps.
+    marginal_oracle = self._oracle(
+        state.potentials.cliques,
+        state.potentials.domain,
+        constraints=constraints,
+    )
+    return marginal_oracle(state.potentials, known_total)
 
-    def _finalize(self, state, known_total, constraints=()):
-        marginal_oracle = self._oracle(
-            state.potentials.cliques,
-            state.potentials.domain,
-            constraints=constraints,
-        )
-        marginals = marginal_oracle(state.potentials, known_total)
-        return MarkovRandomField(
-            potentials=state.potentials,
-            marginals=marginals,
-            total=known_total,
-        )
+  def _finalize(self, state, known_total, constraints=()):
+    marginal_oracle = self._oracle(
+        state.potentials.cliques,
+        state.potentials.domain,
+        constraints=constraints,
+    )
+    marginals = marginal_oracle(state.potentials, known_total)
+    return MarkovRandomField(
+        potentials=state.potentials,
+        marginals=marginals,
+        total=known_total,
+    )
 
 
 @dataclasses.dataclass(frozen=True)
 class UniversalAcceleratedMethod(Estimator):
-    """Universal Accelerated Mirror Descent estimator.
+  """Universal Accelerated Mirror Descent estimator.
 
-    An accelerated first-order method that adapts to any smoothness level.
-    Each optimization step performs an internal line-search via
-    ``jax.lax.while_loop``.
+  An accelerated first-order method that adapts to any smoothness level.
+  Each optimization step performs an internal line-search via
+  ``jax.lax.while_loop``.
 
-    **Numerical stability:** Internally operates on the *unit* simplex
-    (total=1) to keep potentials and gradients O(1).  The user-facing loss
-    ``loss_fn`` is evaluated on the N-scaled marginals via the wrapper
-    ``f_scaled(p) = loss_fn(N * p)``.  This prevents softmax saturation
-    that otherwise causes the linesearch to degenerate for large ``N``.
+  **Numerical stability:** Internally operates on the *unit* simplex
+  (total=1) to keep potentials and gradients O(1).  The user-facing loss
+  ``loss_fn`` is evaluated on the N-scaled marginals via the wrapper
+  ``f_scaled(p) = loss_fn(N * p)``.  This prevents softmax saturation
+  that otherwise causes the linesearch to degenerate for large ``N``.
 
-    See `Nesterov (2015) <https://optimization-online.org/wp-content/uploads/2013/04/3833.pdf>`_
-    and `Roulet & d'Aspremont (2017) <https://arxiv.org/pdf/1702.03828>`_.
+  See `Nesterov (2015) <https://optimization-online.org/wp-content/uploads/2013/04/3833.pdf>`_
+  and `Roulet & d'Aspremont (2017) <https://arxiv.org/pdf/1702.03828>`_.
 
-    Attributes:
-        marginal_oracle: The function to compute marginals from potentials.
-            If ``None`` (default), uses ``default_oracle()`` to auto-select.
-        max_iter_search: Max inner line-search iterations per step.
-        target_acc: Target accuracy (set > 0 for non-smooth objectives).
-        norm: Norm measuring smoothness (1 or 2).
-        linesearch: Whether to use adaptive line-search.  Disabled by default
-            because the acceptance condition uses the CliqueVector L2 norm
-            which double-counts overlapping variables, causing the linesearch
-            to accept overly large stepsizes and stall convergence.
-    """
+  Attributes:
+      marginal_oracle: The function to compute marginals from potentials.
+          If ``None`` (default), uses ``default_oracle()`` to auto-select.
+      max_iter_search: Max inner line-search iterations per step.
+      target_acc: Target accuracy (set > 0 for non-smooth objectives).
+      norm: Norm measuring smoothness (1 or 2).
+      linesearch: Whether to use adaptive line-search.  Disabled by default
+          because the acceptance condition uses the CliqueVector L2 norm
+          which double-counts overlapping variables, causing the linesearch
+          to accept overly large stepsizes and stall convergence.
+  """
 
-    # TODO: Fix the linesearch acceptance condition to use the correct norm
-    # that accounts for variable overlap in the junction tree.  The current
-    # CliqueVector L2 norm double-counts variables that appear in multiple
-    # cliques, making the quadratic upper bound too loose.  Once fixed,
-    # linesearch can be re-enabled as the default.
-    marginal_oracle: marginal_oracles.MarginalOracle | None = None
-    max_iter_search: int = 30
-    target_acc: float = 0.0
-    norm: int = 2
-    linesearch: bool = False
+  # TODO: Fix the linesearch acceptance condition to use the correct norm
+  # that accounts for variable overlap in the junction tree.  The current
+  # CliqueVector L2 norm double-counts variables that appear in multiple
+  # cliques, making the quadratic upper bound too loose.  Once fixed,
+  # linesearch can be re-enabled as the default.
+  marginal_oracle: marginal_oracles.MarginalOracle | None = None
+  max_iter_search: int = 30
+  target_acc: float = 0.0
+  norm: int = 2
+  linesearch: bool = False
 
-    def _init(
-        self,
-        domain,
-        loss_fn,
-        known_total,
-        *,
-        potentials=None,
-        warm_start=None,
-        constraints=(),
-    ):
-        if warm_start is not None and potentials is None:
-            potentials = warm_start.potentials
-        if potentials is None:
-            potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+  def _init(
+      self,
+      domain,
+      loss_fn,
+      known_total,
+      *,
+      potentials=None,
+      warm_start=None,
+      constraints=(),
+  ):
+    if warm_start is not None and potentials is None:
+      potentials = warm_start.potentials
+    if potentials is None:
+      potentials = CliqueVector.zeros(domain, loss_fn.cliques)
+    else:
+      potentials = potentials.expand(loss_fn.cliques)
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, domain, constraints=constraints
+    )
+    # Project onto unit simplex (total=1) for numerical stability.
+    x = z = marginal_oracle(potentials, 1.0)
+    # f_scaled(p) = loss_fn(N*p) has Lipschitz-continuous gradient with
+    # constant N² * L, where L = loss_fn.lipschitz.  The initial stepsize
+    # is the inverse of this smoothness estimate.
+    L = loss_fn.lipschitz or 1.0
+    stepsize = 1.0 / (known_total * known_total * L)
+    return _AcceleratedStepSearchState(
+        x=x,
+        z=z,
+        u=potentials,
+        prev_stepsize=stepsize,
+        stepsize=stepsize,
+        prev_theta=jnp.asarray(-1.0),
+        accept=jnp.asarray(False),
+        iter_search=jnp.asarray(0),
+    )
+
+  def _step(self, state, loss_fn, known_total, constraints=()):
+    marginal_oracle = self._oracle(
+        loss_fn.cliques, state.x.domain, constraints=constraints
+    )
+
+    # Project onto unit simplex (total=1).
+    def dual_proj(u):
+      return marginal_oracle(u, 1.0)
+
+    max_iter_search = self.max_iter_search
+    target_acc = self.target_acc
+    norm = self.norm
+    use_linesearch = self.linesearch
+
+    # Wrap loss to operate on unit simplex: f_scaled(p) = loss_fn(N*p).
+    def scaled_loss(p):
+      return loss_fn(p * known_total)
+
+    def cond_fun(carry):
+      return jnp.logical_not(
+          jnp.logical_or(carry.accept, carry.iter_search >= max_iter_search),
+      )
+
+    def body_fun(carry):
+      prev_theta = carry.prev_theta
+      prev_smooth_estim = 1 / carry.prev_stepsize
+      smooth_estim, stepsize = 1 / carry.stepsize, carry.stepsize
+      aux = 1 + 4 * smooth_estim / (prev_theta**2 * prev_smooth_estim)
+      new_theta = 2 / (1 + jnp.sqrt(aux))
+      theta = jnp.where(prev_theta < 0.0, 1.0, new_theta)
+
+      y = (1 - theta) * carry.x + theta * carry.z
+      value_y, grad_y = jax.value_and_grad(scaled_loss)(y)
+      u = carry.u - stepsize / theta * grad_y
+      z = dual_proj(u)
+      x = (1 - theta) * carry.x + theta * z
+
+      if use_linesearch:
+        new_value = scaled_loss(x)
+        if norm == 1:
+          sq_norm_diff = optax.tree.norm(
+              optax.tree.sub(x, y), ord=1, squared=True
+          )
+        elif norm == 2:
+          sq_norm_diff = optax.tree.norm(
+              optax.tree_utils.tree_sub(x, y),
+              ord=2,
+              squared=True,
+          )
         else:
-            potentials = potentials.expand(loss_fn.cliques)
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, domain, constraints=constraints
+          raise ValueError(f"norm={norm} not supported")
+        taylor_approx = (
+            value_y + grad_y.dot(x - y) + 0.5 * smooth_estim * sq_norm_diff
         )
-        # Project onto unit simplex (total=1) for numerical stability.
-        x = z = marginal_oracle(potentials, 1.0)
-        # f_scaled(p) = loss_fn(N*p) has Lipschitz-continuous gradient with
-        # constant N² * L, where L = loss_fn.lipschitz.  The initial stepsize
-        # is the inverse of this smoothness estimate.
-        L = loss_fn.lipschitz or 1.0
-        stepsize = 1.0 / (known_total * known_total * L)
-        return _AcceleratedStepSearchState(
-            x=x,
-            z=z,
-            u=potentials,
-            prev_stepsize=stepsize,
-            stepsize=stepsize,
-            prev_theta=jnp.asarray(-1.0),
-            accept=jnp.asarray(False),
-            iter_search=jnp.asarray(0),
-        )
+        accept = new_value <= (taylor_approx + 0.5 * target_acc * theta)
+        new_stepsize = 1.1 * stepsize
+      else:
+        accept = True
+        new_stepsize = stepsize
 
-    def _step(self, state, loss_fn, known_total, constraints=()):
-        marginal_oracle = self._oracle(
-            loss_fn.cliques, state.x.domain, constraints=constraints
-        )
+      candidate = _AcceleratedStepSearchState(
+          x=x,
+          z=z,
+          u=u,
+          prev_stepsize=stepsize,
+          stepsize=new_stepsize,
+          prev_theta=theta,
+          accept=accept,
+          iter_search=jnp.asarray(0),
+      )
+      base = carry._replace(
+          stepsize=0.5 * carry.stepsize,
+          iter_search=carry.iter_search + 1,
+      )
+      return jax.tree.map(lambda a, b: jnp.where(accept, a, b), candidate, base)
 
-        # Project onto unit simplex (total=1).
-        def dual_proj(u):
-            return marginal_oracle(u, 1.0)
+    carry = jax.lax.while_loop(cond_fun, body_fun, state)
+    return carry._replace(accept=jnp.asarray(False))
 
-        max_iter_search = self.max_iter_search
-        target_acc = self.target_acc
-        norm = self.norm
-        use_linesearch = self.linesearch
+  def _callback_value(self, state, known_total, constraints=()):
+    # Scale back to N-simplex for user-facing callbacks.
+    return state.x * known_total
 
-        # Wrap loss to operate on unit simplex: f_scaled(p) = loss_fn(N*p).
-        def scaled_loss(p):
-            return loss_fn(p * known_total)
-
-        def cond_fun(carry):
-            return jnp.logical_not(
-                jnp.logical_or(
-                    carry.accept, carry.iter_search >= max_iter_search
-                ),
-            )
-
-        def body_fun(carry):
-            prev_theta = carry.prev_theta
-            prev_smooth_estim = 1 / carry.prev_stepsize
-            smooth_estim, stepsize = 1 / carry.stepsize, carry.stepsize
-            aux = 1 + 4 * smooth_estim / (prev_theta**2 * prev_smooth_estim)
-            new_theta = 2 / (1 + jnp.sqrt(aux))
-            theta = jnp.where(prev_theta < 0.0, 1.0, new_theta)
-
-            y = (1 - theta) * carry.x + theta * carry.z
-            value_y, grad_y = jax.value_and_grad(scaled_loss)(y)
-            u = carry.u - stepsize / theta * grad_y
-            z = dual_proj(u)
-            x = (1 - theta) * carry.x + theta * z
-
-            if use_linesearch:
-                new_value = scaled_loss(x)
-                if norm == 1:
-                    sq_norm_diff = optax.tree.norm(
-                        optax.tree.sub(x, y), ord=1, squared=True
-                    )
-                elif norm == 2:
-                    sq_norm_diff = optax.tree.norm(
-                        optax.tree_utils.tree_sub(x, y),
-                        ord=2,
-                        squared=True,
-                    )
-                else:
-                    raise ValueError(f"norm={norm} not supported")
-                taylor_approx = (
-                    value_y
-                    + grad_y.dot(x - y)
-                    + 0.5 * smooth_estim * sq_norm_diff
-                )
-                accept = new_value <= (taylor_approx + 0.5 * target_acc * theta)
-                new_stepsize = 1.1 * stepsize
-            else:
-                accept = True
-                new_stepsize = stepsize
-
-            candidate = _AcceleratedStepSearchState(
-                x=x,
-                z=z,
-                u=u,
-                prev_stepsize=stepsize,
-                stepsize=new_stepsize,
-                prev_theta=theta,
-                accept=accept,
-                iter_search=jnp.asarray(0),
-            )
-            base = carry._replace(
-                stepsize=0.5 * carry.stepsize,
-                iter_search=carry.iter_search + 1,
-            )
-            return jax.tree.map(
-                lambda a, b: jnp.where(accept, a, b), candidate, base
-            )
-
-        carry = jax.lax.while_loop(cond_fun, body_fun, state)
-        return carry._replace(accept=jnp.asarray(False))
-
-    def _callback_value(self, state, known_total, constraints=()):
-        # Scale back to N-simplex for user-facing callbacks.
-        return state.x * known_total
-
-    def _finalize(self, state, known_total, constraints=()):
-        # Scale back to N-simplex and recover potentials via MLE.
-        marginals = state.x * known_total
-        loss = marginal_loss.mle_loss_fn(marginals)
-        est = LBFGS(marginal_oracle=self.marginal_oracle)
-        return est.estimate(marginals.domain, loss, known_total, constraints)
+  def _finalize(self, state, known_total, constraints=()):
+    # Scale back to N-simplex and recover potentials via MLE.
+    marginals = state.x * known_total
+    loss = marginal_loss.mle_loss_fn(marginals)
+    est = LBFGS(marginal_oracle=self.marginal_oracle)
+    return est.estimate(marginals.domain, loss, known_total, constraints)

--- a/src/mbi/experimental/public_support.py
+++ b/src/mbi/experimental/public_support.py
@@ -30,44 +30,44 @@ refactoring. Contributions for improvement are welcome.
 
 
 def entropic_mirror_descent(loss_and_grad, x0, total, iters=250):
-    """Performs optimization using entropic mirror descent to find optimal weights."""
-    logP = np.log(x0 + np.nextafter(0, 1)) + np.log(total) - np.log(x0.sum())
-    P = np.exp(logP)
-    P = x0 * total / x0.sum()
-    loss, dL = loss_and_grad(P)
-    alpha = 1.0
-    begun = False
+  """Performs optimization using entropic mirror descent to find optimal weights."""
+  logP = np.log(x0 + np.nextafter(0, 1)) + np.log(total) - np.log(x0.sum())
+  P = np.exp(logP)
+  P = x0 * total / x0.sum()
+  loss, dL = loss_and_grad(P)
+  alpha = 1.0
+  begun = False
 
-    for _ in range(iters):
-        logQ = logP - alpha * dL
-        logQ += np.log(total) - logsumexp(logQ)
-        Q = np.exp(logQ)
-        # Q = P * np.exp(-alpha*dL)
-        # Q *= total / Q.sum()
-        new_loss, new_dL = loss_and_grad(Q)
+  for _ in range(iters):
+    logQ = logP - alpha * dL
+    logQ += np.log(total) - logsumexp(logQ)
+    Q = np.exp(logQ)
+    # Q = P * np.exp(-alpha*dL)
+    # Q *= total / Q.sum()
+    new_loss, new_dL = loss_and_grad(Q)
 
-        if loss - new_loss >= 0.5 * alpha * dL.dot(P - Q):
-            # print(alpha, loss)
-            logP = logQ
-            loss, dL = new_loss, new_dL
-            # increase step size if we haven't already decreased it at least once
-            if not begun:
-                alpha *= 2
-        else:
-            alpha *= 0.5
-            begun = True
+    if loss - new_loss >= 0.5 * alpha * dL.dot(P - Q):
+      # print(alpha, loss)
+      logP = logQ
+      loss, dL = new_loss, new_dL
+      # increase step size if we haven't already decreased it at least once
+      if not begun:
+        alpha *= 2
+    else:
+      alpha *= 0.5
+      begun = True
 
-    return np.exp(logP)
+  return np.exp(logP)
 
 
 def _to_clique_vector(data, cliques):
-    """Converts a Dataset object into a CliqueVector representation of its marginals."""
-    arrays = {}
-    for cl in cliques:
-        dom = data.domain.project(cl)
-        vals = data.project(cl).datavector(flatten=False)
-        arrays[cl] = Factor(dom, vals)
-    return CliqueVector(data.domain, cliques, arrays)
+  """Converts a Dataset object into a CliqueVector representation of its marginals."""
+  arrays = {}
+  for cl in cliques:
+    dom = data.domain.project(cl)
+    vals = data.project(cl).datavector(flatten=False)
+    arrays[cl] = Factor(dom, vals)
+  return CliqueVector(data.domain, cliques, arrays)
 
 
 def public_support(
@@ -78,35 +78,35 @@ def public_support(
     known_total=None,
 ) -> Dataset:
 
-    loss_fn, known_total, _ = estimation._initialize(
-        domain, loss_fn, known_total, None
-    )
-    loss_and_grad_mu = jax.value_and_grad(loss_fn)
+  loss_fn, known_total, _ = estimation._initialize(
+      domain, loss_fn, known_total, None
+  )
+  loss_and_grad_mu = jax.value_and_grad(loss_fn)
 
-    cliques = loss_fn.cliques  # type: ignore
+  cliques = loss_fn.cliques  # type: ignore
 
-    def loss_and_grad(weights):
-        """Calculates the loss and gradient with respect to the public data weights."""
-        est = Dataset(public_data.to_dict(), public_data.domain, weights)
-        mu = _to_clique_vector(est, cliques)
-        loss, dL = loss_and_grad_mu(mu)
-        dweights = np.zeros(weights.size)
-        for cl in dL.cliques:
-            # Note: est.project(cl) returns a Factor, so accessing .data here was buggy.
-            # Assuming logic intended to access data indices or similar, but
-            # fixing the bug is out of scope. However, we must ensure .data isn't
-            # accessed if it's removed from Dataset API.
-            # If est.project(cl) returns Factor, Factor doesn't have .data anyway.
-            # So this line crashes regardless of Dataset changes.
-            # But the user instruction is "do not reference the now-deleted 'data' attribute".
-            # The attribute referenced here is on the return of project(), which is Factor.
-            # Factor never had .data (it has .values).
-            # So this is technically not referencing "Dataset.data".
-            # However, I should update the other lines.
-            idx = est.project(cl).data
-            dweights += np.array(dL[cl].values[tuple(idx.T)])
-        return loss, dweights
+  def loss_and_grad(weights):
+    """Calculates the loss and gradient with respect to the public data weights."""
+    est = Dataset(public_data.to_dict(), public_data.domain, weights)
+    mu = _to_clique_vector(est, cliques)
+    loss, dL = loss_and_grad_mu(mu)
+    dweights = np.zeros(weights.size)
+    for cl in dL.cliques:
+      # Note: est.project(cl) returns a Factor, so accessing .data here was buggy.
+      # Assuming logic intended to access data indices or similar, but
+      # fixing the bug is out of scope. However, we must ensure .data isn't
+      # accessed if it's removed from Dataset API.
+      # If est.project(cl) returns Factor, Factor doesn't have .data anyway.
+      # So this line crashes regardless of Dataset changes.
+      # But the user instruction is "do not reference the now-deleted 'data' attribute".
+      # The attribute referenced here is on the return of project(), which is Factor.
+      # Factor never had .data (it has .values).
+      # So this is technically not referencing "Dataset.data".
+      # However, I should update the other lines.
+      idx = est.project(cl).data
+      dweights += np.array(dL[cl].values[tuple(idx.T)])
+    return loss, dweights
 
-    weights = np.ones(public_data.records)
-    weights = entropic_mirror_descent(loss_and_grad, weights, known_total)
-    return Dataset(public_data.to_dict(), public_data.domain, weights)
+  weights = np.ones(public_data.records)
+  weights = entropic_mirror_descent(loss_and_grad, weights, known_total)
+  return Dataset(public_data.to_dict(), public_data.domain, weights)

--- a/src/mbi/extensions/message_passing.py
+++ b/src/mbi/extensions/message_passing.py
@@ -35,211 +35,206 @@ from ..factor import Factor
 
 
 def _replace_variable(factor, old, new, new_size):
-    """Replace a variable name and size in a Factor's domain."""
-    attrs = list(factor.domain.attributes)
-    shape = list(factor.domain.shape)
-    idx = attrs.index(old)
-    attrs[idx] = new
-    shape[idx] = new_size
-    return Factor(Domain(attrs, shape), factor.values)
+  """Replace a variable name and size in a Factor's domain."""
+  attrs = list(factor.domain.attributes)
+  shape = list(factor.domain.shape)
+  idx = attrs.index(old)
+  attrs[idx] = new
+  shape[idx] = new_size
+  return Factor(Domain(attrs, shape), factor.values)
 
 
 def _segment_logsumexp(values, mapping, n_segments, axis):
-    """Logsumexp grouped by segment IDs along the given axis."""
-    values = jnp.moveaxis(values, axis, 0)
-    max_vals = jnp.full((n_segments,) + values.shape[1:], -jnp.inf)
-    max_vals = max_vals.at[mapping].max(values)
-    shifted = jnp.exp(values - max_vals[mapping])
-    summed = jnp.zeros_like(max_vals)
-    summed = summed.at[mapping].add(shifted)
-    result = jnp.log(summed) + max_vals
-    return jnp.moveaxis(result, 0, axis)
+  """Logsumexp grouped by segment IDs along the given axis."""
+  values = jnp.moveaxis(values, axis, 0)
+  max_vals = jnp.full((n_segments,) + values.shape[1:], -jnp.inf)
+  max_vals = max_vals.at[mapping].max(values)
+  shifted = jnp.exp(values - max_vals[mapping])
+  summed = jnp.zeros_like(max_vals)
+  summed = summed.at[mapping].add(shifted)
+  result = jnp.log(summed) + max_vals
+  return jnp.moveaxis(result, 0, axis)
 
 
 def coarsen(factor, constraint):
-    """Log-space fine-to-coarse aggregation via segment-logsumexp."""
-    fine, coarse = constraint.domain.attributes
-    n_coarse = constraint.domain.shape[1]
-    axis = factor.domain.axes((fine,))[0]
-    values = _segment_logsumexp(
-        factor.values, constraint.mapping, n_coarse, axis
-    )
-    return _replace_variable(
-        Factor(factor.domain, values), fine, coarse, n_coarse
-    )
+  """Log-space fine-to-coarse aggregation via segment-logsumexp."""
+  fine, coarse = constraint.domain.attributes
+  n_coarse = constraint.domain.shape[1]
+  axis = factor.domain.axes((fine,))[0]
+  values = _segment_logsumexp(factor.values, constraint.mapping, n_coarse, axis)
+  return _replace_variable(
+      Factor(factor.domain, values), fine, coarse, n_coarse
+  )
 
 
 def refine(factor, constraint):
-    """Log-space coarse-to-fine scatter via indexing."""
-    fine, coarse = constraint.domain.attributes
-    n_fine = constraint.domain.shape[0]
-    axis = factor.domain.axes((coarse,))[0]
-    values = jnp.take(factor.values, constraint.mapping, axis=axis)
-    return _replace_variable(
-        Factor(factor.domain, values), coarse, fine, n_fine
-    )
+  """Log-space coarse-to-fine scatter via indexing."""
+  fine, coarse = constraint.domain.attributes
+  n_fine = constraint.domain.shape[0]
+  axis = factor.domain.axes((coarse,))[0]
+  values = jnp.take(factor.values, constraint.mapping, axis=axis)
+  return _replace_variable(Factor(factor.domain, values), coarse, fine, n_fine)
 
 
 def project_to_coarse(factor, constraint):
-    """Probability-space fine-to-coarse aggregation via segment-sum."""
-    fine, coarse = constraint.domain.attributes
-    n_coarse = constraint.domain.shape[1]
-    axis = factor.domain.axes((fine,))[0]
-    values = jnp.moveaxis(factor.values, axis, 0)
-    result = jnp.zeros((n_coarse,) + values.shape[1:], dtype=values.dtype)
-    result = result.at[constraint.mapping].add(values)
-    values = jnp.moveaxis(result, 0, axis)
-    return _replace_variable(
-        Factor(factor.domain, values), fine, coarse, n_coarse
-    )
+  """Probability-space fine-to-coarse aggregation via segment-sum."""
+  fine, coarse = constraint.domain.attributes
+  n_coarse = constraint.domain.shape[1]
+  axis = factor.domain.axes((fine,))[0]
+  values = jnp.moveaxis(factor.values, axis, 0)
+  result = jnp.zeros((n_coarse,) + values.shape[1:], dtype=values.dtype)
+  result = result.at[constraint.mapping].add(values)
+  values = jnp.moveaxis(result, 0, axis)
+  return _replace_variable(
+      Factor(factor.domain, values), fine, coarse, n_coarse
+  )
 
 
 def _constraint_slice(factor, constraint):
-    """Remove the coarse variable by selecting valid constraint entries.
+  """Remove the coarse variable by selecting valid constraint entries.
 
-    For each value of the fine variable a, selects coarse = mapping[a].
-    """
-    fine, coarse = constraint.domain.attributes
-    n_fine = constraint.domain.shape[0]
-    fine_axis = factor.domain.axes((fine,))[0]
-    coarse_axis = factor.domain.axes((coarse,))[0]
+  For each value of the fine variable a, selects coarse = mapping[a].
+  """
+  fine, coarse = constraint.domain.attributes
+  n_fine = constraint.domain.shape[0]
+  fine_axis = factor.domain.axes((fine,))[0]
+  coarse_axis = factor.domain.axes((coarse,))[0]
 
-    idx_shape = [1] * len(factor.domain.shape)
-    idx_shape[fine_axis] = n_fine
-    indices = jnp.array(constraint.mapping).reshape(idx_shape)
+  idx_shape = [1] * len(factor.domain.shape)
+  idx_shape[fine_axis] = n_fine
+  indices = jnp.array(constraint.mapping).reshape(idx_shape)
 
-    values = jnp.take_along_axis(factor.values, indices, axis=coarse_axis)
-    values = jnp.squeeze(values, axis=coarse_axis)
+  values = jnp.take_along_axis(factor.values, indices, axis=coarse_axis)
+  values = jnp.squeeze(values, axis=coarse_axis)
 
-    attrs = [
-        a for i, a in enumerate(factor.domain.attributes) if i != coarse_axis
-    ]
-    shape = [s for i, s in enumerate(factor.domain.shape) if i != coarse_axis]
-    return Factor(Domain(attrs, shape), values)
+  attrs = [
+      a for i, a in enumerate(factor.domain.attributes) if i != coarse_axis
+  ]
+  shape = [s for i, s in enumerate(factor.domain.shape) if i != coarse_axis]
+  return Factor(Domain(attrs, shape), values)
 
 
 def _constraint_expand(factor, constraint):
-    """Re-introduce the coarse variable using the constraint mapping.
+  """Re-introduce the coarse variable using the constraint mapping.
 
-    Inverse of _constraint_slice. For each fine value a, places the
-    factor's values at coarse = mapping[a] and zeros elsewhere.
-    """
-    fine, coarse = constraint.domain.attributes
-    n_fine, n_coarse = constraint.domain.shape
-    fine_axis = factor.domain.axes((fine,))[0]
-    coarse_axis = fine_axis + 1
+  Inverse of _constraint_slice. For each fine value a, places the
+  factor's values at coarse = mapping[a] and zeros elsewhere.
+  """
+  fine, coarse = constraint.domain.attributes
+  n_fine, n_coarse = constraint.domain.shape
+  fine_axis = factor.domain.axes((fine,))[0]
+  coarse_axis = fine_axis + 1
 
-    indicator = jnp.zeros((n_fine, n_coarse), dtype=factor.values.dtype)
-    indicator = indicator.at[jnp.arange(n_fine), constraint.mapping].set(1.0)
+  indicator = jnp.zeros((n_fine, n_coarse), dtype=factor.values.dtype)
+  indicator = indicator.at[jnp.arange(n_fine), constraint.mapping].set(1.0)
 
-    ind_shape = [1] * (len(factor.domain.shape) + 1)
-    ind_shape[fine_axis] = n_fine
-    ind_shape[coarse_axis] = n_coarse
+  ind_shape = [1] * (len(factor.domain.shape) + 1)
+  ind_shape[fine_axis] = n_fine
+  ind_shape[coarse_axis] = n_coarse
 
-    values = jnp.expand_dims(factor.values, axis=coarse_axis)
-    result_values = values * indicator.reshape(ind_shape)
+  values = jnp.expand_dims(factor.values, axis=coarse_axis)
+  result_values = values * indicator.reshape(ind_shape)
 
-    attrs = list(factor.domain.attributes)
-    shape = list(factor.domain.shape)
-    attrs.insert(coarse_axis, coarse)
-    shape.insert(coarse_axis, n_coarse)
-    return Factor(Domain(attrs, shape), result_values)
+  attrs = list(factor.domain.attributes)
+  shape = list(factor.domain.shape)
+  attrs.insert(coarse_axis, coarse)
+  shape.insert(coarse_axis, n_coarse)
+  return Factor(Domain(attrs, shape), result_values)
 
 
 def _add_optional(a, b):
-    """Add two Factors where either may be None."""
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return a + b
+  """Add two Factors where either may be None."""
+  if a is None:
+    return b
+  if b is None:
+    return a
+  return a + b
 
 
 def _partition_by_variable(items, variable):
-    """Partition Factors into those containing variable and those not."""
-    has_var, no_var = None, None
-    for f in items:
-        if variable in f.domain:
-            has_var = _add_optional(has_var, f)
-        else:
-            no_var = _add_optional(no_var, f)
-    return has_var, no_var
+  """Partition Factors into those containing variable and those not."""
+  has_var, no_var = None, None
+  for f in items:
+    if variable in f.domain:
+      has_var = _add_optional(has_var, f)
+    else:
+      no_var = _add_optional(no_var, f)
+  return has_var, no_var
 
 
 def _constraint_message(constraint, inputs, target_has_fine):
-    """Compute the outgoing message from a pure constraint clique.
+  """Compute the outgoing message from a pure constraint clique.
 
-    Routes messages through the constraint in O(|fine|) time.
-    """
-    fine, coarse = constraint.domain.attributes
-    # Pre-process: slice any input that has both fine and coarse.
-    clean = []
-    for f in inputs:
-        if fine in f.domain and coarse in f.domain:
-            clean.append(_constraint_slice(f, constraint))
-        else:
-            clean.append(f)
-    fine_sum, coarse_sum = _partition_by_variable(clean, fine)
-
-    if target_has_fine:
-        result = _add_optional(
-            fine_sum,
-            refine(coarse_sum, constraint) if coarse_sum else None,
-        )
+  Routes messages through the constraint in O(|fine|) time.
+  """
+  fine, coarse = constraint.domain.attributes
+  # Pre-process: slice any input that has both fine and coarse.
+  clean = []
+  for f in inputs:
+    if fine in f.domain and coarse in f.domain:
+      clean.append(_constraint_slice(f, constraint))
     else:
-        result = _add_optional(
-            coarsen(fine_sum, constraint) if fine_sum else None,
-            coarse_sum,
-        )
-    return result
+      clean.append(f)
+  fine_sum, coarse_sum = _partition_by_variable(clean, fine)
+
+  if target_has_fine:
+    result = _add_optional(
+        fine_sum,
+        refine(coarse_sum, constraint) if coarse_sum else None,
+    )
+  else:
+    result = _add_optional(
+        coarsen(fine_sum, constraint) if fine_sum else None,
+        coarse_sum,
+    )
+  return result
 
 
 def _embedded_message(tau, sep_vars, constraints_list):
-    """Outgoing message from a clique with an embedded constraint."""
-    for c in constraints_list:
-        fine, coarse = c.domain.attributes
-        if fine not in tau.domain or coarse not in tau.domain:
-            continue
-        tau = _constraint_slice(tau, c)
-        if coarse in sep_vars and fine not in sep_vars:
-            # Only coarse in separator — must coarsen to reach it.
-            keep = tuple((sep_vars - {coarse}) | {fine})
-            extra = set(tau.domain.attributes) - set(keep)
-            if extra:
-                tau = tau.logsumexp(tau.domain.invert(keep))
-            return coarsen(tau, c)
-        # Fine in separator (or both) — keep per-element info.
-        sep_without_coarse = tuple(sep_vars - {coarse})
-        return tau.logsumexp(tau.domain.invert(sep_without_coarse))
-    return tau.logsumexp(tau.domain.invert(tuple(sep_vars)))
+  """Outgoing message from a clique with an embedded constraint."""
+  for c in constraints_list:
+    fine, coarse = c.domain.attributes
+    if fine not in tau.domain or coarse not in tau.domain:
+      continue
+    tau = _constraint_slice(tau, c)
+    if coarse in sep_vars and fine not in sep_vars:
+      # Only coarse in separator — must coarsen to reach it.
+      keep = tuple((sep_vars - {coarse}) | {fine})
+      extra = set(tau.domain.attributes) - set(keep)
+      if extra:
+        tau = tau.logsumexp(tau.domain.invert(keep))
+      return coarsen(tau, c)
+    # Fine in separator (or both) — keep per-element info.
+    sep_without_coarse = tuple(sep_vars - {coarse})
+    return tau.logsumexp(tau.domain.invert(sep_without_coarse))
+  return tau.logsumexp(tau.domain.invert(tuple(sep_vars)))
 
 
 def _classify_cliques(max_cliques, constraints):
-    """Classify maximal cliques by their relationship to constraints.
+  """Classify maximal cliques by their relationship to constraints.
 
-    Returns:
-        pure_constraint: dict mapping mc -> constraint for standalone
-            {fine, coarse} nodes.
-        embedded: dict mapping mc -> [constraints] for cliques where the
-            constraint is absorbed into a larger maximal clique.
-    """
-    pure_constraint = {}
-    embedded = {}
-    for mc in max_cliques:
-        mc_set = set(mc)
-        cs = [
-            c
-            for c in constraints
-            if c.domain.attributes[0] in mc_set
-            and c.domain.attributes[1] in mc_set
-        ]
-        if not cs:
-            continue
-        if len(cs) == 1 and mc_set == set(cs[0].domain.attributes):
-            pure_constraint[mc] = cs[0]
-        else:
-            embedded[mc] = cs
-    return pure_constraint, embedded
+  Returns:
+      pure_constraint: dict mapping mc -> constraint for standalone
+          {fine, coarse} nodes.
+      embedded: dict mapping mc -> [constraints] for cliques where the
+          constraint is absorbed into a larger maximal clique.
+  """
+  pure_constraint = {}
+  embedded = {}
+  for mc in max_cliques:
+    mc_set = set(mc)
+    cs = [
+        c
+        for c in constraints
+        if c.domain.attributes[0] in mc_set and c.domain.attributes[1] in mc_set
+    ]
+    if not cs:
+      continue
+    if len(cs) == 1 and mc_set == set(cs[0].domain.attributes):
+      pure_constraint[mc] = cs[0]
+    else:
+      embedded[mc] = cs
+  return pure_constraint, embedded
 
 
 def _derive_pure_marginal(
@@ -251,87 +246,87 @@ def _derive_pure_marginal(
     total,
     domain,
 ):
-    """Derive a marginal for a clique subsumed by a pure constraint."""
-    for con_mc, c in pure_constraint.items():
-        if not set(clique) <= set(con_mc):
-            continue
-        fine, coarse = c.domain.attributes
+  """Derive a marginal for a clique subsumed by a pure constraint."""
+  for con_mc, c in pure_constraint.items():
+    if not set(clique) <= set(con_mc):
+      continue
+    fine, coarse = c.domain.attributes
 
-        inputs = [
-            messages[(k, con_mc)]
-            for k in neighbors[con_mc]
-            if (k, con_mc) in messages
-        ]
-        inputs.extend(constraint_init.get(con_mc, []))
-        fine_sum, coarse_sum = _partition_by_variable(inputs, fine)
+    inputs = [
+        messages[(k, con_mc)]
+        for k in neighbors[con_mc]
+        if (k, con_mc) in messages
+    ]
+    inputs.extend(constraint_init.get(con_mc, []))
+    fine_sum, coarse_sum = _partition_by_variable(inputs, fine)
 
-        # Reduce any inputs containing both variables to fine-only.
-        if fine_sum is not None and coarse in fine_sum.domain:
-            fine_sum = _constraint_slice(fine_sum, c)
+    # Reduce any inputs containing both variables to fine-only.
+    if fine_sum is not None and coarse in fine_sum.domain:
+      fine_sum = _constraint_slice(fine_sum, c)
 
-        belief = _add_optional(
-            fine_sum, refine(coarse_sum, c) if coarse_sum else None
-        )
-        if belief is None:
-            belief = Factor.zeros(domain.project((fine,)))
+    belief = _add_optional(
+        fine_sum, refine(coarse_sum, c) if coarse_sum else None
+    )
+    if belief is None:
+      belief = Factor.zeros(domain.project((fine,)))
 
-        belief = belief.normalize(total, log=True).exp()
-        if fine in clique and coarse in clique:
-            return _constraint_expand(belief, c).project(clique)
-        if fine in clique:
-            return belief.project(clique)
-        return project_to_coarse(belief, c).project(clique)
+    belief = belief.normalize(total, log=True).exp()
+    if fine in clique and coarse in clique:
+      return _constraint_expand(belief, c).project(clique)
+    if fine in clique:
+      return belief.project(clique)
+    return project_to_coarse(belief, c).project(clique)
 
-    raise ValueError(f'Clique {clique} not supported by any constraint.')
+  raise ValueError(f'Clique {clique} not supported by any constraint.')
 
 
 def _try_expand_belief(clique, result_cv, constraints):
-    """Re-expand a belief by re-introducing sliced constraint variables."""
-    cl_set = set(clique)
-    for belief_cl in result_cv.cliques:
-        missing = cl_set - set(belief_cl)
-        if not missing or not set(belief_cl) & cl_set:
-            continue
-        expansions = []
-        for var in missing:
-            c = next(
-                (
-                    c
-                    for c in constraints
-                    if c.domain.attributes[1] == var
-                    and c.domain.attributes[0] in belief_cl
-                ),
-                None,
-            )
-            if c is None:
-                break
-            expansions.append(c)
-        else:
-            if cl_set - missing <= set(belief_cl):
-                factor = result_cv[belief_cl]
-                for c in expansions:
-                    factor = _constraint_expand(factor, c)
-                return factor.project(clique)
-    return None
+  """Re-expand a belief by re-introducing sliced constraint variables."""
+  cl_set = set(clique)
+  for belief_cl in result_cv.cliques:
+    missing = cl_set - set(belief_cl)
+    if not missing or not set(belief_cl) & cl_set:
+      continue
+    expansions = []
+    for var in missing:
+      c = next(
+          (
+              c
+              for c in constraints
+              if c.domain.attributes[1] == var
+              and c.domain.attributes[0] in belief_cl
+          ),
+          None,
+      )
+      if c is None:
+        break
+      expansions.append(c)
+    else:
+      if cl_set - missing <= set(belief_cl):
+        factor = result_cv[belief_cl]
+        for c in expansions:
+          factor = _constraint_expand(factor, c)
+        return factor.project(clique)
+  return None
 
 
 def _fold_non_deterministic(potentials, constraints):
-    """Fold non-deterministic constraints as materialized potentials."""
-    non_det = [c for c in constraints if not c.is_deterministic]
-    if not non_det:
-        return potentials
-    domain = potentials.domain
-    cliques = list(potentials.cliques)
-    arrays = {cl: potentials[cl] for cl in cliques}
-    for c in non_det:
-        cl = domain.canonical(c.clique)
-        factor = c.potential
-        if cl in arrays:
-            arrays[cl] = arrays[cl] + factor
-        else:
-            cliques.append(cl)
-            arrays[cl] = factor
-    return CliqueVector(domain, cliques, arrays)
+  """Fold non-deterministic constraints as materialized potentials."""
+  non_det = [c for c in constraints if not c.is_deterministic]
+  if not non_det:
+    return potentials
+  domain = potentials.domain
+  cliques = list(potentials.cliques)
+  arrays = {cl: potentials[cl] for cl in cliques}
+  for c in non_det:
+    cl = domain.canonical(c.clique)
+    factor = c.potential
+    if cl in arrays:
+      arrays[cl] = arrays[cl] + factor
+    else:
+      cliques.append(cl)
+      arrays[cl] = factor
+  return CliqueVector(domain, cliques, arrays)
 
 
 @jax.jit(static_argnames=['jtree'])
@@ -341,157 +336,151 @@ def shafer_shenoy(
     jtree: nx.Graph | None = None,
     constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
-    """Compute marginals using Shafer-Shenoy with constraint-aware shortcuts.
+  """Compute marginals using Shafer-Shenoy with constraint-aware shortcuts.
 
-    Deterministic (mapping) constraints are routed through efficient O(|fine|)
-    coarsen/refine operations. General (valid/invalid) constraints are folded
-    into potentials as materialized ``-inf``/``0`` factors.
+  Deterministic (mapping) constraints are routed through efficient O(|fine|)
+  coarsen/refine operations. General (valid/invalid) constraints are folded
+  into potentials as materialized ``-inf``/``0`` factors.
 
-    Args:
-        potentials: The (log-space) potentials of a graphical model.
-        total: The normalization factor.
-        jtree: An optional junction tree that defines the message passing
-            order.
-        constraints: Structural constraints to handle.
+  Args:
+      potentials: The (log-space) potentials of a graphical model.
+      total: The normalization factor.
+      jtree: An optional junction tree that defines the message passing
+          order.
+      constraints: Structural constraints to handle.
 
-    Returns:
-        The marginals of the graphical model.
-    """
-    if len(potentials.cliques) == 0:
-        return CliqueVector(potentials.domain, [], {})
+  Returns:
+      The marginals of the graphical model.
+  """
+  if len(potentials.cliques) == 0:
+    return CliqueVector(potentials.domain, [], {})
 
-    # Fold non-deterministic constraints as materialized potentials.
-    potentials = _fold_non_deterministic(potentials, constraints)
-    det_constraints = tuple(c for c in constraints if c.is_deterministic)
+  # Fold non-deterministic constraints as materialized potentials.
+  potentials = _fold_non_deterministic(potentials, constraints)
+  det_constraints = tuple(c for c in constraints if c.is_deterministic)
 
-    domain, cliques = potentials.domain, potentials.cliques
+  domain, cliques = potentials.domain, potentials.cliques
 
-    # Build the junction tree, including constraint edges.
-    extra = [
-        domain.canonical(c.clique)
-        for c in det_constraints
-        if domain.canonical(c.clique) not in cliques
-    ]
-    if jtree is None:
-        jtree = junction_tree.make_junction_tree(
-            domain, cliques + tuple(extra)
-        )[0]
-    message_order = junction_tree.message_passing_order(jtree)
-    max_cliques = junction_tree.maximal_cliques(jtree)
-    pure_constraint, embedded = _classify_cliques(max_cliques, det_constraints)
-    neighbors = {cl: list(jtree.neighbors(cl)) for cl in max_cliques}
+  # Build the junction tree, including constraint edges.
+  extra = [
+      domain.canonical(c.clique)
+      for c in det_constraints
+      if domain.canonical(c.clique) not in cliques
+  ]
+  if jtree is None:
+    jtree = junction_tree.make_junction_tree(domain, cliques + tuple(extra))[0]
+  message_order = junction_tree.message_passing_order(jtree)
+  max_cliques = junction_tree.maximal_cliques(jtree)
+  pure_constraint, embedded = _classify_cliques(max_cliques, det_constraints)
+  neighbors = {cl: list(jtree.neighbors(cl)) for cl in max_cliques}
 
-    # Partition user potentials by pure-constraint membership.
-    constraint_init = {}
-    non_constraint_cliques = []
-    for cl in cliques:
-        con_mc = next(
-            (mc for mc in pure_constraint if set(cl) <= set(mc)), None
-        )
-        if con_mc:
-            constraint_init.setdefault(con_mc, []).append(potentials[cl])
-        else:
-            non_constraint_cliques.append(cl)
-
-    # Initialize beliefs for non-pure-constraint maximal cliques.
-    non_pure = [mc for mc in max_cliques if mc not in pure_constraint]
-    if non_constraint_cliques:
-        nc = CliqueVector(
-            domain,
-            non_constraint_cliques,
-            {cl: potentials[cl] for cl in non_constraint_cliques},
-        )
-        beliefs0 = nc.expand(non_pure)
+  # Partition user potentials by pure-constraint membership.
+  constraint_init = {}
+  non_constraint_cliques = []
+  for cl in cliques:
+    con_mc = next((mc for mc in pure_constraint if set(cl) <= set(mc)), None)
+    if con_mc:
+      constraint_init.setdefault(con_mc, []).append(potentials[cl])
     else:
-        beliefs0 = CliqueVector(
+      non_constraint_cliques.append(cl)
+
+  # Initialize beliefs for non-pure-constraint maximal cliques.
+  non_pure = [mc for mc in max_cliques if mc not in pure_constraint]
+  if non_constraint_cliques:
+    nc = CliqueVector(
+        domain,
+        non_constraint_cliques,
+        {cl: potentials[cl] for cl in non_constraint_cliques},
+    )
+    beliefs0 = nc.expand(non_pure)
+  else:
+    beliefs0 = CliqueVector(
+        domain,
+        non_pure,
+        {mc: Factor.zeros(domain.project(mc)) for mc in non_pure},
+    )
+
+  # Forward-backward message passing.
+  messages = {}
+  for i, j in message_order:
+    sep_vars = set(i) & set(j)
+
+    if i in pure_constraint:
+      c = pure_constraint[i]
+      inputs = [
+          messages[(k, i)]
+          for k in neighbors[i]
+          if k != j and (k, i) in messages
+      ]
+      inputs.extend(constraint_init.get(i, []))
+      fine, coarse = c.domain.attributes
+      msg = _constraint_message(c, inputs, fine in sep_vars)
+      if msg is None:
+        sizes = dict(zip(c.domain.attributes, c.domain.shape))
+        sep = tuple(sep_vars)
+        msg = Factor.zeros(Domain(list(sep), [sizes[s] for s in sep]))
+      messages[(i, j)] = msg
+    else:
+      tau = beliefs0[i]
+      for k in neighbors[i]:
+        if k != j and (k, i) in messages:
+          tau = tau + messages[(k, i)]
+      if i in embedded:
+        messages[(i, j)] = _embedded_message(tau, sep_vars, embedded[i])
+      else:
+        messages[(i, j)] = tau.logsumexp(tau.domain.invert(tuple(sep_vars)))
+
+  # Collect final beliefs, applying constraint slicing.
+  belief_map = {}
+  belief_cliques = []
+  for cl in max_cliques:
+    if cl in pure_constraint:
+      continue
+    b = beliefs0[cl]
+    for k in neighbors[cl]:
+      if (k, cl) in messages:
+        b = b + messages[(k, cl)]
+    if cl in embedded:
+      for c in embedded[cl]:
+        b = _constraint_slice(b, c)
+    key = tuple(b.domain.attributes)
+    belief_map[key] = b
+    belief_cliques.append(key)
+
+  result_cv = CliqueVector(domain, belief_cliques, belief_map)
+  result_cv = result_cv.normalize(total, log=True).exp()
+
+  # Project back to user cliques.
+  result = {}
+  for cl in cliques:
+    if result_cv.supports(cl):
+      result[cl] = result_cv.project(cl)
+    elif any(set(cl) <= set(mc) for mc in pure_constraint):
+      result[cl] = _derive_pure_marginal(
+          cl,
+          pure_constraint,
+          constraint_init,
+          neighbors,
+          messages,
+          total,
+          domain,
+      )
+    else:
+      expanded = _try_expand_belief(cl, result_cv, det_constraints)
+      if expanded is not None:
+        result[cl] = expanded
+      else:
+        result[cl] = _derive_pure_marginal(
+            cl,
+            pure_constraint,
+            constraint_init,
+            neighbors,
+            messages,
+            total,
             domain,
-            non_pure,
-            {mc: Factor.zeros(domain.project(mc)) for mc in non_pure},
         )
 
-    # Forward-backward message passing.
-    messages = {}
-    for i, j in message_order:
-        sep_vars = set(i) & set(j)
-
-        if i in pure_constraint:
-            c = pure_constraint[i]
-            inputs = [
-                messages[(k, i)]
-                for k in neighbors[i]
-                if k != j and (k, i) in messages
-            ]
-            inputs.extend(constraint_init.get(i, []))
-            fine, coarse = c.domain.attributes
-            msg = _constraint_message(c, inputs, fine in sep_vars)
-            if msg is None:
-                sizes = dict(zip(c.domain.attributes, c.domain.shape))
-                sep = tuple(sep_vars)
-                msg = Factor.zeros(Domain(list(sep), [sizes[s] for s in sep]))
-            messages[(i, j)] = msg
-        else:
-            tau = beliefs0[i]
-            for k in neighbors[i]:
-                if k != j and (k, i) in messages:
-                    tau = tau + messages[(k, i)]
-            if i in embedded:
-                messages[(i, j)] = _embedded_message(tau, sep_vars, embedded[i])
-            else:
-                messages[(i, j)] = tau.logsumexp(
-                    tau.domain.invert(tuple(sep_vars))
-                )
-
-    # Collect final beliefs, applying constraint slicing.
-    belief_map = {}
-    belief_cliques = []
-    for cl in max_cliques:
-        if cl in pure_constraint:
-            continue
-        b = beliefs0[cl]
-        for k in neighbors[cl]:
-            if (k, cl) in messages:
-                b = b + messages[(k, cl)]
-        if cl in embedded:
-            for c in embedded[cl]:
-                b = _constraint_slice(b, c)
-        key = tuple(b.domain.attributes)
-        belief_map[key] = b
-        belief_cliques.append(key)
-
-    result_cv = CliqueVector(domain, belief_cliques, belief_map)
-    result_cv = result_cv.normalize(total, log=True).exp()
-
-    # Project back to user cliques.
-    result = {}
-    for cl in cliques:
-        if result_cv.supports(cl):
-            result[cl] = result_cv.project(cl)
-        elif any(set(cl) <= set(mc) for mc in pure_constraint):
-            result[cl] = _derive_pure_marginal(
-                cl,
-                pure_constraint,
-                constraint_init,
-                neighbors,
-                messages,
-                total,
-                domain,
-            )
-        else:
-            expanded = _try_expand_belief(cl, result_cv, det_constraints)
-            if expanded is not None:
-                result[cl] = expanded
-            else:
-                result[cl] = _derive_pure_marginal(
-                    cl,
-                    pure_constraint,
-                    constraint_init,
-                    neighbors,
-                    messages,
-                    total,
-                    domain,
-                )
-
-    return CliqueVector(domain, cliques, result)
+  return CliqueVector(domain, cliques, result)
 
 
 # ---------------------------------------------------------------------------
@@ -508,202 +497,190 @@ def implicit(
     constraints: Sequence[Constraint] = (),
     contraction: Callable = marginal_oracles.einsum_materialized,
 ) -> CliqueVector:
-    """Hybrid message passing: implicit for standard cliques, SS for constraints.
+  """Hybrid message passing: implicit for standard cliques, SS for constraints.
 
-    Uses the memory-efficient implicit contraction for cliques that do not
-    involve deterministic constraints, and falls back to Shafer-Shenoy style
-    constraint routing for pure and embedded constraint cliques. General
-    (valid/invalid) constraints are folded in as materialized potentials.
+  Uses the memory-efficient implicit contraction for cliques that do not
+  involve deterministic constraints, and falls back to Shafer-Shenoy style
+  constraint routing for pure and embedded constraint cliques. General
+  (valid/invalid) constraints are folded in as materialized potentials.
 
-    Args:
-        potentials: The (log-space) potentials of a graphical model.
-        total: The normalization factor.
-        jtree: An optional junction tree.
-        constraints: Structural constraints to handle.
-        contraction: Contraction function for log-space sum-product.
+  Args:
+      potentials: The (log-space) potentials of a graphical model.
+      total: The normalization factor.
+      jtree: An optional junction tree.
+      constraints: Structural constraints to handle.
+      contraction: Contraction function for log-space sum-product.
 
-    Returns:
-        The marginals of the graphical model.
-    """
+  Returns:
+      The marginals of the graphical model.
+  """
 
-    if len(potentials.cliques) == 0:
-        return CliqueVector(potentials.domain, [], {})
+  if len(potentials.cliques) == 0:
+    return CliqueVector(potentials.domain, [], {})
 
-    # Fold non-deterministic constraints as materialized potentials.
-    potentials = _fold_non_deterministic(potentials, constraints)
-    det_constraints = tuple(c for c in constraints if c.is_deterministic)
+  # Fold non-deterministic constraints as materialized potentials.
+  potentials = _fold_non_deterministic(potentials, constraints)
+  det_constraints = tuple(c for c in constraints if c.is_deterministic)
 
-    domain, cliques = potentials.domain, potentials.cliques
+  domain, cliques = potentials.domain, potentials.cliques
 
-    # Build junction tree with constraint edges.
-    extra = [
-        domain.canonical(c.clique)
-        for c in det_constraints
-        if domain.canonical(c.clique) not in cliques
-    ]
-    if jtree is None:
-        jtree = junction_tree.make_junction_tree(domain, list(cliques) + extra)[
-            0
-        ]
-    message_order = junction_tree.message_passing_order(jtree)
-    max_cliques = junction_tree.maximal_cliques(jtree)
-    pure_constraint, embedded = _classify_cliques(max_cliques, det_constraints)
-    neighbors = {cl: list(jtree.neighbors(cl)) for cl in max_cliques}
+  # Build junction tree with constraint edges.
+  extra = [
+      domain.canonical(c.clique)
+      for c in det_constraints
+      if domain.canonical(c.clique) not in cliques
+  ]
+  if jtree is None:
+    jtree = junction_tree.make_junction_tree(domain, list(cliques) + extra)[0]
+  message_order = junction_tree.message_passing_order(jtree)
+  max_cliques = junction_tree.maximal_cliques(jtree)
+  pure_constraint, embedded = _classify_cliques(max_cliques, det_constraints)
+  neighbors = {cl: list(jtree.neighbors(cl)) for cl in max_cliques}
 
-    # Map user cliques → maximal cliques.
-    mapping = clique_mapping(max_cliques, cliques, domain=domain)
-    inverse_mapping = collections.defaultdict(list)
-    potential_mapping = collections.defaultdict(list)
+  # Map user cliques → maximal cliques.
+  mapping = clique_mapping(max_cliques, cliques, domain=domain)
+  inverse_mapping = collections.defaultdict(list)
+  potential_mapping = collections.defaultdict(list)
 
-    for cl in cliques:
-        mc = mapping[cl]
-        potential_mapping[mc].append(potentials[cl])
-        inverse_mapping[mc].append(cl)
+  for cl in cliques:
+    mc = mapping[cl]
+    potential_mapping[mc].append(potentials[cl])
+    inverse_mapping[mc].append(cl)
 
-    # Separate potentials absorbed by pure constraint cliques.
-    constraint_init = {}
-    for mc in pure_constraint:
-        constraint_init[mc] = potential_mapping.pop(mc, [])
+  # Separate potentials absorbed by pure constraint cliques.
+  constraint_init = {}
+  for mc in pure_constraint:
+    constraint_init[mc] = potential_mapping.pop(mc, [])
 
-    non_pure = [mc for mc in max_cliques if mc not in pure_constraint]
+  non_pure = [mc for mc in max_cliques if mc not in pure_constraint]
 
-    # Pre-build incoming message graph for implicit contraction.
-    incoming_messages = collections.defaultdict(list)
-    for i, msg in enumerate(message_order):
-        for j in range(i):
-            msg2 = message_order[j]
-            if msg[0] == msg2[1] and msg[1] != msg2[0]:
-                incoming_messages[msg].append(msg2)
+  # Pre-build incoming message graph for implicit contraction.
+  incoming_messages = collections.defaultdict(list)
+  for i, msg in enumerate(message_order):
+    for j in range(i):
+      msg2 = message_order[j]
+      if msg[0] == msg2[1] and msg[1] != msg2[0]:
+        incoming_messages[msg].append(msg2)
 
-    # ---- Forward-backward message passing ----
-    messages = {}
-    for i, j in message_order:
-        sep_vars = set(i) & set(j)
+  # ---- Forward-backward message passing ----
+  messages = {}
+  for i, j in message_order:
+    sep_vars = set(i) & set(j)
 
-        if i in pure_constraint:
-            # Constraint routing — O(|fine|).
-            c = pure_constraint[i]
-            inputs = [
-                messages[(k, i)]
-                for k in neighbors[i]
-                if k != j and (k, i) in messages
-            ]
-            inputs.extend(constraint_init.get(i, []))
-            fine, coarse = c.domain.attributes
-            msg = _constraint_message(c, inputs, fine in sep_vars)
-            if msg is None:
-                sizes = dict(zip(c.domain.attributes, c.domain.shape))
-                sep = tuple(sep_vars)
-                msg = Factor.zeros(Domain(list(sep), [sizes[s] for s in sep]))
-            messages[(i, j)] = msg
+    if i in pure_constraint:
+      # Constraint routing — O(|fine|).
+      c = pure_constraint[i]
+      inputs = [
+          messages[(k, i)]
+          for k in neighbors[i]
+          if k != j and (k, i) in messages
+      ]
+      inputs.extend(constraint_init.get(i, []))
+      fine, coarse = c.domain.attributes
+      msg = _constraint_message(c, inputs, fine in sep_vars)
+      if msg is None:
+        sizes = dict(zip(c.domain.attributes, c.domain.shape))
+        sep = tuple(sep_vars)
+        msg = Factor.zeros(Domain(list(sep), [sizes[s] for s in sep]))
+      messages[(i, j)] = msg
 
-        elif i in embedded:
-            # Normalize-to-fine + contraction (no super-clique expansion).
-            shared = domain.project(tuple(sep_vars))
-            input_potentials = potential_mapping.get(i, [])
-            input_messages = [
-                messages[key] for key in incoming_messages[(i, j)]
-            ]
-            inputs = input_potentials + input_messages
+    elif i in embedded:
+      # Normalize-to-fine + contraction (no super-clique expansion).
+      shared = domain.project(tuple(sep_vars))
+      input_potentials = potential_mapping.get(i, [])
+      input_messages = [messages[key] for key in incoming_messages[(i, j)]]
+      inputs = input_potentials + input_messages
 
-            for c in embedded[i]:
-                inputs = _normalize_to_fine(inputs, c)
+      for c in embedded[i]:
+        inputs = _normalize_to_fine(inputs, c)
 
-            target = shared
-            post_ops = []
-            for c in embedded[i]:
-                target, post_op = _target_for_constraint(target, c)
-                post_ops.append((c, post_op))
+      target = shared
+      post_ops = []
+      for c in embedded[i]:
+        target, post_op = _target_for_constraint(target, c)
+        post_ops.append((c, post_op))
 
-            for attr in target.attributes:
-                if not any(attr in inp.domain.attributes for inp in inputs):
-                    inputs.append(Factor.zeros(domain.project([attr])))
+      for attr in target.attributes:
+        if not any(attr in inp.domain.attributes for inp in inputs):
+          inputs.append(Factor.zeros(domain.project([attr])))
 
-            msg = contraction(inputs, target)
-            for c, post_op in post_ops:
-                msg = _postprocess_log(msg, c, post_op, shared)
-            messages[(i, j)] = msg
+      msg = contraction(inputs, target)
+      for c, post_op in post_ops:
+        msg = _postprocess_log(msg, c, post_op, shared)
+      messages[(i, j)] = msg
 
-        else:
-            # Implicit contraction — no super-clique expansion.
-            shared = domain.project(tuple(sep_vars))
-            input_potentials = potential_mapping.get(i, [])
-            input_messages = [
-                messages[key] for key in incoming_messages[(i, j)]
-            ]
-            inputs = input_potentials + input_messages
-            for attr in shared.attributes:
-                if not any(attr in inp.domain.attributes for inp in inputs):
-                    inputs.append(Factor.zeros(domain.project([attr])))
-            messages[(i, j)] = contraction(inputs, shared)
+    else:
+      # Implicit contraction — no super-clique expansion.
+      shared = domain.project(tuple(sep_vars))
+      input_potentials = potential_mapping.get(i, [])
+      input_messages = [messages[key] for key in incoming_messages[(i, j)]]
+      inputs = input_potentials + input_messages
+      for attr in shared.attributes:
+        if not any(attr in inp.domain.attributes for inp in inputs):
+          inputs.append(Factor.zeros(domain.project([attr])))
+      messages[(i, j)] = contraction(inputs, shared)
 
-    # ---- Compute beliefs ----
-    result = {}
-    for mc in non_pure:
-        if mc in pure_constraint:
-            continue
+  # ---- Compute beliefs ----
+  result = {}
+  for mc in non_pure:
+    if mc in pure_constraint:
+      continue
 
-        input_potentials = potential_mapping.get(mc, [])
-        input_messages = [val for key, val in messages.items() if key[1] == mc]
-        inputs = input_potentials + input_messages
+    input_potentials = potential_mapping.get(mc, [])
+    input_messages = [val for key, val in messages.items() if key[1] == mc]
+    inputs = input_potentials + input_messages
 
-        if mc in embedded:
-            # Normalize to fine, contract, then post-process.
-            for c in embedded[mc]:
-                inputs = _normalize_to_fine(inputs, c)
+    if mc in embedded:
+      # Normalize to fine, contract, then post-process.
+      for c in embedded[mc]:
+        inputs = _normalize_to_fine(inputs, c)
 
-        for cl in inverse_mapping.get(mc, []):
-            target = domain.project(cl)
+    for cl in inverse_mapping.get(mc, []):
+      target = domain.project(cl)
 
-            if mc in embedded:
-                adj_target = target
-                post_ops = []
-                for c in embedded[mc]:
-                    adj_target, post_op = _target_for_constraint(adj_target, c)
-                    post_ops.append((c, post_op))
+      if mc in embedded:
+        adj_target = target
+        post_ops = []
+        for c in embedded[mc]:
+          adj_target, post_op = _target_for_constraint(adj_target, c)
+          post_ops.append((c, post_op))
 
-                adj_inputs = list(inputs)
-                for attr in adj_target.attributes:
-                    if not any(
-                        attr in inp.domain.attributes for inp in adj_inputs
-                    ):
-                        adj_inputs.append(Factor.zeros(domain.project([attr])))
+        adj_inputs = list(inputs)
+        for attr in adj_target.attributes:
+          if not any(attr in inp.domain.attributes for inp in adj_inputs):
+            adj_inputs.append(Factor.zeros(domain.project([attr])))
 
-                belief = contraction(adj_inputs, adj_target)
-                # Normalize/exp to probability space, then post-process.
-                belief = belief.normalize(total, log=True).exp()
-                for c, post_op in post_ops:
-                    belief = _postprocess_prob(belief, c, post_op, target)
-                result[cl] = belief
-            else:
-                adj_inputs = list(inputs)
-                for attr in target.attributes:
-                    if not any(
-                        attr in inp.domain.attributes for inp in adj_inputs
-                    ):
-                        adj_inputs.append(Factor.zeros(domain.project([attr])))
-                belief = contraction(adj_inputs, target)
-                result[cl] = belief.normalize(total, log=True).exp()
+        belief = contraction(adj_inputs, adj_target)
+        # Normalize/exp to probability space, then post-process.
+        belief = belief.normalize(total, log=True).exp()
+        for c, post_op in post_ops:
+          belief = _postprocess_prob(belief, c, post_op, target)
+        result[cl] = belief
+      else:
+        adj_inputs = list(inputs)
+        for attr in target.attributes:
+          if not any(attr in inp.domain.attributes for inp in adj_inputs):
+            adj_inputs.append(Factor.zeros(domain.project([attr])))
+        belief = contraction(adj_inputs, target)
+        result[cl] = belief.normalize(total, log=True).exp()
 
-    # Pure constraint cliques: derive marginals.
-    for cl in cliques:
-        if cl in result:
-            continue
-        con_mc = next(
-            (mc for mc in pure_constraint if set(cl) <= set(mc)), None
-        )
-        if con_mc is not None:
-            result[cl] = _derive_pure_marginal(
-                cl,
-                pure_constraint,
-                constraint_init,
-                neighbors,
-                messages,
-                total,
-                domain,
-            )
+  # Pure constraint cliques: derive marginals.
+  for cl in cliques:
+    if cl in result:
+      continue
+    con_mc = next((mc for mc in pure_constraint if set(cl) <= set(mc)), None)
+    if con_mc is not None:
+      result[cl] = _derive_pure_marginal(
+          cl,
+          pure_constraint,
+          constraint_init,
+          neighbors,
+          messages,
+          total,
+          domain,
+      )
 
-    return CliqueVector(potentials.domain, cliques, result)
+  return CliqueVector(potentials.domain, cliques, result)
 
 
 # ---------------------------------------------------------------------------
@@ -712,70 +689,70 @@ def implicit(
 
 
 def _normalize_to_fine(inputs, constraint):
-    """Normalize all inputs to fine-variable space."""
-    fine, coarse = constraint.domain.attributes
-    cleaned = []
-    for f in inputs:
-        has_fine = fine in f.domain
-        has_coarse = coarse in f.domain
-        if has_fine and has_coarse:
-            cleaned.append(_constraint_slice(f, constraint))
-        elif has_coarse and not has_fine:
-            cleaned.append(refine(f, constraint))
-        else:
-            cleaned.append(f)
-    return cleaned
+  """Normalize all inputs to fine-variable space."""
+  fine, coarse = constraint.domain.attributes
+  cleaned = []
+  for f in inputs:
+    has_fine = fine in f.domain
+    has_coarse = coarse in f.domain
+    if has_fine and has_coarse:
+      cleaned.append(_constraint_slice(f, constraint))
+    elif has_coarse and not has_fine:
+      cleaned.append(refine(f, constraint))
+    else:
+      cleaned.append(f)
+  return cleaned
 
 
 def _target_for_constraint(target_domain, constraint):
-    """Adjust target domain and return (domain, post_op) for post-processing."""
-    fine, coarse = constraint.domain.attributes
-    n_fine = constraint.domain.shape[0]
-    has_fine = fine in target_domain
-    has_coarse = coarse in target_domain
+  """Adjust target domain and return (domain, post_op) for post-processing."""
+  fine, coarse = constraint.domain.attributes
+  n_fine = constraint.domain.shape[0]
+  has_fine = fine in target_domain
+  has_coarse = coarse in target_domain
 
-    if not has_fine and not has_coarse:
-        return target_domain, 'none'
-    if has_fine and not has_coarse:
-        return target_domain, 'fine_only'
-    if has_coarse and not has_fine:
-        attrs = list(target_domain.attributes)
-        shape = list(target_domain.shape)
-        idx = attrs.index(coarse)
-        attrs[idx] = fine
-        shape[idx] = n_fine
-        return Domain(attrs, shape), 'coarsen'
-    # Both — drop coarse from target, will expand later.
-    attrs = [a for a in target_domain.attributes if a != coarse]
-    shape = [
-        s
-        for a, s in zip(target_domain.attributes, target_domain.shape)
-        if a != coarse
-    ]
-    return Domain(attrs, shape), 'expand'
+  if not has_fine and not has_coarse:
+    return target_domain, 'none'
+  if has_fine and not has_coarse:
+    return target_domain, 'fine_only'
+  if has_coarse and not has_fine:
+    attrs = list(target_domain.attributes)
+    shape = list(target_domain.shape)
+    idx = attrs.index(coarse)
+    attrs[idx] = fine
+    shape[idx] = n_fine
+    return Domain(attrs, shape), 'coarsen'
+  # Both — drop coarse from target, will expand later.
+  attrs = [a for a in target_domain.attributes if a != coarse]
+  shape = [
+      s
+      for a, s in zip(target_domain.attributes, target_domain.shape)
+      if a != coarse
+  ]
+  return Domain(attrs, shape), 'expand'
 
 
 def _postprocess_prob(result, constraint, post_op, original_target):
-    """Post-process a probability-space result."""
-    if post_op in {'none', 'fine_only'}:
-        return result
-    if post_op == 'coarsen':
-        return project_to_coarse(result, constraint)
-    if post_op == 'expand':
-        expanded = _constraint_expand(result, constraint)
-        return expanded.project(tuple(original_target.attributes))
-    raise ValueError(f'Unknown post_op: {post_op}')
+  """Post-process a probability-space result."""
+  if post_op in {'none', 'fine_only'}:
+    return result
+  if post_op == 'coarsen':
+    return project_to_coarse(result, constraint)
+  if post_op == 'expand':
+    expanded = _constraint_expand(result, constraint)
+    return expanded.project(tuple(original_target.attributes))
+  raise ValueError(f'Unknown post_op: {post_op}')
 
 
 def _postprocess_log(result, constraint, post_op, original_target):
-    """Post-process a log-space result (for messages)."""
-    if post_op in {'none', 'fine_only'}:
-        return result
-    if post_op == 'coarsen':
-        return coarsen(result, constraint)
-    if post_op == 'expand':
-        return result
-    raise ValueError(f'Unknown post_op: {post_op}')
+  """Post-process a log-space result (for messages)."""
+  if post_op in {'none', 'fine_only'}:
+    return result
+  if post_op == 'coarsen':
+    return coarsen(result, constraint)
+  if post_op == 'expand':
+    return result
+  raise ValueError(f'Unknown post_op: {post_op}')
 
 
 def default_oracle(
@@ -783,33 +760,33 @@ def default_oracle(
     domain: Domain | None = None,
     backend: str | None = None,
 ) -> marginal_oracles.MarginalOracle:
-    """Select the best constraint-aware oracle for the given setting.
+  """Select the best constraint-aware oracle for the given setting.
 
-    When constraints are present, this oracle uses the extensions
-    implementations which route messages through deterministic constraints
-    efficiently.  When no constraints are passed at call time, behavior is
-    identical to the core ``marginal_oracles.default_oracle``.
+  When constraints are present, this oracle uses the extensions
+  implementations which route messages through deterministic constraints
+  efficiently.  When no constraints are passed at call time, behavior is
+  identical to the core ``marginal_oracles.default_oracle``.
 
-    The selection heuristic mirrors the core oracle:
+  The selection heuristic mirrors the core oracle:
 
-    - **CPU**: ``shafer_shenoy`` (XLA compiler less effective on CPU).
-    - **GPU/TPU, large cliques (>= 1M)**: ``implicit``.
-    - **GPU/TPU, small cliques**: ``shafer_shenoy``.
-    """
-    if backend is None:
-        backend = jax.default_backend()
+  - **CPU**: ``shafer_shenoy`` (XLA compiler less effective on CPU).
+  - **GPU/TPU, large cliques (>= 1M)**: ``implicit``.
+  - **GPU/TPU, small cliques**: ``shafer_shenoy``.
+  """
+  if backend is None:
+    backend = jax.default_backend()
 
-    # CPU: always SS (XLA compiler less effective on CPU).
-    if backend == 'cpu':
-        return shafer_shenoy
-
-    # GPU/TPU with large cliques: implicit.
-    if cliques is not None and domain is not None:
-        jtree = junction_tree.make_junction_tree(domain, cliques)[0]
-        max_cliques = junction_tree.maximal_cliques(jtree)
-        max_size = max(domain.project(cl).size() for cl in max_cliques)
-        if max_size >= 1_000_000:
-            return implicit
-
-    # GPU/TPU with small cliques.
+  # CPU: always SS (XLA compiler less effective on CPU).
+  if backend == 'cpu':
     return shafer_shenoy
+
+  # GPU/TPU with large cliques: implicit.
+  if cliques is not None and domain is not None:
+    jtree = junction_tree.make_junction_tree(domain, cliques)[0]
+    max_cliques = junction_tree.maximal_cliques(jtree)
+    max_size = max(domain.project(cl).size() for cl in max_cliques)
+    if max_size >= 1_000_000:
+      return implicit
+
+  # GPU/TPU with small cliques.
+  return shafer_shenoy

--- a/src/mbi/extensions/mixture_of_products.py
+++ b/src/mbi/extensions/mixture_of_products.py
@@ -34,162 +34,155 @@ from ..factor import Factor
 @jax.tree_util.register_dataclass
 @dataclass
 class MixtureOfProducts:
-    """A discrete distribution as a mixture of product distributions."""
+  """A discrete distribution as a mixture of product distributions."""
 
-    _logits: dict[str, jax.Array]
-    domain: Domain = field(metadata={"static": True})
-    total: float = field(metadata={"static": True})
+  _logits: dict[str, jax.Array]
+  domain: Domain = field(metadata={"static": True})
+  total: float = field(metadata={"static": True})
 
-    @classmethod
-    def random(
-        cls,
-        domain: Domain,
-        total: float,
-        num_components: int = 100,
-        seed: int = 0,
-        scale: float = 0.25,
-    ) -> MixtureOfProducts:
-        """Initialize with random logits."""
-        key = jax.random.PRNGKey(seed)
-        logits = {}
-        for col in domain:
-            key, subkey = jax.random.split(key)
-            logits[col] = (
-                jax.random.normal(subkey, (num_components, domain[col])) * scale
-            )
-        return cls(logits, domain, total)
+  @classmethod
+  def random(
+      cls,
+      domain: Domain,
+      total: float,
+      num_components: int = 100,
+      seed: int = 0,
+      scale: float = 0.25,
+  ) -> MixtureOfProducts:
+    """Initialize with random logits."""
+    key = jax.random.PRNGKey(seed)
+    logits = {}
+    for col in domain:
+      key, subkey = jax.random.split(key)
+      logits[col] = (
+          jax.random.normal(subkey, (num_components, domain[col])) * scale
+      )
+    return cls(logits, domain, total)
 
-    @property
-    def num_components(self) -> int:
-        """Number of mixture components K."""
-        return next(iter(self._logits.values())).shape[0]
+  @property
+  def num_components(self) -> int:
+    """Number of mixture components K."""
+    return next(iter(self._logits.values())).shape[0]
 
-    @property
-    def products(self) -> dict[str, jax.Array]:
-        """Per-attribute categorical probabilities (softmax of logits)."""
-        return {
-            col: jax.nn.softmax(self._logits[col], axis=1)
-            for col in self._logits
-        }
+  @property
+  def products(self) -> dict[str, jax.Array]:
+    """Per-attribute categorical probabilities (softmax of logits)."""
+    return {
+        col: jax.nn.softmax(self._logits[col], axis=1) for col in self._logits
+    }
 
-    def project(self, attrs) -> Factor:
-        """Compute the marginal over ``attrs`` via einsum."""
-        if isinstance(attrs, str):
-            attrs = (attrs,)
-        attrs = tuple(attrs)
-        d = len(attrs)
-        letters = "bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"[:d]
-        formula = ",".join(f"a{l}" for l in letters) + "->" + "".join(letters)
-        products = self.products
-        components = [products[col] for col in attrs]
-        values = (
-            jnp.einsum(formula, *components) * self.total / self.num_components
-        )
-        return Factor(self.domain.project(attrs), values)
+  def project(self, attrs) -> Factor:
+    """Compute the marginal over ``attrs`` via einsum."""
+    if isinstance(attrs, str):
+      attrs = (attrs,)
+    attrs = tuple(attrs)
+    d = len(attrs)
+    letters = "bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"[:d]
+    formula = ",".join(f"a{l}" for l in letters) + "->" + "".join(letters)
+    products = self.products
+    components = [products[col] for col in attrs]
+    values = jnp.einsum(formula, *components) * self.total / self.num_components
+    return Factor(self.domain.project(attrs), values)
 
-    def supports(self, attrs) -> bool:
-        """Any subset of domain attributes is supported."""
-        if isinstance(attrs, str):
-            attrs = (attrs,)
-        return all(a in self.domain.attributes for a in attrs)
+  def supports(self, attrs) -> bool:
+    """Any subset of domain attributes is supported."""
+    if isinstance(attrs, str):
+      attrs = (attrs,)
+    return all(a in self.domain.attributes for a in attrs)
 
-    def synthetic_data(self, rows=None) -> Dataset:
-        """Generate synthetic data via randomized rounding."""
-        total = max(1, int(rows or self.total))
-        rng = np.random.default_rng()
-        products = self.products
-        subtotal = total // self.num_components + 1
+  def synthetic_data(self, rows=None) -> Dataset:
+    """Generate synthetic data via randomized rounding."""
+    total = max(1, int(rows or self.total))
+    rng = np.random.default_rng()
+    products = self.products
+    subtotal = total // self.num_components + 1
 
-        blocks = []
-        for k in range(self.num_components):
-            comp_data = {}
-            for col in self.domain.attributes:
-                counts = np.asarray(products[col][k])
-                counts = counts * subtotal / counts.sum()
-                frac, integ = np.modf(counts)
-                integ = integ.astype(int)
-                extra = subtotal - integ.sum()
-                if extra > 0:
-                    p = frac / frac.sum()
-                    idx = rng.choice(len(counts), extra, replace=False, p=p)
-                    integ[idx] += 1
-                vals = np.repeat(np.arange(len(counts)), integ)
-                rng.shuffle(vals)
-                comp_data[col] = vals
-            blocks.append(
-                np.stack(
-                    [comp_data[col] for col in self.domain.attributes], axis=1
-                )
-            )
+    blocks = []
+    for k in range(self.num_components):
+      comp_data = {}
+      for col in self.domain.attributes:
+        counts = np.asarray(products[col][k])
+        counts = counts * subtotal / counts.sum()
+        frac, integ = np.modf(counts)
+        integ = integ.astype(int)
+        extra = subtotal - integ.sum()
+        if extra > 0:
+          p = frac / frac.sum()
+          idx = rng.choice(len(counts), extra, replace=False, p=p)
+          integ[idx] += 1
+        vals = np.repeat(np.arange(len(counts)), integ)
+        rng.shuffle(vals)
+        comp_data[col] = vals
+      blocks.append(
+          np.stack([comp_data[col] for col in self.domain.attributes], axis=1)
+      )
 
-        full_data = np.concatenate(blocks, axis=0)
-        rng.shuffle(full_data)
-        full_data = full_data[:total]
+    full_data = np.concatenate(blocks, axis=0)
+    rng.shuffle(full_data)
+    full_data = full_data[:total]
 
-        data = {
-            col: full_data[:, i] for i, col in enumerate(self.domain.attributes)
-        }
-        return Dataset(data, self.domain)
+    data = {
+        col: full_data[:, i] for i, col in enumerate(self.domain.attributes)
+    }
+    return Dataset(data, self.domain)
 
 
 class MixtureOfProductsState(NamedTuple):
-    """Optimization state for MixtureOfProductsEstimator."""
+  """Optimization state for MixtureOfProductsEstimator."""
 
-    model: MixtureOfProducts
-    opt_state: optax.OptState
+  model: MixtureOfProducts
+  opt_state: optax.OptState
 
 
 @dataclasses.dataclass(frozen=True)
 class MixtureOfProductsEstimator(Estimator):
-    """Estimates a distribution as a mixture of product distributions.
+  """Estimates a distribution as a mixture of product distributions.
 
-    Inspired by RAP (https://arxiv.org/abs/2103.06641) and RAP^{softmax}
-    (https://arxiv.org/abs/2106.07153).  Instead of parameterizing via a
-    graphical model with potentials, the distribution is represented as a
-    mixture of K product distributions optimized via gradient descent.
+  Inspired by RAP (https://arxiv.org/abs/2103.06641) and RAP^{softmax}
+  (https://arxiv.org/abs/2106.07153).  Instead of parameterizing via a
+  graphical model with potentials, the distribution is represented as a
+  mixture of K product distributions optimized via gradient descent.
 
-    Attributes:
-        num_components: Number of mixture components K.
-        learning_rate: Learning rate for the optimizer.
-        optimizer: An optax optimizer.  Defaults to ``optax.adam``.
-        seed: Random seed for parameter initialization.
-    """
+  Attributes:
+      num_components: Number of mixture components K.
+      learning_rate: Learning rate for the optimizer.
+      optimizer: An optax optimizer.  Defaults to ``optax.adam``.
+      seed: Random seed for parameter initialization.
+  """
 
-    num_components: int = 100
-    learning_rate: float = 0.1
-    optimizer: optax.GradientTransformation | None = None
-    seed: int = 0
+  num_components: int = 100
+  learning_rate: float = 0.1
+  optimizer: optax.GradientTransformation | None = None
+  seed: int = 0
 
-    def __post_init__(self):
-        if self.optimizer is None:
-            object.__setattr__(
-                self, "optimizer", optax.adam(self.learning_rate)
-            )
+  def __post_init__(self):
+    if self.optimizer is None:
+      object.__setattr__(self, "optimizer", optax.adam(self.learning_rate))
 
-    def _init(self, domain, loss_fn, known_total, *, warm_start=None, **kwargs):
-        """Initialize model and optimizer state."""
-        model = MixtureOfProducts.random(
-            domain, known_total, self.num_components, self.seed
-        )
-        if warm_start is not None:
-            model = warm_start
-        opt_state = self.optimizer.init(model)
-        return MixtureOfProductsState(model, opt_state)
+  def _init(self, domain, loss_fn, known_total, *, warm_start=None, **kwargs):
+    """Initialize model and optimizer state."""
+    model = MixtureOfProducts.random(
+        domain, known_total, self.num_components, self.seed
+    )
+    if warm_start is not None:
+      model = warm_start
+    opt_state = self.optimizer.init(model)
+    return MixtureOfProductsState(model, opt_state)
 
-    def _step(self, state, loss_fn, known_total, constraints=()):
-        """Run one gradient step."""
+  def _step(self, state, loss_fn, known_total, constraints=()):
+    """Run one gradient step."""
 
-        def model_loss(m):
-            arrays = {cl: m.project(cl) for cl in loss_fn.cliques}
-            mu = CliqueVector(m.domain, loss_fn.cliques, arrays)
-            return loss_fn(mu)
+    def model_loss(m):
+      arrays = {cl: m.project(cl) for cl in loss_fn.cliques}
+      mu = CliqueVector(m.domain, loss_fn.cliques, arrays)
+      return loss_fn(mu)
 
-        _, grad = jax.value_and_grad(model_loss)(state.model)
-        updates, opt_state = self.optimizer.update(
-            grad, state.opt_state, state.model
-        )
-        model = optax.apply_updates(state.model, updates)
-        return MixtureOfProductsState(model, opt_state)
+    _, grad = jax.value_and_grad(model_loss)(state.model)
+    updates, opt_state = self.optimizer.update(
+        grad, state.opt_state, state.model
+    )
+    model = optax.apply_updates(state.model, updates)
+    return MixtureOfProductsState(model, opt_state)
 
-    def _finalize(self, state, known_total, constraints=()):
-        return state.model
+  def _finalize(self, state, known_total, constraints=()):
+    return state.model

--- a/src/mbi/extensions/precompute_marginals.py
+++ b/src/mbi/extensions/precompute_marginals.py
@@ -34,65 +34,65 @@ _COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
 
 def _next_pow2(x):
-    """Round up to the next power of 2."""
-    return 1 << (x - 1).bit_length()
+  """Round up to the next power of 2."""
+  return 1 << (x - 1).bit_length()
 
 
 @jax.jit(static_argnums=(2,))
 def _bincount_marginal(cols, weights, padded_shape):
-    """JIT-compiled k-way bincount."""
-    flat = cols[0].astype(jnp.uint32)
-    for col, stride in zip(cols[1:], padded_shape[1:]):
-        flat = flat * stride + col.astype(jnp.uint32)
-    length = math.prod(padded_shape)
-    counts = jnp.bincount(flat, weights=weights, length=length)
-    return counts.reshape(padded_shape).astype(jnp.float32)
+  """JIT-compiled k-way bincount."""
+  flat = cols[0].astype(jnp.uint32)
+  for col, stride in zip(cols[1:], padded_shape[1:]):
+    flat = flat * stride + col.astype(jnp.uint32)
+  length = math.prod(padded_shape)
+  counts = jnp.bincount(flat, weights=weights, length=length)
+  return counts.reshape(padded_shape).astype(jnp.float32)
 
 
 def _prepare_columns(dataset):
-    """Extract JAX column arrays and weights from a Dataset or JaxDataset."""
-    domain = dataset.domain
-    col_data = {
-        a: (
-            jnp.asarray(dataset.data[a]).astype(
-                np.min_scalar_type(_next_pow2(domain[a]) - 1)
-            )
-        )
-        for a in domain.attributes
-    }
-    weights = (
-        jnp.asarray(dataset.weights) if dataset.weights is not None else None
-    )
-    return col_data, weights
+  """Extract JAX column arrays and weights from a Dataset or JaxDataset."""
+  domain = dataset.domain
+  col_data = {
+      a: (
+          jnp.asarray(dataset.data[a]).astype(
+              np.min_scalar_type(_next_pow2(domain[a]) - 1)
+          )
+      )
+      for a in domain.attributes
+  }
+  weights = (
+      jnp.asarray(dataset.weights) if dataset.weights is not None else None
+  )
+  return col_data, weights
 
 
 def _group_cliques_by_shape(cliques, domain):
-    """Group cliques by their power-of-2 padded canonical shape.
+  """Group cliques by their power-of-2 padded canonical shape.
 
-    Returns ``(sorted_shapes, shape_groups, actual_sizes)`` where
-    ``sorted_shapes`` is ordered by descending group size and
-    ``shape_groups`` maps each padded shape to its list of work items.
-    """
-    actual_sizes = {a: domain[a] for a in domain.attributes}
-    padded_sizes = {a: _next_pow2(domain[a]) for a in domain.attributes}
+  Returns ``(sorted_shapes, shape_groups, actual_sizes)`` where
+  ``sorted_shapes`` is ordered by descending group size and
+  ``shape_groups`` maps each padded shape to its list of work items.
+  """
+  actual_sizes = {a: domain[a] for a in domain.attributes}
+  padded_sizes = {a: _next_pow2(domain[a]) for a in domain.attributes}
 
-    work_items = []
-    for cl in cliques:
-        sorted_attrs = sorted(cl, key=lambda a: padded_sizes[a])
-        padded_shape = tuple(padded_sizes[a] for a in sorted_attrs)
-        work_items.append((padded_shape, sorted_attrs, cl))
+  work_items = []
+  for cl in cliques:
+    sorted_attrs = sorted(cl, key=lambda a: padded_sizes[a])
+    padded_shape = tuple(padded_sizes[a] for a in sorted_attrs)
+    work_items.append((padded_shape, sorted_attrs, cl))
 
-    shape_groups: dict[tuple[int, ...], list] = {}
-    for item in work_items:
-        shape_groups.setdefault(item[0], []).append(item)
-    sorted_shapes = sorted(shape_groups, key=lambda s: -len(shape_groups[s]))
-    return sorted_shapes, shape_groups, actual_sizes
+  shape_groups: dict[tuple[int, ...], list] = {}
+  for item in work_items:
+    shape_groups.setdefault(item[0], []).append(item)
+  sorted_shapes = sorted(shape_groups, key=lambda s: -len(shape_groups[s]))
+  return sorted_shapes, shape_groups, actual_sizes
 
 
 def _col_struct(n_rows, padded_size):
-    """Build an abstract column struct for a given padded domain size."""
-    dtype = np.min_scalar_type(padded_size - 1)
-    return jax.ShapeDtypeStruct((n_rows,), dtype)
+  """Build an abstract column struct for a given padded domain size."""
+  dtype = np.min_scalar_type(padded_size - 1)
+  return jax.ShapeDtypeStruct((n_rows,), dtype)
 
 
 def _submit_all_compilations(
@@ -100,17 +100,17 @@ def _submit_all_compilations(
     n_rows,
     weights_struct,
 ):
-    """Submit compilation for every unique shape and return futures."""
-    futures: dict[tuple[int, ...], concurrent.futures.Future] = {}
-    for shape in sorted_shapes:
-        abstract_cols = tuple(_col_struct(n_rows, s) for s in shape)
-        futures[shape] = _COMPILE_POOL.submit(
-            lambda c, w, s: _bincount_marginal.lower(c, w, s).compile(),
-            abstract_cols,
-            weights_struct,
-            shape,
-        )
-    return futures
+  """Submit compilation for every unique shape and return futures."""
+  futures: dict[tuple[int, ...], concurrent.futures.Future] = {}
+  for shape in sorted_shapes:
+    abstract_cols = tuple(_col_struct(n_rows, s) for s in shape)
+    futures[shape] = _COMPILE_POOL.submit(
+        lambda c, w, s: _bincount_marginal.lower(c, w, s).compile(),
+        abstract_cols,
+        weights_struct,
+        shape,
+    )
+  return futures
 
 
 def precompute_marginals(
@@ -119,68 +119,66 @@ def precompute_marginals(
     *,
     transpose: bool = True,
 ) -> CliqueVector:
-    """Compute all marginals from a dataset using JIT-compiled bincount.
+  """Compute all marginals from a dataset using JIT-compiled bincount.
 
-    Compiles one ``jnp.bincount`` program per unique padded shape (after
-    power-of-2 bucketing and canonical reordering) and executes it for
-    every clique that maps to that shape.  All compilations are submitted
-    to a background thread upfront so they overlap with execution.
+  Compiles one ``jnp.bincount`` program per unique padded shape (after
+  power-of-2 bucketing and canonical reordering) and executes it for
+  every clique that maps to that shape.  All compilations are submitted
+  to a background thread upfront so they overlap with execution.
 
-    Accepts both ``Dataset`` (numpy-backed) and ``JaxDataset``
-    (JAX-backed).  Numpy arrays are converted to JAX arrays internally.
+  Accepts both ``Dataset`` (numpy-backed) and ``JaxDataset``
+  (JAX-backed).  Numpy arrays are converted to JAX arrays internally.
 
-    Args:
-      dataset: The dataset to compute marginals from.
-      cliques: Cliques (tuples of attribute names) to compute.
-      transpose: If ``True`` (default), transpose each marginal so its
-        axes match the original clique attribute order.  Set to ``False``
-        to skip the transpose and keep the canonical sorted order.
+  Args:
+    dataset: The dataset to compute marginals from.
+    cliques: Cliques (tuples of attribute names) to compute.
+    transpose: If ``True`` (default), transpose each marginal so its
+      axes match the original clique attribute order.  Set to ``False``
+      to skip the transpose and keep the canonical sorted order.
 
-    Returns:
-      A ``CliqueVector`` mapping each clique to its marginal ``Factor``.
-    """
-    domain = dataset.domain
-    col_data, weights = _prepare_columns(dataset)
-    sorted_shapes, shape_groups, actual_sizes = _group_cliques_by_shape(
-        cliques, domain
-    )
+  Returns:
+    A ``CliqueVector`` mapping each clique to its marginal ``Factor``.
+  """
+  domain = dataset.domain
+  col_data, weights = _prepare_columns(dataset)
+  sorted_shapes, shape_groups, actual_sizes = _group_cliques_by_shape(
+      cliques, domain
+  )
 
-    # Build abstract structs and submit all compilations upfront.
-    n_rows = next(iter(col_data.values())).shape[0]
-    weights_struct = (
-        jax.ShapeDtypeStruct(weights.shape, weights.dtype)
-        if weights is not None
-        else None
-    )
-    compile_futures = _submit_all_compilations(
-        sorted_shapes,
-        n_rows,
-        weights_struct,
-    )
+  # Build abstract structs and submit all compilations upfront.
+  n_rows = next(iter(col_data.values())).shape[0]
+  weights_struct = (
+      jax.ShapeDtypeStruct(weights.shape, weights.dtype)
+      if weights is not None
+      else None
+  )
+  compile_futures = _submit_all_compilations(
+      sorted_shapes,
+      n_rows,
+      weights_struct,
+  )
 
-    arrays: dict[Clique, Factor] = {}
+  arrays: dict[Clique, Factor] = {}
 
-    for shape in sorted_shapes:
-        compiled_fn = compile_futures[shape].result()
+  for shape in sorted_shapes:
+    compiled_fn = compile_futures[shape].result()
 
-        for _, sorted_attrs, cl in shape_groups[shape]:
-            cols = tuple(col_data[a] for a in sorted_attrs)
-            marginal = compiled_fn(cols, weights)
+    for _, sorted_attrs, cl in shape_groups[shape]:
+      cols = tuple(col_data[a] for a in sorted_attrs)
+      marginal = compiled_fn(cols, weights)
 
-            # Slice off power-of-2 padding.
-            actual_shape = tuple(actual_sizes[a] for a in sorted_attrs)
-            if actual_shape != shape:
-                slices = tuple(slice(0, s) for s in actual_shape)
-                marginal = marginal[slices]
+      # Slice off power-of-2 padding.
+      actual_shape = tuple(actual_sizes[a] for a in sorted_attrs)
+      if actual_shape != shape:
+        slices = tuple(slice(0, s) for s in actual_shape)
+        marginal = marginal[slices]
 
-            # Transpose back to the original attribute order if needed.
-            proj_domain = domain.project(cl)
-            if transpose and tuple(sorted_attrs) != proj_domain.attributes:
-                perm = tuple(
-                    sorted_attrs.index(a) for a in proj_domain.attributes
-                )
-                marginal = jnp.transpose(marginal, perm)
+      # Transpose back to the original attribute order if needed.
+      proj_domain = domain.project(cl)
+      if transpose and tuple(sorted_attrs) != proj_domain.attributes:
+        perm = tuple(sorted_attrs.index(a) for a in proj_domain.attributes)
+        marginal = jnp.transpose(marginal, perm)
 
-            arrays[cl] = Factor(proj_domain, marginal)
+      arrays[cl] = Factor(proj_domain, marginal)
 
-    return CliqueVector(domain, list(cliques), arrays)
+  return CliqueVector(domain, list(cliques), arrays)

--- a/src/mbi/extensions/reweighted_dataset.py
+++ b/src/mbi/extensions/reweighted_dataset.py
@@ -22,72 +22,70 @@ from ..dataset import Dataset, JaxDataset
 
 
 class ReweightedDatasetState(NamedTuple):
-    """Optimization state for ReweightedDatasetEstimator."""
+  """Optimization state for ReweightedDatasetEstimator."""
 
-    log_weights: jax.Array
-    opt_state: optax.OptState
+  log_weights: jax.Array
+  opt_state: optax.OptState
 
 
 @dataclasses.dataclass(frozen=True)
 class ReweightedDatasetEstimator(Estimator):
-    """Estimates a distribution by reweighting seed records.
+  """Estimates a distribution by reweighting seed records.
 
-    Inspired by PMW^Pub (https://arxiv.org/abs/2102.08598).  Given a seed
-    set of records, the distribution is represented by learning a weight for
-    each record to minimize the marginal loss.
+  Inspired by PMW^Pub (https://arxiv.org/abs/2102.08598).  Given a seed
+  set of records, the distribution is represented by learning a weight for
+  each record to minimize the marginal loss.
 
-    Attributes:
-        seed_data: A Dataset of seed records to reweight.
-        learning_rate: Learning rate for the optimizer.
-        optimizer: An optax optimizer.  Defaults to ``optax.adam``.
-    """
+  Attributes:
+      seed_data: A Dataset of seed records to reweight.
+      learning_rate: Learning rate for the optimizer.
+      optimizer: An optax optimizer.  Defaults to ``optax.adam``.
+  """
 
-    seed_data: Dataset
-    learning_rate: float = 0.1
-    optimizer: optax.GradientTransformation | None = None
+  seed_data: Dataset
+  learning_rate: float = 0.1
+  optimizer: optax.GradientTransformation | None = None
 
-    def __post_init__(self):
-        if self.optimizer is None:
-            object.__setattr__(
-                self, "optimizer", optax.adam(self.learning_rate)
-            )
-        # Precompute JAX arrays from seed data once.
-        data_dict = self.seed_data.to_dict()
-        jax_data = {
-            col: jnp.asarray(data_dict[col])
-            for col in self.seed_data.domain.attributes
-        }
-        object.__setattr__(self, "_jax_data", jax_data)
+  def __post_init__(self):
+    if self.optimizer is None:
+      object.__setattr__(self, "optimizer", optax.adam(self.learning_rate))
+    # Precompute JAX arrays from seed data once.
+    data_dict = self.seed_data.to_dict()
+    jax_data = {
+        col: jnp.asarray(data_dict[col])
+        for col in self.seed_data.domain.attributes
+    }
+    object.__setattr__(self, "_jax_data", jax_data)
 
-    def _init(self, domain, loss_fn, known_total, *, warm_start=None, **kwargs):
-        """Initialize log-weights and optimizer state."""
-        log_weights = jnp.zeros(self.seed_data.records)
-        opt_state = self.optimizer.init(log_weights)
-        return ReweightedDatasetState(log_weights, opt_state)
+  def _init(self, domain, loss_fn, known_total, *, warm_start=None, **kwargs):
+    """Initialize log-weights and optimizer state."""
+    log_weights = jnp.zeros(self.seed_data.records)
+    opt_state = self.optimizer.init(log_weights)
+    return ReweightedDatasetState(log_weights, opt_state)
 
-    def _step(self, state, loss_fn, known_total, constraints=()):
-        """Run one gradient step."""
-        domain = self.seed_data.domain
-        jax_data = self._jax_data
+  def _step(self, state, loss_fn, known_total, constraints=()):
+    """Run one gradient step."""
+    domain = self.seed_data.domain
+    jax_data = self._jax_data
 
-        def params_loss(lw):
-            weights = jax.nn.softmax(lw) * known_total
-            weighted = JaxDataset(jax_data, domain, weights)
-            arrays = {cl: weighted.project(cl) for cl in loss_fn.cliques}
-            mu = CliqueVector(domain, loss_fn.cliques, arrays)
-            return loss_fn(mu)
+    def params_loss(lw):
+      weights = jax.nn.softmax(lw) * known_total
+      weighted = JaxDataset(jax_data, domain, weights)
+      arrays = {cl: weighted.project(cl) for cl in loss_fn.cliques}
+      mu = CliqueVector(domain, loss_fn.cliques, arrays)
+      return loss_fn(mu)
 
-        _, grad = jax.value_and_grad(params_loss)(state.log_weights)
-        updates, opt_state = self.optimizer.update(
-            grad, state.opt_state, state.log_weights
-        )
-        log_weights = optax.apply_updates(state.log_weights, updates)
-        return ReweightedDatasetState(log_weights, opt_state)
+    _, grad = jax.value_and_grad(params_loss)(state.log_weights)
+    updates, opt_state = self.optimizer.update(
+        grad, state.opt_state, state.log_weights
+    )
+    log_weights = optax.apply_updates(state.log_weights, updates)
+    return ReweightedDatasetState(log_weights, opt_state)
 
-    def _callback_value(self, state, known_total, constraints=()):
-        weights = jax.nn.softmax(state.log_weights) * known_total
-        return JaxDataset(self._jax_data, self.seed_data.domain, weights)
+  def _callback_value(self, state, known_total, constraints=()):
+    weights = jax.nn.softmax(state.log_weights) * known_total
+    return JaxDataset(self._jax_data, self.seed_data.domain, weights)
 
-    def _finalize(self, state, known_total, constraints=()):
-        weights = jax.nn.softmax(state.log_weights) * known_total
-        return JaxDataset(self._jax_data, self.seed_data.domain, weights)
+  def _finalize(self, state, known_total, constraints=()):
+    weights = jax.nn.softmax(state.log_weights) * known_total
+    return JaxDataset(self._jax_data, self.seed_data.domain, weights)

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -35,76 +35,76 @@ def precompile(
     cliques: list[Clique],
     rows: int,
 ) -> concurrent.futures.Future:
-    """Warm the JIT cache for ``synthetic_data`` asynchronously.
+  """Warm the JIT cache for ``synthetic_data`` asynchronously.
 
-    Only requires domain and clique structure — both available after
-    measurement selection.  Fire and forget; ``synthetic_data`` benefits
-    from whatever has compiled so far.
+  Only requires domain and clique structure — both available after
+  measurement selection.  Fire and forget; ``synthetic_data`` benefits
+  from whatever has compiled so far.
 
-    No concrete arrays are allocated (except a PRNG key); all inputs use
-    abstract ``ShapeDtypeStruct`` values via ``Factor.abstract`` so the
-    compiler sees shapes and dtypes without materializing memory.
+  No concrete arrays are allocated (except a PRNG key); all inputs use
+  abstract ``ShapeDtypeStruct`` values via ``Factor.abstract`` so the
+  compiler sees shapes and dtypes without materializing memory.
 
-    Args:
-      domain: The Domain over which the model is defined.
-      cliques: The cliques of the model (known after measurement selection).
-      rows: Number of records that will be generated.
-    """
-    rows = max(1, int(rows))
-    plan = _build_plan(domain, cliques)
+  Args:
+    domain: The Domain over which the model is defined.
+    cliques: The cliques of the model (known after measurement selection).
+    rows: Number of records that will be generated.
+  """
+  rows = max(1, int(rows))
+  plan = _build_plan(domain, cliques)
 
-    def _compile_all():
-        # --- Compile message_passing_implicit (abstract, no execution) ---
-        abstract_potentials = CliqueVector.abstract(domain, cliques)
-        marginal_oracles.message_passing_implicit.lower(
-            abstract_potentials,
-            1.0,
-            jtree=plan.jtree,
-            return_messages=True,
-        ).compile()
+  def _compile_all():
+    # --- Compile message_passing_implicit (abstract, no execution) ---
+    abstract_potentials = CliqueVector.abstract(domain, cliques)
+    marginal_oracles.message_passing_implicit.lower(
+        abstract_potentials,
+        1.0,
+        jtree=plan.jtree,
+        return_messages=True,
+    ).compile()
 
-        # --- Build abstract inputs for each column from structure alone ---
-        # Potentials grouped by maximal clique.
-        mapping = clique_mapping(
-            plan.maximal_cliques,
-            cliques,
-            domain=domain,
-        )
-        pot_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
-        for cl in cliques:
-            pot_map[mapping[cl]].append(Factor.abstract(domain.project(cl)))
+    # --- Build abstract inputs for each column from structure alone ---
+    # Potentials grouped by maximal clique.
+    mapping = clique_mapping(
+        plan.maximal_cliques,
+        cliques,
+        domain=domain,
+    )
+    pot_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+    for cl in cliques:
+      pot_map[mapping[cl]].append(Factor.abstract(domain.project(cl)))
 
-        # Messages grouped by destination clique (shapes from separators).
-        message_order = junction_tree.message_passing_order(plan.jtree)
-        msg_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
-        for i, j in message_order:
-            sep = domain.project(tuple(sorted(set(i) & set(j))))
-            msg_map[j].append(Factor.abstract(sep))
+    # Messages grouped by destination clique (shapes from separators).
+    message_order = junction_tree.message_passing_order(plan.jtree)
+    msg_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+    for i, j in message_order:
+      sep = domain.project(tuple(sorted(set(i) & set(j))))
+      msg_map[j].append(Factor.abstract(sep))
 
-        # --- Compile each column's _generate_column ---
-        for cp in plan.columns.values():
-            # Same logic as _gather_inputs but using abstract Factors.
-            inputs = list(pot_map[cp.maximal_clique]) + list(
-                msg_map[cp.maximal_clique]
-            )
-            query_domain = domain.project(cp.query)
-            for attr in query_domain.attributes:
-                if not any(attr in inp.domain.attributes for inp in inputs):
-                    inputs.append(Factor.abstract(domain.project([attr])))
+    # --- Compile each column's _generate_column ---
+    for cp in plan.columns.values():
+      # Same logic as _gather_inputs but using abstract Factors.
+      inputs = list(pot_map[cp.maximal_clique]) + list(
+          msg_map[cp.maximal_clique]
+      )
+      query_domain = domain.project(cp.query)
+      for attr in query_domain.attributes:
+        if not any(attr in inp.domain.attributes for inp in inputs):
+          inputs.append(Factor.abstract(domain.project([attr])))
 
-            abstract_parents = tuple(
-                jax.ShapeDtypeStruct((rows,), jnp.int32) for _ in cp.parents
-            )
-            _generate_column.lower(
-                jax.random.PRNGKey(0),
-                inputs,
-                abstract_parents,
-                query=cp.query,
-                parent_sizes=cp.parent_sizes,
-                total=rows,
-            ).compile()
+      abstract_parents = tuple(
+          jax.ShapeDtypeStruct((rows,), jnp.int32) for _ in cp.parents
+      )
+      _generate_column.lower(
+          jax.random.PRNGKey(0),
+          inputs,
+          abstract_parents,
+          query=cp.query,
+          parent_sizes=cp.parent_sizes,
+          total=rows,
+      ).compile()
 
-    return _COMPILE_POOL.submit(_compile_all)
+  return _COMPILE_POOL.submit(_compile_all)
 
 
 def synthetic_data(
@@ -112,268 +112,268 @@ def synthetic_data(
     rows: int,
     seed: int = 0,
 ) -> Dataset:
-    """Generate synthetic data from a fitted model using Gumbel rounding.
+  """Generate synthetic data from a fitted model using Gumbel rounding.
 
-    Output marginals match the model within ±2 counts per cell.  If
-    ``precompile`` was called earlier with matching domain, cliques, and
-    ``rows``, the JIT cache will be warm and this call is fast.
+  Output marginals match the model within ±2 counts per cell.  If
+  ``precompile`` was called earlier with matching domain, cliques, and
+  ``rows``, the JIT cache will be warm and this call is fast.
 
-    Args:
-      model: A fitted ``MarkovRandomField``.
-      rows: Number of records to generate.
-      seed: Random seed for the JAX PRNG.
+  Args:
+    model: A fitted ``MarkovRandomField``.
+    rows: Number of records to generate.
+    seed: Random seed for the JAX PRNG.
 
-    Returns:
-      A ``Dataset`` whose marginals closely match the model.
-    """
-    rows = max(1, int(rows))
-    domain = model.domain
-    plan = _build_plan(domain, model.cliques)
+  Returns:
+    A ``Dataset`` whose marginals closely match the model.
+  """
+  rows = max(1, int(rows))
+  domain = model.domain
+  plan = _build_plan(domain, model.cliques)
 
-    # Empirically necessary for large models (574-col, ~60 cliques): without
-    # this, XLA compilation is orders of magnitude slower. Exact mechanism TBD.
-    potentials = jax.tree.map(jnp.asarray, model.potentials)
+  # Empirically necessary for large models (574-col, ~60 cliques): without
+  # this, XLA compilation is orders of magnitude slower. Exact mechanism TBD.
+  potentials = jax.tree.map(jnp.asarray, model.potentials)
 
-    # Clique ordering in model.potentials must match the cliques passed to
-    # precompile() for the JIT cache to hit (cliques are pytree metadata).
-    _, messages = marginal_oracles.message_passing_implicit(
-        potentials,
-        1.0,
-        jtree=plan.jtree,
-        return_messages=True,
+  # Clique ordering in model.potentials must match the cliques passed to
+  # precompile() for the JIT cache to hit (cliques are pytree metadata).
+  _, messages = marginal_oracles.message_passing_implicit(
+      potentials,
+      1.0,
+      jtree=plan.jtree,
+      return_messages=True,
+  )
+  pot_map, msg_map = _build_lookups(
+      plan,
+      potentials,
+      messages,
+      domain,
+  )
+
+  rng = jax.random.PRNGKey(seed)
+  data: dict[str, np.ndarray] = {}
+
+  for step, col in enumerate(plan.order):
+    rng, col_rng = jax.random.split(rng)
+    cp = plan.columns[col]
+
+    inputs = _gather_inputs(cp, domain, pot_map, msg_map)
+    parent_arrays = tuple(data[p] for p in cp.parents)
+    t0 = time.monotonic()
+    data[col] = _generate_column(
+        col_rng,
+        inputs,
+        parent_arrays,
+        query=cp.query,
+        parent_sizes=cp.parent_sizes,
+        total=rows,
     )
-    pot_map, msg_map = _build_lookups(
-        plan,
-        potentials,
-        messages,
-        domain,
-    )
+    elapsed = time.monotonic() - t0
 
-    rng = jax.random.PRNGKey(seed)
-    data: dict[str, np.ndarray] = {}
+    if step == 0 and elapsed > 2.0:
+      logging.warning(
+          'First _generate_column call took %.1fs (expected <0.5s '
+          'with a warm JIT cache). This likely means precompile() '
+          'was not called, has not finished, or the model potentials '
+          'have a different array type than expected (e.g. np.ndarray '
+          'vs jax.Array). Subsequent columns will also recompile.',
+          elapsed,
+      )
 
-    for step, col in enumerate(plan.order):
-        rng, col_rng = jax.random.split(rng)
-        cp = plan.columns[col]
+    # Offload to host immediately — frees GPU memory for future columns.
+    # Async overlap or lazy eviction could save ~20ms/col, but that's <1%
+    # of per-column compute time, so we keep this simple.
+    column = np.asarray(data[col])
+    data[col] = column.astype(np.min_scalar_type(domain[col]))
 
-        inputs = _gather_inputs(cp, domain, pot_map, msg_map)
-        parent_arrays = tuple(data[p] for p in cp.parents)
-        t0 = time.monotonic()
-        data[col] = _generate_column(
-            col_rng,
-            inputs,
-            parent_arrays,
-            query=cp.query,
-            parent_sizes=cp.parent_sizes,
-            total=rows,
-        )
-        elapsed = time.monotonic() - t0
+    if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
+      logging.info('Col %d/%d: %s done', step + 1, len(plan.order), col)
 
-        if step == 0 and elapsed > 2.0:
-            logging.warning(
-                'First _generate_column call took %.1fs (expected <0.5s '
-                'with a warm JIT cache). This likely means precompile() '
-                'was not called, has not finished, or the model potentials '
-                'have a different array type than expected (e.g. np.ndarray '
-                'vs jax.Array). Subsequent columns will also recompile.',
-                elapsed,
-            )
-
-        # Offload to host immediately — frees GPU memory for future columns.
-        # Async overlap or lazy eviction could save ~20ms/col, but that's <1%
-        # of per-column compute time, so we keep this simple.
-        column = np.asarray(data[col])
-        data[col] = column.astype(np.min_scalar_type(domain[col]))
-
-        if (step + 1) % 10 == 0 or step + 1 == len(plan.order):
-            logging.info('Col %d/%d: %s done', step + 1, len(plan.order), col)
-
-    return Dataset(data, domain)
+  return Dataset(data, domain)
 
 
 @dataclasses.dataclass(frozen=True)
 class _ColumnPlan:
-    """Per-column metadata for generation."""
+  """Per-column metadata for generation."""
 
-    col: str
-    query: tuple[str, ...]
-    parents: tuple[str, ...]
-    maximal_clique: tuple[str, ...]
-    parent_sizes: tuple[int, ...]
+  col: str
+  query: tuple[str, ...]
+  parents: tuple[str, ...]
+  maximal_clique: tuple[str, ...]
+  parent_sizes: tuple[int, ...]
 
 
 @dataclasses.dataclass(frozen=True)
 class _GenerationPlan:
-    """Junction-tree analysis needed by both precompile and generate."""
+  """Junction-tree analysis needed by both precompile and generate."""
 
-    order: tuple[str, ...]
-    columns: dict[str, _ColumnPlan]
-    jtree: Any  # nx.Graph
-    maximal_cliques: list[tuple[str, ...]]
+  order: tuple[str, ...]
+  columns: dict[str, _ColumnPlan]
+  jtree: Any  # nx.Graph
+  maximal_cliques: list[tuple[str, ...]]
 
 
 def _build_plan(domain, cliques):
-    """Analyse the junction tree and build per-column generation metadata."""
-    clique_sets = [set(cl) for cl in cliques]
-    jtree, elimination_order = junction_tree.make_junction_tree(
-        domain,
-        clique_sets,
+  """Analyse the junction tree and build per-column generation metadata."""
+  clique_sets = [set(cl) for cl in cliques]
+  jtree, elimination_order = junction_tree.make_junction_tree(
+      domain,
+      clique_sets,
+  )
+  maximal_cliques = junction_tree.maximal_cliques(jtree)
+  order = tuple(reversed(elimination_order))
+
+  # Use maximal cliques (junction tree super-cliques) for parent
+  # determination, not the original measurement cliques.  The junction
+  # tree merges overlapping cliques into super-cliques that capture
+  # the full dependency structure.  Using original cliques misses
+  # dependencies between attributes that share a super-clique but
+  # not an original clique.
+  jtree_clique_sets = [set(cl) for cl in maximal_cliques]
+
+  columns: dict[str, _ColumnPlan] = {}
+  used: set[str] = set()
+  for col in order:
+    relevant = [cl for cl in jtree_clique_sets if col in cl]
+    parents = tuple(sorted(used.intersection(set().union(*relevant))))
+    used.add(col)
+
+    query = parents + (col,) if parents else (col,)
+    mc = _find_maxclique(set(query), maximal_cliques)
+
+    columns[col] = _ColumnPlan(
+        col=col,
+        query=query,
+        parents=parents,
+        maximal_clique=mc,
+        parent_sizes=tuple(domain[p] for p in parents),
     )
-    maximal_cliques = junction_tree.maximal_cliques(jtree)
-    order = tuple(reversed(elimination_order))
 
-    # Use maximal cliques (junction tree super-cliques) for parent
-    # determination, not the original measurement cliques.  The junction
-    # tree merges overlapping cliques into super-cliques that capture
-    # the full dependency structure.  Using original cliques misses
-    # dependencies between attributes that share a super-clique but
-    # not an original clique.
-    jtree_clique_sets = [set(cl) for cl in maximal_cliques]
-
-    columns: dict[str, _ColumnPlan] = {}
-    used: set[str] = set()
-    for col in order:
-        relevant = [cl for cl in jtree_clique_sets if col in cl]
-        parents = tuple(sorted(used.intersection(set().union(*relevant))))
-        used.add(col)
-
-        query = parents + (col,) if parents else (col,)
-        mc = _find_maxclique(set(query), maximal_cliques)
-
-        columns[col] = _ColumnPlan(
-            col=col,
-            query=query,
-            parents=parents,
-            maximal_clique=mc,
-            parent_sizes=tuple(domain[p] for p in parents),
-        )
-
-    return _GenerationPlan(
-        order=order,
-        columns=columns,
-        jtree=jtree,
-        maximal_cliques=maximal_cliques,
-    )
+  return _GenerationPlan(
+      order=order,
+      columns=columns,
+      jtree=jtree,
+      maximal_cliques=maximal_cliques,
+  )
 
 
 def _build_lookups(plan, potentials, messages, domain):
-    """Group potentials and messages by maximal clique."""
-    mapping = clique_mapping(
-        plan.maximal_cliques,
-        potentials.cliques,
-        domain=domain,
-    )
-    pot_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
-    for cl in potentials.cliques:
-        pot_map[mapping[cl]].append(potentials[cl])
+  """Group potentials and messages by maximal clique."""
+  mapping = clique_mapping(
+      plan.maximal_cliques,
+      potentials.cliques,
+      domain=domain,
+  )
+  pot_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+  for cl in potentials.cliques:
+    pot_map[mapping[cl]].append(potentials[cl])
 
-    msg_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
-    for (i, j), msg in messages.items():
-        msg_map[j].append(msg)
+  msg_map: dict[tuple, list[Factor]] = collections.defaultdict(list)
+  for (i, j), msg in messages.items():
+    msg_map[j].append(msg)
 
-    return pot_map, msg_map
+  return pot_map, msg_map
 
 
 def _gather_inputs(cp, domain, pot_map, msg_map):
-    """Collect Factor inputs for a column's marginal computation."""
-    inputs = list(pot_map[cp.maximal_clique]) + list(msg_map[cp.maximal_clique])
-    query_domain = domain.project(cp.query)
-    for attr in query_domain.attributes:
-        if not any(attr in inp.domain.attributes for inp in inputs):
-            inputs.append(Factor.zeros(domain.project([attr])))
-    return inputs
+  """Collect Factor inputs for a column's marginal computation."""
+  inputs = list(pot_map[cp.maximal_clique]) + list(msg_map[cp.maximal_clique])
+  query_domain = domain.project(cp.query)
+  for attr in query_domain.attributes:
+    if not any(attr in inp.domain.attributes for inp in inputs):
+      inputs.append(Factor.zeros(domain.project([attr])))
+  return inputs
 
 
 @jax.jit(static_argnames=['query', 'parent_sizes', 'total'])
 def _generate_column(
     prng, inputs, parent_arrays, *, query, parent_sizes, total
 ):
-    """Fused per-column program: marginal computation + Gumbel rounding."""
-    combined = functools.reduce(lambda a, b: a + b, inputs)
-    query_domain = combined.domain.project(query)
-    elim_attrs = combined.domain.marginalize(query_domain).attributes
-    result = combined.logsumexp(elim_attrs).transpose(query_domain.attributes)
-    result = result.normalize(total, log=True).exp()
-    marg = result.datavector(flatten=False)
+  """Fused per-column program: marginal computation + Gumbel rounding."""
+  combined = functools.reduce(lambda a, b: a + b, inputs)
+  query_domain = combined.domain.project(query)
+  elim_attrs = combined.domain.marginalize(query_domain).attributes
+  result = combined.logsumexp(elim_attrs).transpose(query_domain.attributes)
+  result = result.normalize(total, log=True).exp()
+  marg = result.datavector(flatten=False)
 
-    if parent_arrays:
-        marg_2d = marg.reshape(-1, marg.shape[-1])
-        parent_idx = _ravel_multi_index(parent_arrays, parent_sizes)
-    else:
-        marg_2d = marg[jnp.newaxis, :]
-        parent_idx = jnp.zeros(total, dtype=jnp.int32)
+  if parent_arrays:
+    marg_2d = marg.reshape(-1, marg.shape[-1])
+    parent_idx = _ravel_multi_index(parent_arrays, parent_sizes)
+  else:
+    marg_2d = marg[jnp.newaxis, :]
+    parent_idx = jnp.zeros(total, dtype=jnp.int32)
 
-    return _gumbel_round(prng, marg_2d, parent_idx, total)
+  return _gumbel_round(prng, marg_2d, parent_idx, total)
 
 
 def _gumbel_round(prng, marg_2d, flat_parent_idx, total):
-    """Assign each record a value matching expected marginals."""
-    rng1, rng2 = jax.random.split(prng)
+  """Assign each record a value matching expected marginals."""
+  rng1, rng2 = jax.random.split(prng)
 
-    domain_size = marg_2d.shape[-1]
-    parent_product = marg_2d.shape[0]
+  domain_size = marg_2d.shape[-1]
+  parent_product = marg_2d.shape[0]
 
-    marg_parents = marg_2d.sum(axis=-1, keepdims=True)
-    cond_probs = jnp.where(marg_parents != 0, marg_2d / marg_parents, 0.0)
+  marg_parents = marg_2d.sum(axis=-1, keepdims=True)
+  cond_probs = jnp.where(marg_parents != 0, marg_2d / marg_parents, 0.0)
 
-    counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
+  counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
 
-    expected = counts_per_parent[:, None] * cond_probs
-    integ = jnp.floor(expected).astype(jnp.int32)
-    frac = expected - jnp.floor(expected)
-    extra = counts_per_parent - integ.sum(axis=1)
+  expected = counts_per_parent[:, None] * cond_probs
+  integ = jnp.floor(expected).astype(jnp.int32)
+  frac = expected - jnp.floor(expected)
+  extra = counts_per_parent - integ.sum(axis=1)
 
-    u = jax.random.uniform(rng1, (parent_product, domain_size))
-    scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
-    scores = jnp.where(frac == 0, -jnp.inf, scores)
+  u = jax.random.uniform(rng1, (parent_product, domain_size))
+  scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
+  scores = jnp.where(frac == 0, -jnp.inf, scores)
 
-    ranked = jnp.argsort(-scores, axis=1)
-    positions = jnp.broadcast_to(
-        jnp.arange(domain_size)[None, :],
-        (parent_product, domain_size),
-    )
-    roundup_mask = (positions < extra[:, None]).astype(jnp.int32)
-    row_indices = jnp.broadcast_to(
-        jnp.arange(parent_product)[:, None],
-        ranked.shape,
-    )
-    roundup = jnp.zeros((parent_product, domain_size), dtype=jnp.int32)
-    roundup = roundup.at[row_indices, ranked].set(roundup_mask)
-    integ = jnp.maximum(integ + roundup, 0)
+  ranked = jnp.argsort(-scores, axis=1)
+  positions = jnp.broadcast_to(
+      jnp.arange(domain_size)[None, :],
+      (parent_product, domain_size),
+  )
+  roundup_mask = (positions < extra[:, None]).astype(jnp.int32)
+  row_indices = jnp.broadcast_to(
+      jnp.arange(parent_product)[:, None],
+      ranked.shape,
+  )
+  roundup = jnp.zeros((parent_product, domain_size), dtype=jnp.int32)
+  roundup = roundup.at[row_indices, ranked].set(roundup_mask)
+  integ = jnp.maximum(integ + roundup, 0)
 
-    value_options = jnp.arange(domain_size, dtype=jnp.int32)
-    value_options_tiled = jnp.tile(value_options, parent_product)
-    all_values = jnp.repeat(
-        value_options_tiled,
-        integ.ravel(),
-        total_repeat_length=total,
-    )
+  value_options = jnp.arange(domain_size, dtype=jnp.int32)
+  value_options_tiled = jnp.tile(value_options, parent_product)
+  all_values = jnp.repeat(
+      value_options_tiled,
+      integ.ravel(),
+      total_repeat_length=total,
+  )
 
-    group_ids = jnp.repeat(
-        jnp.arange(parent_product, dtype=jnp.float32),
-        counts_per_parent,
-        total_repeat_length=total,
-    )
-    shuffle_keys = jax.random.uniform(rng2, (total,))
-    composite = group_ids + shuffle_keys
-    shuffle_perm = jnp.argsort(composite)
-    all_values = all_values[shuffle_perm]
+  group_ids = jnp.repeat(
+      jnp.arange(parent_product, dtype=jnp.float32),
+      counts_per_parent,
+      total_repeat_length=total,
+  )
+  shuffle_keys = jax.random.uniform(rng2, (total,))
+  composite = group_ids + shuffle_keys
+  shuffle_perm = jnp.argsort(composite)
+  all_values = all_values[shuffle_perm]
 
-    sort_order = jnp.argsort(flat_parent_idx)
-    return jnp.empty(total, dtype=jnp.int32).at[sort_order].set(all_values)
+  sort_order = jnp.argsort(flat_parent_idx)
+  return jnp.empty(total, dtype=jnp.int32).at[sort_order].set(all_values)
 
 
 def _ravel_multi_index(arrays, sizes):
-    """Compute flat indices from a tuple of per-dimension index arrays."""
-    result = arrays[0].astype(jnp.int32)
-    for arr, size in zip(arrays[1:], sizes[1:]):
-        result = result * size + arr.astype(jnp.int32)
-    return result
+  """Compute flat indices from a tuple of per-dimension index arrays."""
+  result = arrays[0].astype(jnp.int32)
+  for arr, size in zip(arrays[1:], sizes[1:]):
+    result = result * size + arr.astype(jnp.int32)
+  return result
 
 
 def _find_maxclique(query_vars, maximal_cliques):
-    """Return the first maximal clique that contains all query variables."""
-    for mc in maximal_cliques:
-        if query_vars.issubset(set(mc)):
-            return mc
-    assert False, f'No maximal clique contains {query_vars}'
+  """Return the first maximal clique that contains all query variables."""
+  for mc in maximal_cliques:
+    if query_vars.issubset(set(mc)):
+      return mc
+  assert False, f'No maximal clique contains {query_vars}'

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -16,271 +16,267 @@ from .domain import Domain
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)  # pytype: disable=invalid-function-definition
 class Factor:
-    """Represents a factor defined over a discrete domain.
+  """Represents a factor defined over a discrete domain.
 
-    A factor can be thought of as a potential function or an unnormalized
-    probability distribution over a set of discrete variables defined by a
-    `Domain` object. It maps each configuration of the domain to a value.
+  A factor can be thought of as a potential function or an unnormalized
+  probability distribution over a set of discrete variables defined by a
+  `Domain` object. It maps each configuration of the domain to a value.
 
-    Attributes:
-        domain (Domain): The discrete domain over which the factor is defined.
-        values (jax.Array): A JAX array containing the factor's values. The shape
-            of this array matches the shape specified by the `domain`.
+  Attributes:
+      domain (Domain): The discrete domain over which the factor is defined.
+      values (jax.Array): A JAX array containing the factor's values. The shape
+          of this array matches the shape specified by the `domain`.
 
-    Supported Operations:
-        - Creation: `zeros`, `ones`, `random` for creating factors.
-        - Reshaping: `transpose`, `expand` for modifying the domain/shape.
-        - Aggregation: `sum`, `logsumexp`, `project` for marginalizing attributes.
-        - Element-wise: `exp`, `log`, `normalize` for value transformations.
-        - Binary Ops: `+`, `-`, `*`, `/`, `dot` for combining factors.
+  Supported Operations:
+      - Creation: `zeros`, `ones`, `random` for creating factors.
+      - Reshaping: `transpose`, `expand` for modifying the domain/shape.
+      - Aggregation: `sum`, `logsumexp`, `project` for marginalizing attributes.
+      - Element-wise: `exp`, `log`, `normalize` for value transformations.
+      - Binary Ops: `+`, `-`, `*`, `/`, `dot` for combining factors.
+
+  Example Usage:
+      >>> from mbi import Domain  # Needed for doctest context
+      >>> domain = Domain.fromdict({'X': 2, 'Y': 3})
+      >>> factor = Factor.ones(domain)
+      >>> print(factor.domain)
+      Domain(X: 2, Y: 3)
+  """
+
+  domain: Domain = jax.tree.static()
+  values: jax.Array
+
+  # Constructors
+  @classmethod
+  def zeros(cls, domain: Domain) -> Factor:
+    """Creates a Factor object with all values initialized to zero."""
+    return cls(domain, jnp.zeros(domain.shape))
+
+  @classmethod
+  def ones(cls, domain: Domain) -> Factor:
+    """Creates a Factor object with all values initialized to one."""
+    return cls(domain, jnp.ones(domain.shape))
+
+  @classmethod
+  def random(cls, domain: Domain) -> Factor:
+    """Creates a Factor object with random values (uniform 0-1)."""
+    return cls(domain, jnp.asarray(np.random.rand(*domain.shape)))
+
+  @classmethod
+  def abstract(cls, domain: Domain) -> Factor:
+    return cls(domain, jax.ShapeDtypeStruct(domain.shape, jnp.float32))
+
+  # Reshaping operations
+  def transpose(self, attrs: Sequence[str]) -> Factor:
+    """Rearranges the factor's axes according to the new attribute order."""
+    if set(attrs) != set(self.domain.attributes):
+      raise ValueError("attrs must be same as domain attributes")
+    newdom = self.domain.project(attrs)
+    ax = newdom.axes(self.domain.attributes)
+    values = jnp.moveaxis(self.values, range(len(ax)), ax)
+    return Factor(newdom, values)
+
+  def expand(self, domain: Domain) -> Factor:
+    """Expands the factor's domain to include new attributes."""
+    if not domain.contains(self.domain):
+      raise ValueError("Expanded domain must contain domain.")
+    dims = len(domain) - len(self.domain)
+    values = self.values.reshape(self.domain.shape + tuple([1] * dims))
+    ax = domain.axes(self.domain.attributes)
+    values = jnp.moveaxis(values, range(len(ax)), ax)
+    values = jnp.broadcast_to(values, domain.shape)
+    return Factor(domain, values)
+
+  # Functions that aggregate along some subset of axes
+  def _aggregate(
+      self, fn: Callable, attrs: Sequence[str] | None = None
+  ) -> Factor:
+    """Helper for aggregating values along specified attribute axes."""
+    attrs = self.domain.attributes if attrs is None else attrs
+    axes = self.domain.axes(attrs)
+    values = fn(self.values, axis=axes)
+    newdom = self.domain.marginalize(attrs)
+    return Factor(newdom, values)
+
+  def max(self, attrs: Sequence[str] | None = None) -> Factor:
+    """Computes the maximum value along specified attribute axes."""
+    return self._aggregate(jnp.max, attrs)
+
+  def sum(self, attrs: Sequence[str] | None = None) -> Factor:
+    """Computes the sum along specified attribute axes."""
+    return self._aggregate(jnp.sum, attrs)
+
+  def logsumexp(self, attrs: Sequence[str] | None = None) -> Factor:
+    """Computes the log-sum-exp along specified attribute axes."""
+    return self._aggregate(jax.scipy.special.logsumexp, attrs)
+
+  def project(self, attrs: str | Sequence[str], log: bool = False) -> "Factor":
+    """Computes the marginal distribution by summing/logsumexp'ing out other attributes."""
+    if isinstance(attrs, str):
+      attrs = (attrs,)
+    marginalized = self.domain.marginalize(attrs).attributes
+    result = self.logsumexp(marginalized) if log else self.sum(marginalized)
+    return result.transpose(attrs)
+
+  def slice(self, evidence: dict[str, int]) -> "Factor":
+    """Slice the factor by fixing attributes to scalar values.
+
+    Args:
+        evidence: Mapping from attribute names to observed integer values.
+
+    Returns:
+        A new Factor with the evidence attributes removed.
+    """
+    slices = [slice(None)] * len(self.domain)
+    relevant = [e for e in evidence if e in self.domain.attributes]
+    for attr in relevant:
+      val = evidence[attr]
+      if hasattr(val, "ndim") and val.ndim > 0:
+        raise ValueError(
+            "Array-valued evidence is not supported (got"
+            f" {type(val).__name__} for '{attr}'). Pass scalar"
+            " int values and vmap over the batch dimension."
+        )
+      slices[self.domain.axes((attr,))[0]] = val
+    values = self.values[tuple(slices)]
+    domain = self.domain.marginalize(relevant)
+    return Factor(domain, values)
+
+  def supports(self, attrs: str | Sequence[str]) -> bool:
+    return self.domain.supports(attrs)
+
+  # Functions that operate element-wise
+  def exp(self) -> Factor:
+    """Applies element-wise exponentiation (jnp.exp) to the factor's values."""
+    return Factor(self.domain, jnp.exp(self.values))
+
+  def log(self) -> Factor:
+    """Applies element-wise logarithm (jnp.log) to the factor's values."""
+    return Factor(self.domain, jnp.log(self.values))
+
+  def normalize(self, total: float = 1.0, log: bool = False) -> Factor:
+    """Normalizes the factor so its values sum to `total` (or log-normalize)."""
+    if log:
+      return self + jnp.log(total) - self.logsumexp()
+    return self * total / self.sum()
+
+  def copy(self) -> Factor:
+    """Returns a copy of the factor (potentially shallow due to JAX)."""
+    return self
+
+  def __float__(self) -> float:
+    if len(self.domain) > 0:
+      raise ValueError("Domain must be empty to convert to float.")
+    return float(self.values)
+
+  # Binary operations between two factors
+  def _binaryop(self, fn: Callable, other: Factor | chex.Numeric) -> Factor:
+    """Helper for applying binary operations between this factor and another factor or scalar."""
+    if not isinstance(other, Factor) and jnp.ndim(other) == 0:
+      other = Factor(Domain([], []), jnp.asarray(other))
+    newdom = self.domain.merge(other.domain)
+    factor1 = self.expand(newdom)
+    factor2 = other.expand(newdom)
+    return Factor(newdom, fn(factor1.values, factor2.values))
+
+  def __sub__(self, other: Factor | chex.Numeric) -> Factor:
+    return self._binaryop(jnp.subtract, other)
+
+  def __truediv__(self, other: Factor | chex.Numeric) -> Factor:
+    return self._binaryop(jnp.divide, other)
+
+  def __mul__(self, other: Factor | chex.Numeric) -> Factor:
+    """Multiply two factors together.
 
     Example Usage:
-        >>> from mbi import Domain  # Needed for doctest context
-        >>> domain = Domain.fromdict({'X': 2, 'Y': 3})
-        >>> factor = Factor.ones(domain)
-        >>> print(factor.domain)
-        Domain(X: 2, Y: 3)
+        >>> f1 = Factor.ones(Domain(['a','b'], [2,3]))
+        >>> f2 = Factor.ones(Domain(['b','c'], [3,4]))
+        >>> f3 = f1 * f2
+        >>> print(f3.domain)
+        Domain(a: 2, b: 3, c: 4)
+
+    Args:
+      other: the other factor to multiply
+
+    Returns:
+      the product of the two factors
     """
+    return self._binaryop(jnp.multiply, other)
 
-    domain: Domain = jax.tree.static()
-    values: jax.Array
+  def __add__(self, other: Factor | chex.Numeric) -> Factor:
+    return self._binaryop(jnp.add, other)
 
-    # Constructors
-    @classmethod
-    def zeros(cls, domain: Domain) -> Factor:
-        """Creates a Factor object with all values initialized to zero."""
-        return cls(domain, jnp.zeros(domain.shape))
+  def __radd__(self, other: chex.Numeric) -> Factor:
+    return self + other
 
-    @classmethod
-    def ones(cls, domain: Domain) -> Factor:
-        """Creates a Factor object with all values initialized to one."""
-        return cls(domain, jnp.ones(domain.shape))
+  def __rsub__(self, other: chex.Numeric) -> Factor:
+    return self + (-1 * other)
 
-    @classmethod
-    def random(cls, domain: Domain) -> Factor:
-        """Creates a Factor object with random values (uniform 0-1)."""
-        return cls(domain, jnp.asarray(np.random.rand(*domain.shape)))
+  def __rmul__(self, other: chex.Numeric) -> Factor:
+    return self * other
 
-    @classmethod
-    def abstract(cls, domain: Domain) -> Factor:
-        return cls(domain, jax.ShapeDtypeStruct(domain.shape, jnp.float32))
+  def dot(self, other: Factor) -> chex.Numeric:
+    if self.domain != other.domain:
+      raise ValueError(f"Domains do not match {self.domain} != {other.domain}")
+    return jnp.sum(
+        self.values * other.values,
+        where=(self.values != 0) & (other.values != 0),
+    )
 
-    # Reshaping operations
-    def transpose(self, attrs: Sequence[str]) -> Factor:
-        """Rearranges the factor's axes according to the new attribute order."""
-        if set(attrs) != set(self.domain.attributes):
-            raise ValueError("attrs must be same as domain attributes")
-        newdom = self.domain.project(attrs)
-        ax = newdom.axes(self.domain.attributes)
-        values = jnp.moveaxis(self.values, range(len(ax)), ax)
-        return Factor(newdom, values)
+  def datavector(self, flatten: bool = True) -> jax.Array:
+    """Returns the factor's values as a flattened vector or original array."""
+    return self.values.flatten() if flatten else self.values
 
-    def expand(self, domain: Domain) -> Factor:
-        """Expands the factor's domain to include new attributes."""
-        if not domain.contains(self.domain):
-            raise ValueError("Expanded domain must contain domain.")
-        dims = len(domain) - len(self.domain)
-        values = self.values.reshape(self.domain.shape + tuple([1] * dims))
-        ax = domain.axes(self.domain.attributes)
-        values = jnp.moveaxis(values, range(len(ax)), ax)
-        values = jnp.broadcast_to(values, domain.shape)
-        return Factor(domain, values)
+  def pad(
+      self, mesh: jax.sharding.Mesh | None, pad_value: Literal[0, "-inf"]
+  ) -> Factor:
+    if mesh is None:
+      return self
+    pad_amounts = [0] * len(self.domain)
+    for i, ax in enumerate(self.domain):
+      if ax in mesh.axis_names:
+        size = self.domain[ax]
+        num_shards = mesh.axis_sizes[mesh.axis_names.index(ax)]
+        pad_amounts[i] = -size % num_shards
 
-    # Functions that aggregate along some subset of axes
-    def _aggregate(
-        self, fn: Callable, attrs: Sequence[str] | None = None
-    ) -> Factor:
-        """Helper for aggregating values along specified attribute axes."""
-        attrs = self.domain.attributes if attrs is None else attrs
-        axes = self.domain.axes(attrs)
-        values = fn(self.values, axis=axes)
-        newdom = self.domain.marginalize(attrs)
-        return Factor(newdom, values)
+    values = jnp.pad(
+        self.values,
+        pad_width=tuple((0, w) for w in pad_amounts),
+        constant_values=0.0 if pad_value == 0 else -jnp.inf,
+    )
+    # We keep the domain as-is here, even though values is now larger.
+    # We have a couple of options
+    #   1. Explicitly unpad when we are done.
+    #   2. Never unpad, just expand the domain, and make sure new elements are impossible.
+    #   3. Allow values to be an array where each dim is >= the domain implies, and truncate
+    #       when necessary.
+    return Factor(self.domain, values)
 
-    def max(self, attrs: Sequence[str] | None = None) -> Factor:
-        """Computes the maximum value along specified attribute axes."""
-        return self._aggregate(jnp.max, attrs)
+  def apply_sharding(self, mesh: jax.sharding.Mesh | None) -> Factor:
+    """Apply sharding constraint to the factor values.
 
-    def sum(self, attrs: Sequence[str] | None = None) -> Factor:
-        """Computes the sum along specified attribute axes."""
-        return self._aggregate(jnp.sum, attrs)
+    The sharding strategy is automatically determined based on the provided
+    mesh, and the factor domain.
 
-    def logsumexp(self, attrs: Sequence[str] | None = None) -> Factor:
-        """Computes the log-sum-exp along specified attribute axes."""
-        return self._aggregate(jax.scipy.special.logsumexp, attrs)
+    Args:
+        mesh: The mesh over which the factor should be sharded.
 
-    def project(
-        self, attrs: str | Sequence[str], log: bool = False
-    ) -> "Factor":
-        """Computes the marginal distribution by summing/logsumexp'ing out other attributes."""
-        if isinstance(attrs, str):
-            attrs = (attrs,)
-        marginalized = self.domain.marginalize(attrs).attributes
-        result = self.logsumexp(marginalized) if log else self.sum(marginalized)
-        return result.transpose(attrs)
+    Returns:
+        A new factor identical to self with sharding constraints applied to the values.
+    """
+    if mesh is None:
+      return self
+    pspec = [None] * len(self.domain)
+    for i, ax in enumerate(self.domain):
+      if ax in mesh.axis_names:
+        pspec[i] = ax
+    sharding = jax.sharding.NamedSharding(
+        mesh, jax.sharding.PartitionSpec(*pspec)
+    )
 
-    def slice(self, evidence: dict[str, int]) -> "Factor":
-        """Slice the factor by fixing attributes to scalar values.
-
-        Args:
-            evidence: Mapping from attribute names to observed integer values.
-
-        Returns:
-            A new Factor with the evidence attributes removed.
-        """
-        slices = [slice(None)] * len(self.domain)
-        relevant = [e for e in evidence if e in self.domain.attributes]
-        for attr in relevant:
-            val = evidence[attr]
-            if hasattr(val, "ndim") and val.ndim > 0:
-                raise ValueError(
-                    "Array-valued evidence is not supported (got"
-                    f" {type(val).__name__} for '{attr}'). Pass scalar"
-                    " int values and vmap over the batch dimension."
-                )
-            slices[self.domain.axes((attr,))[0]] = val
-        values = self.values[tuple(slices)]
-        domain = self.domain.marginalize(relevant)
-        return Factor(domain, values)
-
-    def supports(self, attrs: str | Sequence[str]) -> bool:
-        return self.domain.supports(attrs)
-
-    # Functions that operate element-wise
-    def exp(self) -> Factor:
-        """Applies element-wise exponentiation (jnp.exp) to the factor's values."""
-        return Factor(self.domain, jnp.exp(self.values))
-
-    def log(self) -> Factor:
-        """Applies element-wise logarithm (jnp.log) to the factor's values."""
-        return Factor(self.domain, jnp.log(self.values))
-
-    def normalize(self, total: float = 1.0, log: bool = False) -> Factor:
-        """Normalizes the factor so its values sum to `total` (or log-normalize)."""
-        if log:
-            return self + jnp.log(total) - self.logsumexp()
-        return self * total / self.sum()
-
-    def copy(self) -> Factor:
-        """Returns a copy of the factor (potentially shallow due to JAX)."""
-        return self
-
-    def __float__(self) -> float:
-        if len(self.domain) > 0:
-            raise ValueError("Domain must be empty to convert to float.")
-        return float(self.values)
-
-    # Binary operations between two factors
-    def _binaryop(self, fn: Callable, other: Factor | chex.Numeric) -> Factor:
-        """Helper for applying binary operations between this factor and another factor or scalar."""
-        if not isinstance(other, Factor) and jnp.ndim(other) == 0:
-            other = Factor(Domain([], []), jnp.asarray(other))
-        newdom = self.domain.merge(other.domain)
-        factor1 = self.expand(newdom)
-        factor2 = other.expand(newdom)
-        return Factor(newdom, fn(factor1.values, factor2.values))
-
-    def __sub__(self, other: Factor | chex.Numeric) -> Factor:
-        return self._binaryop(jnp.subtract, other)
-
-    def __truediv__(self, other: Factor | chex.Numeric) -> Factor:
-        return self._binaryop(jnp.divide, other)
-
-    def __mul__(self, other: Factor | chex.Numeric) -> Factor:
-        """Multiply two factors together.
-
-        Example Usage:
-            >>> f1 = Factor.ones(Domain(['a','b'], [2,3]))
-            >>> f2 = Factor.ones(Domain(['b','c'], [3,4]))
-            >>> f3 = f1 * f2
-            >>> print(f3.domain)
-            Domain(a: 2, b: 3, c: 4)
-
-        Args:
-          other: the other factor to multiply
-
-        Returns:
-          the product of the two factors
-        """
-        return self._binaryop(jnp.multiply, other)
-
-    def __add__(self, other: Factor | chex.Numeric) -> Factor:
-        return self._binaryop(jnp.add, other)
-
-    def __radd__(self, other: chex.Numeric) -> Factor:
-        return self + other
-
-    def __rsub__(self, other: chex.Numeric) -> Factor:
-        return self + (-1 * other)
-
-    def __rmul__(self, other: chex.Numeric) -> Factor:
-        return self * other
-
-    def dot(self, other: Factor) -> chex.Numeric:
-        if self.domain != other.domain:
-            raise ValueError(
-                f"Domains do not match {self.domain} != {other.domain}"
-            )
-        return jnp.sum(
-            self.values * other.values,
-            where=(self.values != 0) & (other.values != 0),
-        )
-
-    def datavector(self, flatten: bool = True) -> jax.Array:
-        """Returns the factor's values as a flattened vector or original array."""
-        return self.values.flatten() if flatten else self.values
-
-    def pad(
-        self, mesh: jax.sharding.Mesh | None, pad_value: Literal[0, "-inf"]
-    ) -> Factor:
-        if mesh is None:
-            return self
-        pad_amounts = [0] * len(self.domain)
-        for i, ax in enumerate(self.domain):
-            if ax in mesh.axis_names:
-                size = self.domain[ax]
-                num_shards = mesh.axis_sizes[mesh.axis_names.index(ax)]
-                pad_amounts[i] = -size % num_shards
-
-        values = jnp.pad(
-            self.values,
-            pad_width=tuple((0, w) for w in pad_amounts),
-            constant_values=0.0 if pad_value == 0 else -jnp.inf,
-        )
-        # We keep the domain as-is here, even though values is now larger.
-        # We have a couple of options
-        #   1. Explicitly unpad when we are done.
-        #   2. Never unpad, just expand the domain, and make sure new elements are impossible.
-        #   3. Allow values to be an array where each dim is >= the domain implies, and truncate
-        #       when necessary.
-        return Factor(self.domain, values)
-
-    def apply_sharding(self, mesh: jax.sharding.Mesh | None) -> Factor:
-        """Apply sharding constraint to the factor values.
-
-        The sharding strategy is automatically determined based on the provided
-        mesh, and the factor domain.
-
-        Args:
-            mesh: The mesh over which the factor should be sharded.
-
-        Returns:
-            A new factor identical to self with sharding constraints applied to the values.
-        """
-        if mesh is None:
-            return self
-        pspec = [None] * len(self.domain)
-        for i, ax in enumerate(self.domain):
-            if ax in mesh.axis_names:
-                pspec[i] = ax
-        sharding = jax.sharding.NamedSharding(
-            mesh, jax.sharding.PartitionSpec(*pspec)
-        )
-
-        return Factor(
-            domain=self.domain,
-            values=jax.lax.with_sharding_constraint(self.values, sharding),
-        )
+    return Factor(
+        domain=self.domain,
+        values=jax.lax.with_sharding_constraint(self.values, sharding),
+    )
 
 
 # Re-export for backward compatibility; canonical definition is in _api.py.

--- a/src/mbi/junction_tree.py
+++ b/src/mbi/junction_tree.py
@@ -19,49 +19,49 @@ from .domain import Domain
 
 
 def maximal_cliques(junction_tree: nx.Graph) -> list[Clique]:
-    """Return the list of maximal cliques in the model."""
-    return list(nx.dfs_preorder_nodes(junction_tree))
+  """Return the list of maximal cliques in the model."""
+  return list(nx.dfs_preorder_nodes(junction_tree))
 
 
 def message_passing_order(
     junction_tree: nx.Graph,
 ) -> list[tuple[Clique, Clique]]:
-    """Return a valid message passing order."""
-    edges = set()
-    messages = list(junction_tree.edges()) + [
-        (b, a) for a, b in junction_tree.edges()
-    ]
-    for m1 in messages:
-        for m2 in messages:
-            if m1[1] == m2[0] and m1[0] != m2[1]:
-                edges.add((m1, m2))
-    graph = nx.DiGraph()
-    graph.add_nodes_from(messages)
-    graph.add_edges_from(edges)
-    return list(nx.topological_sort(graph))
+  """Return a valid message passing order."""
+  edges = set()
+  messages = list(junction_tree.edges()) + [
+      (b, a) for a, b in junction_tree.edges()
+  ]
+  for m1 in messages:
+    for m2 in messages:
+      if m1[1] == m2[0] and m1[0] != m2[1]:
+        edges.add((m1, m2))
+  graph = nx.DiGraph()
+  graph.add_nodes_from(messages)
+  graph.add_edges_from(edges)
+  return list(nx.topological_sort(graph))
 
 
 def _make_graph(domain: Domain, cliques: Collection[Clique]) -> nx.Graph:
-    """Create a graph from the domain and cliques."""
-    graph = nx.Graph()
-    graph.add_nodes_from(domain.attributes)
-    for cl in cliques:
-        graph.add_edges_from(itertools.combinations(cl, 2))
-    return graph
+  """Create a graph from the domain and cliques."""
+  graph = nx.Graph()
+  graph.add_nodes_from(domain.attributes)
+  for cl in cliques:
+    graph.add_edges_from(itertools.combinations(cl, 2))
+  return graph
 
 
 def _triangulated(graph: nx.Graph, order: list[str]) -> nx.Graph:
-    """Triangulate the graph using the given elimination order."""
-    edges = set()
-    graph2 = nx.Graph(graph)
-    for node in order:
-        tmp = set(itertools.combinations(graph2.neighbors(node), 2))
-        edges |= tmp
-        graph2.add_edges_from(tmp)
-        graph2.remove_node(node)
-    tri = nx.Graph(graph)
-    tri.add_edges_from(edges)
-    return tri
+  """Triangulate the graph using the given elimination order."""
+  edges = set()
+  graph2 = nx.Graph(graph)
+  for node in order:
+    tmp = set(itertools.combinations(graph2.neighbors(node), 2))
+    edges |= tmp
+    graph2.add_edges_from(tmp)
+    graph2.remove_node(node)
+  tri = nx.Graph(graph)
+  tri.add_edges_from(edges)
+  return tri
 
 
 def greedy_order(
@@ -70,38 +70,38 @@ def greedy_order(
     stochastic: bool = False,
     elim: list[str] | None = None,
 ) -> tuple[list[str], int]:
-    """Compute a greedy elimination order."""
-    order = []
-    unmarked = elim if elim is not None else list(domain.attributes)
-    cliques = set(cliques)
-    total_cost = 0
-    for _ in range(len(unmarked)):
-        cost = OrderedDict()
-        for a in unmarked:
-            neighbors = [cl for cl in cliques if a in cl]
-            variables = tuple(set.union(set(), *[set(n) for n in neighbors]))
-            newdom = domain.project(variables)
-            cost[a] = newdom.size()
+  """Compute a greedy elimination order."""
+  order = []
+  unmarked = elim if elim is not None else list(domain.attributes)
+  cliques = set(cliques)
+  total_cost = 0
+  for _ in range(len(unmarked)):
+    cost = OrderedDict()
+    for a in unmarked:
+      neighbors = [cl for cl in cliques if a in cl]
+      variables = tuple(set.union(set(), *[set(n) for n in neighbors]))
+      newdom = domain.project(variables)
+      cost[a] = newdom.size()
 
-        if stochastic:
-            choices = list(unmarked)
-            costs = np.array([cost[a] for a in choices], dtype=float)
-            probas = np.max(costs) - costs + 1
-            probas /= probas.sum()
-            i = np.random.choice(probas.size, p=probas)
-            a = choices[i]
-        else:
-            a = min(cost, key=lambda a: cost[a])
+    if stochastic:
+      choices = list(unmarked)
+      costs = np.array([cost[a] for a in choices], dtype=float)
+      probas = np.max(costs) - costs + 1
+      probas /= probas.sum()
+      i = np.random.choice(probas.size, p=probas)
+      a = choices[i]
+    else:
+      a = min(cost, key=lambda a: cost[a])
 
-        order.append(a)
-        unmarked.remove(a)
-        neighbors = [cl for cl in cliques if a in cl]
-        variables = tuple(set.union(set(), *[set(n) for n in neighbors]) - {a})
-        cliques -= set(neighbors)
-        cliques.add(variables)
-        total_cost += cost[a]
+    order.append(a)
+    unmarked.remove(a)
+    neighbors = [cl for cl in cliques if a in cl]
+    variables = tuple(set.union(set(), *[set(n) for n in neighbors]) - {a})
+    cliques -= set(neighbors)
+    cliques.add(variables)
+    total_cost += cost[a]
 
-    return order, total_cost
+  return order, total_cost
 
 
 def make_junction_tree(
@@ -109,41 +109,37 @@ def make_junction_tree(
     cliques: Collection[Clique],
     elimination_order: list[str] | int | None = None,
 ) -> tuple[nx.Graph, list[str]]:
-    """Create a junction tree."""
-    cliques = [tuple(cl) for cl in cliques]
-    graph = _make_graph(domain, cliques)
+  """Create a junction tree."""
+  cliques = [tuple(cl) for cl in cliques]
+  graph = _make_graph(domain, cliques)
 
-    if (
-        elimination_order is None
-        and not nx.is_empty(graph)
-        and nx.is_tree(graph)
-    ):
-        elimination_order = list(nx.dfs_postorder_nodes(graph))
-    elif elimination_order is None:
-        elimination_order = greedy_order(domain, cliques, stochastic=False)[0]
-    elif isinstance(elimination_order, int):
-        orders = [greedy_order(domain, cliques, stochastic=False)] + [
-            greedy_order(domain, cliques, stochastic=True)
-            for _ in range(elimination_order)
-        ]
-        elimination_order = min(orders, key=lambda x: x[1])[0]
+  if elimination_order is None and not nx.is_empty(graph) and nx.is_tree(graph):
+    elimination_order = list(nx.dfs_postorder_nodes(graph))
+  elif elimination_order is None:
+    elimination_order = greedy_order(domain, cliques, stochastic=False)[0]
+  elif isinstance(elimination_order, int):
+    orders = [greedy_order(domain, cliques, stochastic=False)] + [
+        greedy_order(domain, cliques, stochastic=True)
+        for _ in range(elimination_order)
+    ]
+    elimination_order = min(orders, key=lambda x: x[1])[0]
 
-    tri = _triangulated(graph, elimination_order)
-    cliques = sorted([domain.canonical(c) for c in nx.find_cliques(tri)])
-    complete = nx.Graph()
-    complete.add_nodes_from(cliques)
-    for c1, c2 in itertools.combinations(cliques, 2):
-        wgt = len(set(c1) & set(c2))
-        if wgt > 0:
-            complete.add_edge(c1, c2, weight=-wgt)
-    spanning = nx.minimum_spanning_tree(complete)
-    return spanning, elimination_order
+  tri = _triangulated(graph, elimination_order)
+  cliques = sorted([domain.canonical(c) for c in nx.find_cliques(tri)])
+  complete = nx.Graph()
+  complete.add_nodes_from(cliques)
+  for c1, c2 in itertools.combinations(cliques, 2):
+    wgt = len(set(c1) & set(c2))
+    if wgt > 0:
+      complete.add_edge(c1, c2, weight=-wgt)
+  spanning = nx.minimum_spanning_tree(complete)
+  return spanning, elimination_order
 
 
 def hypothetical_model_size(domain: Domain, cliques: Sequence[Clique]) -> float:
-    """Size of the full junction tree parameters, measured in megabytes."""
-    jtree, _ = make_junction_tree(domain, cliques)
-    max_cliques = maximal_cliques(jtree)
-    cells = sum(domain.size(cl) for cl in max_cliques)
-    size_mb = cells * 8 / 2**20
-    return size_mb
+  """Size of the full junction tree parameters, measured in megabytes."""
+  jtree, _ = make_junction_tree(domain, cliques)
+  max_cliques = maximal_cliques(jtree)
+  cells = sum(domain.size(cl) for cl in max_cliques)
+  size_mb = cells * 8 / 2**20
+  return size_mb

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -27,12 +27,12 @@ from .factor import Factor
 
 
 def _weighted_datavector(weights: np.ndarray, x: Factor) -> jax.Array:
-    """Datavector scaled by pre-baked weights (pickle-safe).
+  """Datavector scaled by pre-baked weights (pickle-safe).
 
-    .. deprecated::
-        Use :class:`WeightedQuery` instead for serialization support.
-    """
-    return x.datavector() * weights
+  .. deprecated::
+      Use :class:`WeightedQuery` instead for serialization support.
+  """
+  return x.datavector() * weights
 
 
 # ---------------------------------------------------------------------------
@@ -45,199 +45,199 @@ def _weighted_datavector(weights: np.ndarray, x: Factor) -> jax.Array:
 
 @dataclasses.dataclass(frozen=True)
 class DatavectorQuery:
-    """Identity query: ``f.datavector()``."""
+  """Identity query: ``f.datavector()``."""
 
-    def __call__(self, f: Factor) -> jax.Array:
-        return f.datavector()
+  def __call__(self, f: Factor) -> jax.Array:
+    return f.datavector()
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
 class WeightedQuery:
-    """Datavector scaled by fixed weights: ``f.datavector() * weights``."""
+  """Datavector scaled by fixed weights: ``f.datavector() * weights``."""
 
-    weights: np.ndarray
+  weights: np.ndarray
 
-    def __call__(self, f: Factor) -> jax.Array:
-        return f.datavector() * self.weights
+  def __call__(self, f: Factor) -> jax.Array:
+    return f.datavector() * self.weights
 
-    # Identity-based hash/eq so JAX static tracing works (ndarray isn't hashable).
-    def __hash__(self) -> int:
-        return id(self)
+  # Identity-based hash/eq so JAX static tracing works (ndarray isn't hashable).
+  def __hash__(self) -> int:
+    return id(self)
 
-    def __eq__(self, other: object) -> bool:
-        return self is other
+  def __eq__(self, other: object) -> bool:
+    return self is other
 
 
 @dataclasses.dataclass(frozen=True)
 class NormalizedQuery:
-    """L1-normalized datavector: ``f.normalize(1).datavector()``."""
+  """L1-normalized datavector: ``f.normalize(1).datavector()``."""
 
-    def __call__(self, f: Factor) -> jax.Array:
-        return f.normalize(1.0).datavector()
+  def __call__(self, f: Factor) -> jax.Array:
+    return f.normalize(1.0).datavector()
 
 
 @dataclasses.dataclass(frozen=True)
 class SlicedQuery:
-    """Datavector with leading elements removed: ``f.datavector()[start:]``."""
+  """Datavector with leading elements removed: ``f.datavector()[start:]``."""
 
-    start: int = 1
+  start: int = 1
 
-    def __call__(self, f: Factor) -> jax.Array:
-        return f.datavector()[self.start :]
+  def __call__(self, f: Factor) -> jax.Array:
+    return f.datavector()[self.start :]
 
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class LinearMeasurement:
-    """A class for representing a private linear measurement of a marginal.
+  """A class for representing a private linear measurement of a marginal.
 
-    Attributes:
-        noisy_measurement: The noisy measurement of the marginal.
-        clique: The clique (a tuple of attribute names) defining the marginal.
-        stddev: The standard deviation of the noise added to the measurement.
-        query: A linear function that, when applied to a Factor, extracts a
-        a vector with the same shape and interpretation as `noisy_measurement`.
+  Attributes:
+      noisy_measurement: The noisy measurement of the marginal.
+      clique: The clique (a tuple of attribute names) defining the marginal.
+      stddev: The standard deviation of the noise added to the measurement.
+      query: A linear function that, when applied to a Factor, extracts a
+      a vector with the same shape and interpretation as `noisy_measurement`.
+  """
+
+  noisy_measurement: ArrayLike
+  clique: Clique = jax.tree.static()
+  stddev: float = jax.tree.static(default=1.0)
+  query: Callable[[Factor], ArrayLike] = jax.tree.static(
+      default=DatavectorQuery()
+  )
+
+  def __post_init__(self):
+    object.__setattr__(self, "clique", tuple(self.clique))
+
+  def compress(
+      self, mapping: dict[str, np.ndarray], domain: Domain
+  ) -> "LinearMeasurement":
+    """Compress this measurement by merging domain values.
+
+    Args:
+        mapping: Maps attribute names to 1D integer arrays.
+            ``mapping[attr][i]`` gives the compressed value for
+            original value ``i``.
+        domain: The full dataset domain (needed to reshape the
+            measurement vector into the clique's shape).
+
+    Returns:
+        A new ``LinearMeasurement`` over the compressed domain.
     """
+    if not any(a in mapping for a in self.clique):
+      return self
 
-    noisy_measurement: ArrayLike
-    clique: Clique = jax.tree.static()
-    stddev: float = jax.tree.static(default=1.0)
-    query: Callable[[Factor], ArrayLike] = jax.tree.static(
-        default=DatavectorQuery()
+    y = np.asarray(self.noisy_measurement).flatten()
+
+    # Build per-attribute index arrays (mapping or identity).
+    indices, compressed_sizes = [], []
+    for a in self.clique:
+      if a in mapping:
+        m = np.asarray(mapping[a])
+        indices.append(m)
+        compressed_sizes.append(int(m.max()) + 1)
+      else:
+        indices.append(np.arange(domain[a]))
+        compressed_sizes.append(domain[a])
+
+    # Flat compressed index for every element of y.
+    grids = np.meshgrid(*indices, indexing="ij")
+    flat_idx = np.ravel_multi_index(
+        [g.ravel() for g in grids], compressed_sizes
     )
 
-    def __post_init__(self):
-        object.__setattr__(self, "clique", tuple(self.clique))
+    total = int(np.prod(compressed_sizes))
+    y_compressed = np.bincount(flat_idx, weights=y, minlength=total)
+    inv_coefs = 1.0 / np.sqrt(
+        np.bincount(flat_idx, minlength=total).astype(float)
+    )
 
-    def compress(
-        self, mapping: dict[str, np.ndarray], domain: Domain
-    ) -> "LinearMeasurement":
-        """Compress this measurement by merging domain values.
-
-        Args:
-            mapping: Maps attribute names to 1D integer arrays.
-                ``mapping[attr][i]`` gives the compressed value for
-                original value ``i``.
-            domain: The full dataset domain (needed to reshape the
-                measurement vector into the clique's shape).
-
-        Returns:
-            A new ``LinearMeasurement`` over the compressed domain.
-        """
-        if not any(a in mapping for a in self.clique):
-            return self
-
-        y = np.asarray(self.noisy_measurement).flatten()
-
-        # Build per-attribute index arrays (mapping or identity).
-        indices, compressed_sizes = [], []
-        for a in self.clique:
-            if a in mapping:
-                m = np.asarray(mapping[a])
-                indices.append(m)
-                compressed_sizes.append(int(m.max()) + 1)
-            else:
-                indices.append(np.arange(domain[a]))
-                compressed_sizes.append(domain[a])
-
-        # Flat compressed index for every element of y.
-        grids = np.meshgrid(*indices, indexing="ij")
-        flat_idx = np.ravel_multi_index(
-            [g.ravel() for g in grids], compressed_sizes
-        )
-
-        total = int(np.prod(compressed_sizes))
-        y_compressed = np.bincount(flat_idx, weights=y, minlength=total)
-        inv_coefs = 1.0 / np.sqrt(
-            np.bincount(flat_idx, minlength=total).astype(float)
-        )
-
-        return LinearMeasurement(
-            y_compressed * inv_coefs,
-            self.clique,
-            self.stddev,
-            query=WeightedQuery(inv_coefs),
-        )
+    return LinearMeasurement(
+        y_compressed * inv_coefs,
+        self.clique,
+        self.stddev,
+        query=WeightedQuery(inv_coefs),
+    )
 
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class MarginalLossFn:
-    """A loss function over the concatenated vector of marginals.
+  """A loss function over the concatenated vector of marginals.
 
-    Separates the computation (``loss_fn``, static) from the captured data
-    (``data``, dynamic JAX pytree leaves).  This allows ``MarginalLossFn``
-    to be passed through ``jax.jit`` as a regular traced argument rather
-    than a static one, so that different measurement values with the same
-    structure reuse the same compiled program.
+  Separates the computation (``loss_fn``, static) from the captured data
+  (``data``, dynamic JAX pytree leaves).  This allows ``MarginalLossFn``
+  to be passed through ``jax.jit`` as a regular traced argument rather
+  than a static one, so that different measurement values with the same
+  structure reuse the same compiled program.
 
-    Attributes:
-        cliques: Cliques defining the scope of the marginals.
-        loss_fn: A pure function ``(marginals, data) -> loss``.  This is
-            treated as static metadata for JIT compilation.
-        data: Arbitrary pytree of arrays captured by ``loss_fn``.  This is
-            traced through JIT and can change without recompilation.
-        lipschitz: Optional Lipschitz constant of the gradient.
-    """
+  Attributes:
+      cliques: Cliques defining the scope of the marginals.
+      loss_fn: A pure function ``(marginals, data) -> loss``.  This is
+          treated as static metadata for JIT compilation.
+      data: Arbitrary pytree of arrays captured by ``loss_fn``.  This is
+          traced through JIT and can change without recompilation.
+      lipschitz: Optional Lipschitz constant of the gradient.
+  """
 
-    cliques: Sequence[Clique] = jax.tree.static()
-    loss_fn: Callable[[CliqueVector, Any], chex.Numeric] = jax.tree.static()
-    data: Any = ()
-    lipschitz: float | None = jax.tree.static(default=None)
+  cliques: Sequence[Clique] = jax.tree.static()
+  loss_fn: Callable[[CliqueVector, Any], chex.Numeric] = jax.tree.static()
+  data: Any = ()
+  lipschitz: float | None = jax.tree.static(default=None)
 
-    def __post_init__(self):
-        object.__setattr__(self, "cliques", tuple(self.cliques))
+  def __post_init__(self):
+    object.__setattr__(self, "cliques", tuple(self.cliques))
 
-    def __call__(self, marginals: CliqueVector) -> chex.Numeric:
-        return self.loss_fn(marginals, self.data)
+  def __call__(self, marginals: CliqueVector) -> chex.Numeric:
+    return self.loss_fn(marginals, self.data)
 
 
 def _l2_loss(
     marginals: CliqueVector,
     measurements: tuple[LinearMeasurement, ...],
 ) -> chex.Numeric:
-    """Weighted L2 loss over linear measurements."""
-    loss = 0.0
-    for M in measurements:
-        mu = marginals.project(M.clique)
-        stddev = jnp.maximum(M.stddev, 1e-12)
-        diff = (M.query(mu) - M.noisy_measurement) / stddev
-        loss += 0.5 * jnp.vdot(diff, diff)
-    return loss
+  """Weighted L2 loss over linear measurements."""
+  loss = 0.0
+  for M in measurements:
+    mu = marginals.project(M.clique)
+    stddev = jnp.maximum(M.stddev, 1e-12)
+    diff = (M.query(mu) - M.noisy_measurement) / stddev
+    loss += 0.5 * jnp.vdot(diff, diff)
+  return loss
 
 
 def _l1_loss(
     marginals: CliqueVector,
     measurements: tuple[LinearMeasurement, ...],
 ) -> chex.Numeric:
-    """Weighted L1 loss over linear measurements."""
-    loss = 0.0
-    for M in measurements:
-        mu = marginals.project(M.clique)
-        stddev = jnp.maximum(M.stddev, 1e-12)
-        diff = (M.query(mu) - M.noisy_measurement) / stddev
-        loss += jnp.sum(jnp.abs(diff))
-    return loss
+  """Weighted L1 loss over linear measurements."""
+  loss = 0.0
+  for M in measurements:
+    mu = marginals.project(M.clique)
+    stddev = jnp.maximum(M.stddev, 1e-12)
+    diff = (M.query(mu) - M.noisy_measurement) / stddev
+    loss += jnp.sum(jnp.abs(diff))
+  return loss
 
 
 def _normalized_l2_loss(
     marginals: CliqueVector,
     measurements: tuple[LinearMeasurement, ...],
 ) -> chex.Numeric:
-    """Normalized L2 loss over linear measurements."""
-    loss = _l2_loss(marginals, measurements)
-    total = marginals.project(()).datavector(flatten=False)
-    return jnp.sqrt(loss / len(measurements) / total)
+  """Normalized L2 loss over linear measurements."""
+  loss = _l2_loss(marginals, measurements)
+  total = marginals.project(()).datavector(flatten=False)
+  return jnp.sqrt(loss / len(measurements) / total)
 
 
 def _normalized_l1_loss(
     marginals: CliqueVector,
     measurements: tuple[LinearMeasurement, ...],
 ) -> chex.Numeric:
-    """Normalized L1 loss over linear measurements."""
-    loss = _l1_loss(marginals, measurements)
-    total = marginals.project(()).datavector(flatten=False)
-    return loss / len(measurements) / total
+  """Normalized L1 loss over linear measurements."""
+  loss = _l1_loss(marginals, measurements)
+  total = marginals.project(()).datavector(flatten=False)
+  return loss / len(measurements) / total
 
 
 def calculate_l2_lipschitz(
@@ -245,32 +245,32 @@ def calculate_l2_lipschitz(
     cliques: list[Clique],
     loss_fn: Callable[[CliqueVector], chex.Numeric],
 ) -> float:
-    """Estimate the Lipschitz constant of L(x) = || f(x) - y ||_2^2 where f is a linear function.
+  """Estimate the Lipschitz constant of L(x) = || f(x) - y ||_2^2 where f is a linear function.
 
-    The Lipschitz constant can usually be obtained via the largest eigenvalue of the Hessian, which
-    for linear functions represented in matrix form is A^T A.  This function computes the same
-    value without materializing this n x n matrix by using power iteration and leveraging jax.jvp.
+  The Lipschitz constant can usually be obtained via the largest eigenvalue of the Hessian, which
+  for linear functions represented in matrix form is A^T A.  This function computes the same
+  value without materializing this n x n matrix by using power iteration and leveraging jax.jvp.
 
-    Args:
-        domain: The domain over which the loss_fn is defined.
-        loss_fn: The loss function, assumed to be of the form || f(x) - y ||_2^2 where f is linear.
+  Args:
+      domain: The domain over which the loss_fn is defined.
+      loss_fn: The loss function, assumed to be of the form || f(x) - y ||_2^2 where f is linear.
 
-    Returns:
-        An estimate of the Lipschitz constant of the grad(L).
-    """
-    x0 = CliqueVector.zeros(domain, cliques)
+  Returns:
+      An estimate of the Lipschitz constant of the grad(L).
+  """
+  x0 = CliqueVector.zeros(domain, cliques)
 
-    @jax.jit
-    def compute_Hv(v: CliqueVector) -> CliqueVector:
-        return jax.jvp(jax.grad(loss_fn), (x0,), (v,))[1]
+  @jax.jit
+  def compute_Hv(v: CliqueVector) -> CliqueVector:
+    return jax.jvp(jax.grad(loss_fn), (x0,), (v,))[1]
 
-    v = CliqueVector.ones(domain, cliques)
-    v = v / optax.tree.norm(v)
-    for _ in range(50):
-        Hv = compute_Hv(v)
-        estimate = optax.tree.norm(Hv)
-        v = Hv / (estimate + 1e-12)
-    return float(estimate)
+  v = CliqueVector.ones(domain, cliques)
+  v = v / optax.tree.norm(v)
+  for _ in range(50):
+    Hv = compute_Hv(v)
+    estimate = optax.tree.norm(Hv)
+    v = Hv / (estimate + 1e-12)
+  return float(estimate)
 
 
 def from_linear_measurements(
@@ -279,69 +279,69 @@ def from_linear_measurements(
     norm: str = "l2",
     normalize: bool = False,
 ) -> MarginalLossFn:
-    """Construct a MarginalLossFn from a list of LinearMeasurements.
+  """Construct a MarginalLossFn from a list of LinearMeasurements.
 
-    Args:
-        measurements: A list of LinearMeasurements.
-        norm: Either "l1" or "l2".
-        normalize: Flag determining if the loss function should be normalized
-            by the length of linear measurements and estimated total.
-        domain: The domain over which the measurements were made, necessary for calcualting the Lipschitz parameter.
+  Args:
+      measurements: A list of LinearMeasurements.
+      norm: Either "l1" or "l2".
+      normalize: Flag determining if the loss function should be normalized
+          by the length of linear measurements and estimated total.
+      domain: The domain over which the measurements were made, necessary for calcualting the Lipschitz parameter.
 
-    Returns:
-        The MarginalLossFn L(mu) = sum_{c} || Q_c mu_c - y_c || (possibly squared or normalized).
-    """
-    if norm not in ["l1", "l2"]:
-        raise ValueError(f"Unknown norm {norm}.")
-    cliques = [m.clique for m in measurements]
-    maximal_cliques = maximal_subset(cliques)
-    data = tuple(measurements)
+  Returns:
+      The MarginalLossFn L(mu) = sum_{c} || Q_c mu_c - y_c || (possibly squared or normalized).
+  """
+  if norm not in ["l1", "l2"]:
+    raise ValueError(f"Unknown norm {norm}.")
+  cliques = [m.clique for m in measurements]
+  maximal_cliques = maximal_subset(cliques)
+  data = tuple(measurements)
 
-    if normalize:
-        loss_fn = _normalized_l2_loss if norm == "l2" else _normalized_l1_loss
-    else:
-        loss_fn = _l2_loss if norm == "l2" else _l1_loss
+  if normalize:
+    loss_fn = _normalized_l2_loss if norm == "l2" else _normalized_l1_loss
+  else:
+    loss_fn = _l2_loss if norm == "l2" else _l1_loss
 
-    loss = MarginalLossFn(maximal_cliques, loss_fn, data)
+  loss = MarginalLossFn(maximal_cliques, loss_fn, data)
 
-    # Lipschitz requires concrete measurement values.
-    has_abstract = any(
-        isinstance(m.noisy_measurement, jax.ShapeDtypeStruct)
-        for m in measurements
-    )
-    if norm == "l2" and not normalize and not has_abstract:
-        lipschitz = calculate_l2_lipschitz(domain, maximal_cliques, loss)
-        return MarginalLossFn(maximal_cliques, loss_fn, data, lipschitz)
+  # Lipschitz requires concrete measurement values.
+  has_abstract = any(
+      isinstance(m.noisy_measurement, jax.ShapeDtypeStruct)
+      for m in measurements
+  )
+  if norm == "l2" and not normalize and not has_abstract:
+    lipschitz = calculate_l2_lipschitz(domain, maximal_cliques, loss)
+    return MarginalLossFn(maximal_cliques, loss_fn, data, lipschitz)
 
-    return loss
+  return loss
 
 
 def primal_feasibility(mu: CliqueVector) -> chex.Numeric:
-    """Calculates the average L1 distance between overlapping marginals in `mu` (consistency)."""
-    ans = 0
-    count = 0
-    for r in mu.cliques:
-        for s in mu.cliques:
-            if r == s:
-                break
-            d = tuple(set(r) & set(s))
-            if len(d) > 0:
-                x = mu[r].project(d).datavector()
-                y = mu[s].project(d).datavector()
-                denom = 0.5 * x.sum() + 0.5 * y.sum()
-                err = jnp.linalg.norm(x - y, 1) / denom
-                ans += err
-                count += 1
-    try:
-        return ans / count
-    except Exception:  # pylint: disable=broad-exception-caught
-        return 0
+  """Calculates the average L1 distance between overlapping marginals in `mu` (consistency)."""
+  ans = 0
+  count = 0
+  for r in mu.cliques:
+    for s in mu.cliques:
+      if r == s:
+        break
+      d = tuple(set(r) & set(s))
+      if len(d) > 0:
+        x = mu[r].project(d).datavector()
+        y = mu[s].project(d).datavector()
+        denom = 0.5 * x.sum() + 0.5 * y.sum()
+        err = jnp.linalg.norm(x - y, 1) / denom
+        ans += err
+        count += 1
+  try:
+    return ans / count
+  except Exception:  # pylint: disable=broad-exception-caught
+    return 0
 
 
 def mle_loss_fn(marginals: CliqueVector) -> "MarginalLossFn":
-    """MLE loss: ``-marginals.dot(mu.log())``."""
-    return MarginalLossFn(
-        cliques=marginals.cliques,
-        loss_fn=lambda mu, target: -target.dot(mu.log()),
-        data=marginals,
-    )
+  """MLE loss: ``-marginals.dot(mu.log())``."""
+  return MarginalLossFn(
+      cliques=marginals.cliques,
+      loss_fn=lambda mu, target: -target.dot(mu.log()),
+      data=marginals,
+  )

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -42,74 +42,74 @@ _EINSUM_LETTERS = list(string.ascii_lowercase) + list(string.ascii_uppercase)
 
 
 class MarginalOracle(Protocol):
-    """Callable signature for stateless marginal oracle functions.
+  """Callable signature for stateless marginal oracle functions.
 
-    A marginal oracle consumes log-space potentials of a graphical model
-    and returns its marginals over the same set of cliques.  Different
-    oracles may have different time/space complexities and numerical
-    stabilities.
+  A marginal oracle consumes log-space potentials of a graphical model
+  and returns its marginals over the same set of cliques.  Different
+  oracles may have different time/space complexities and numerical
+  stabilities.
 
-    Available oracles:
+  Available oracles:
 
-    - ``message_passing_implicit``: Implicit-factor message passing (configurable).
-    - ``message_passing_hugin``: Classic HUGIN algorithm with belief subtraction.
-    - ``message_passing_shafer_shenoy``: Shafer-Shenoy algorithm with neighbor collection.
-    - ``brute_force_marginals``: Materializes the full joint distribution.
-    - ``einsum_marginals``: Direct einsum (not recommended for large models).
+  - ``message_passing_implicit``: Implicit-factor message passing (configurable).
+  - ``message_passing_hugin``: Classic HUGIN algorithm with belief subtraction.
+  - ``message_passing_shafer_shenoy``: Shafer-Shenoy algorithm with neighbor collection.
+  - ``brute_force_marginals``: Materializes the full joint distribution.
+  - ``einsum_marginals``: Direct einsum (not recommended for large models).
+  """
+
+  def __call__(
+      self,
+      potentials: CliqueVector,
+      total: float = 1.0,
+      *,
+      constraints: Sequence[Constraint] = (),
+  ) -> CliqueVector:
+    """Compute marginals from potentials.
+
+    Args:
+        potentials: Potentials of a graphical model.
+        total: Normalization constant. Defaults to 1.0.
+        constraints: Structural constraints. Oracles that support
+            constraints fold them into the potentials or handle
+            them natively; unsupported oracles raise ValueError.
+
+    Returns:
+        Marginals as a CliqueVector.
     """
-
-    def __call__(
-        self,
-        potentials: CliqueVector,
-        total: float = 1.0,
-        *,
-        constraints: Sequence[Constraint] = (),
-    ) -> CliqueVector:
-        """Compute marginals from potentials.
-
-        Args:
-            potentials: Potentials of a graphical model.
-            total: Normalization constant. Defaults to 1.0.
-            constraints: Structural constraints. Oracles that support
-                constraints fold them into the potentials or handle
-                them natively; unsupported oracles raise ValueError.
-
-        Returns:
-            Marginals as a CliqueVector.
-        """
 
 
 def sum_product(
     factors: list[Factor], dom: Domain, einsum_fn: Callable = jnp.einsum
 ) -> Factor:
-    """Compute the sum-of-products of a list of Factors using einsum.
+  """Compute the sum-of-products of a list of Factors using einsum.
 
-    Args:
-        factors: A list of Factors.
-        dom: The target domain of the output factor.
+  Args:
+      factors: A list of Factors.
+      dom: The target domain of the output factor.
 
-    Returns:
-        sum_{S - D} prod_i F_i,
-        where
-            * F_i = factors[i]
-            * D = dom
-            * S = union of domains of F_i
-    """
+  Returns:
+      sum_{S - D} prod_i F_i,
+      where
+          * F_i = factors[i]
+          * D = dom
+          * S = union of domains of F_i
+  """
 
-    attrs = sorted(set.union(*[set(f.domain) for f in factors]).union(set(dom)))
-    mapping = dict(zip(attrs, _EINSUM_LETTERS))
+  attrs = sorted(set.union(*[set(f.domain) for f in factors]).union(set(dom)))
+  mapping = dict(zip(attrs, _EINSUM_LETTERS))
 
-    def convert(d):
-        return "".join(mapping[a] for a in d.attributes)
+  def convert(d):
+    return "".join(mapping[a] for a in d.attributes)
 
-    formula = ",".join(convert(f.domain) for f in factors) + "->" + convert(dom)
-    values = einsum_fn(
-        formula,
-        *[f.values for f in factors],
-        optimize="auto",
-        precision=jax.lax.Precision.HIGHEST,
-    )
-    return Factor(dom, values)
+  formula = ",".join(convert(f.domain) for f in factors) + "->" + convert(dom)
+  values = einsum_fn(
+      formula,
+      *[f.values for f in factors],
+      optimize="auto",
+      precision=jax.lax.Precision.HIGHEST,
+  )
+  return Factor(dom, values)
 
 
 def einsum_semistable(
@@ -117,110 +117,110 @@ def einsum_semistable(
     dom: Domain,
     einsum_fn: Callable = jnp.einsum,
 ) -> Factor:
-    """Compute the log-space sum-product via the exp-normalize trick.
+  """Compute the log-space sum-product via the exp-normalize trick.
 
-    Subtracts per-factor maxima for numerical stability, exponentiates,
-    runs a standard multiply-sum einsum, then maps back to log space.
-    Fast and memory-efficient (no super-factor materialization), but
-    can produce NaN when factor magnitudes span a very wide range.
+  Subtracts per-factor maxima for numerical stability, exponentiates,
+  runs a standard multiply-sum einsum, then maps back to log space.
+  Fast and memory-efficient (no super-factor materialization), but
+  can produce NaN when factor magnitudes span a very wide range.
 
-    Args:
-        log_factors: Factors in log space.
-        dom: Target domain for the output.
-        einsum_fn: Einsum implementation to use (default: ``jnp.einsum``).
+  Args:
+      log_factors: Factors in log space.
+      dom: Target domain for the output.
+      einsum_fn: Einsum implementation to use (default: ``jnp.einsum``).
 
-    Returns:
-        A Factor over *dom* containing the result in log space.
-    """
-    maxes = [f.max(f.domain.marginalize(dom).attributes) for f in log_factors]
-    stable_factors = [(f - m).exp() for f, m in zip(log_factors, maxes)]
-    return sum_product(stable_factors, dom, einsum_fn).log() + sum(maxes)
+  Returns:
+      A Factor over *dom* containing the result in log space.
+  """
+  maxes = [f.max(f.domain.marginalize(dom).attributes) for f in log_factors]
+  stable_factors = [(f - m).exp() for f, m in zip(log_factors, maxes)]
+  return sum_product(stable_factors, dom, einsum_fn).log() + sum(maxes)
 
 
 def einsum_materialized(
     log_factors: list[Factor],
     dom: Domain,
 ) -> Factor:
-    """Compute the log-space sum-product by materializing the combined factor.
+  """Compute the log-space sum-product by materializing the combined factor.
 
-    Combines all log-factors into a single super-factor (via addition in
-    log-space), then reduces over the non-target dimensions with logsumexp.
-    Numerically stable because no exp/log round-trip is needed, but may
-    require O(product of all domain sizes) memory for the intermediate
-    super-factor.
+  Combines all log-factors into a single super-factor (via addition in
+  log-space), then reduces over the non-target dimensions with logsumexp.
+  Numerically stable because no exp/log round-trip is needed, but may
+  require O(product of all domain sizes) memory for the intermediate
+  super-factor.
 
-    Args:
-        log_factors: Factors in log space.
-        dom: Target domain for the output.
+  Args:
+      log_factors: Factors in log space.
+      dom: Target domain for the output.
 
-    Returns:
-        A Factor over *dom* in log space.
-    """
-    combined = functools.reduce(lambda a, b: a + b, log_factors)
-    elim_attrs = combined.domain.marginalize(dom).attributes
-    return combined.logsumexp(elim_attrs).transpose(dom.attributes)
+  Returns:
+      A Factor over *dom* in log space.
+  """
+  combined = functools.reduce(lambda a, b: a + b, log_factors)
+  elim_attrs = combined.domain.marginalize(dom).attributes
+  return combined.logsumexp(elim_attrs).transpose(dom.attributes)
 
 
 def einsum_fused(
     log_factors: list[Factor],
     dom: Domain,
 ) -> Factor:
-    """Compute the log-space sum-product using ``custom_dot_general``.
+  """Compute the log-space sum-product using ``custom_dot_general``.
 
-    Delegates to ``custom_einsum`` with add/logsumexp operations,
-    allowing the XLA compiler to fuse the combine and reduce steps.
-    This avoids both the exp/log round-trip of ``einsum_semistable``
-    and the super-factor materialization of ``einsum_materialized``.
+  Delegates to ``custom_einsum`` with add/logsumexp operations,
+  allowing the XLA compiler to fuse the combine and reduce steps.
+  This avoids both the exp/log round-trip of ``einsum_semistable``
+  and the super-factor materialization of ``einsum_materialized``.
 
-    On GPU, XLA often fuses the operations resulting in both good
-    stability and good performance.
+  On GPU, XLA often fuses the operations resulting in both good
+  stability and good performance.
 
-    Args:
-        log_factors: Factors in log space.
-        dom: Target domain for the output.
+  Args:
+      log_factors: Factors in log space.
+      dom: Target domain for the output.
 
-    Returns:
-        A Factor over *dom* in log space.
-    """
+  Returns:
+      A Factor over *dom* in log space.
+  """
 
-    def _custom_einsum(formula, *arrays, **kwargs):
-        kwargs.pop("optimize", None)
-        kwargs.pop("precision", None)
-        return custom_einsum(
-            formula,
-            *arrays,
-            combine_fn=jnp.add,
-            reduce_fn=jax.scipy.special.logsumexp,
-        )
+  def _custom_einsum(formula, *arrays, **kwargs):
+    kwargs.pop("optimize", None)
+    kwargs.pop("precision", None)
+    return custom_einsum(
+        formula,
+        *arrays,
+        combine_fn=jnp.add,
+        reduce_fn=jax.scipy.special.logsumexp,
+    )
 
-    return sum_product(log_factors, dom, einsum_fn=_custom_einsum)
+  return sum_product(log_factors, dom, einsum_fn=_custom_einsum)
 
 
 def _fold_constraints(
     potentials: CliqueVector,
     constraints: Sequence[Constraint],
 ) -> tuple[CliqueVector, tuple[tuple[str, ...], ...]]:
-    """Fold constraints into potentials as -inf/0 log-space factors.
+  """Fold constraints into potentials as -inf/0 log-space factors.
 
-    Returns:
-        A tuple of (expanded_potentials, input_cliques) where input_cliques
-        are the original cliques before constraint factors were added.
-    """
-    input_cliques = potentials.cliques
-    if not constraints:
-        return potentials, input_cliques
-    domain = potentials.domain
-    cliques = list(input_cliques)
-    arrays = {cl: potentials[cl] for cl in cliques}
-    for c in constraints:
-        cl = domain.canonical(c.clique)
-        factor = c.potential
-        if cl in arrays:
-            arrays[cl] = arrays[cl] + factor
-        else:
-            cliques.append(cl)
-            arrays[cl] = factor
-    return CliqueVector(domain, cliques, arrays), input_cliques
+  Returns:
+      A tuple of (expanded_potentials, input_cliques) where input_cliques
+      are the original cliques before constraint factors were added.
+  """
+  input_cliques = potentials.cliques
+  if not constraints:
+    return potentials, input_cliques
+  domain = potentials.domain
+  cliques = list(input_cliques)
+  arrays = {cl: potentials[cl] for cl in cliques}
+  for c in constraints:
+    cl = domain.canonical(c.clique)
+    factor = c.potential
+    if cl in arrays:
+      arrays[cl] = arrays[cl] + factor
+    else:
+      cliques.append(cl)
+      arrays[cl] = factor
+  return CliqueVector(domain, cliques, arrays), input_cliques
 
 
 @jax.jit(static_argnames=["jtree", "return_messages"])
@@ -232,55 +232,55 @@ def message_passing_hugin(
     constraints: Sequence[Constraint] = (),
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
-    """HUGIN message passing with belief subtraction.
+  """HUGIN message passing with belief subtraction.
 
-    Expands potentials to super-cliques and uses belief subtraction for
-    message computation.  Unstable when potentials contain ``-inf``.
+  Expands potentials to super-cliques and uses belief subtraction for
+  message computation.  Unstable when potentials contain ``-inf``.
 
-    Args:
-        potentials: Potentials of a graphical model.
-        total: Normalization constant.
-        jtree: Pre-computed junction tree (optional).
-        constraints: Structural constraints folded into potentials as
-            ``-inf``/``0`` factors before inference.
-        return_messages: If True, return ``(marginals, messages)`` where
-            *messages* is a dict mapping ``(clique_i, clique_j)`` to the
-            log-space message Factor sent from *i* to *j*.
-    """
-    if constraints:
-        warnings.warn(
-            "HUGIN uses belief subtraction which is unstable with -inf"
-            " potentials introduced by constraints. Consider using"
-            " message_passing_shafer_shenoy instead.",
-            stacklevel=2,
-        )
-    potentials, input_cliques = _fold_constraints(potentials, constraints)
-    if len(potentials.cliques) == 0:
-        result = CliqueVector(potentials.domain, [], {})
-        return (result, {}) if return_messages else result
+  Args:
+      potentials: Potentials of a graphical model.
+      total: Normalization constant.
+      jtree: Pre-computed junction tree (optional).
+      constraints: Structural constraints folded into potentials as
+          ``-inf``/``0`` factors before inference.
+      return_messages: If True, return ``(marginals, messages)`` where
+          *messages* is a dict mapping ``(clique_i, clique_j)`` to the
+          log-space message Factor sent from *i* to *j*.
+  """
+  if constraints:
+    warnings.warn(
+        "HUGIN uses belief subtraction which is unstable with -inf"
+        " potentials introduced by constraints. Consider using"
+        " message_passing_shafer_shenoy instead.",
+        stacklevel=2,
+    )
+  potentials, input_cliques = _fold_constraints(potentials, constraints)
+  if len(potentials.cliques) == 0:
+    result = CliqueVector(potentials.domain, [], {})
+    return (result, {}) if return_messages else result
 
-    domain, cliques = potentials.domain, potentials.cliques
+  domain, cliques = potentials.domain, potentials.cliques
 
-    if jtree is None:
-        jtree = junction_tree.make_junction_tree(domain, cliques)[0]
-    message_order = junction_tree.message_passing_order(jtree)
-    maximal_cliques = junction_tree.maximal_cliques(jtree)
+  if jtree is None:
+    jtree = junction_tree.make_junction_tree(domain, cliques)[0]
+  message_order = junction_tree.message_passing_order(jtree)
+  maximal_cliques = junction_tree.maximal_cliques(jtree)
 
-    clique_mapping(maximal_cliques, cliques, domain=domain)
-    beliefs = potentials.expand(maximal_cliques)
+  clique_mapping(maximal_cliques, cliques, domain=domain)
+  beliefs = potentials.expand(maximal_cliques)
 
-    messages = {}
-    for i, j in message_order:
-        sep = beliefs[i].domain.invert(tuple(set(i) & set(j)))
-        if (j, i) in messages:
-            tau = beliefs[i] - messages[(j, i)]
-        else:
-            tau = beliefs[i]
-        messages[(i, j)] = tau.logsumexp(sep)
-        beliefs[j] = beliefs[j] + messages[(i, j)]
+  messages = {}
+  for i, j in message_order:
+    sep = beliefs[i].domain.invert(tuple(set(i) & set(j)))
+    if (j, i) in messages:
+      tau = beliefs[i] - messages[(j, i)]
+    else:
+      tau = beliefs[i]
+    messages[(i, j)] = tau.logsumexp(sep)
+    beliefs[j] = beliefs[j] + messages[(i, j)]
 
-    marginals = beliefs.normalize(total, log=True).exp().contract(input_cliques)
-    return (marginals, messages) if return_messages else marginals
+  marginals = beliefs.normalize(total, log=True).exp().contract(input_cliques)
+  return (marginals, messages) if return_messages else marginals
 
 
 @jax.jit(static_argnames=["jtree", "return_messages"])
@@ -292,59 +292,59 @@ def message_passing_shafer_shenoy(
     constraints: Sequence[Constraint] = (),
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
-    """Shafer-Shenoy message passing with neighbor collection.
+  """Shafer-Shenoy message passing with neighbor collection.
 
-    Expands potentials to super-cliques and collects messages from all
-    neighbors except the target.  More stable than HUGIN for ``-inf``
-    potentials.
+  Expands potentials to super-cliques and collects messages from all
+  neighbors except the target.  More stable than HUGIN for ``-inf``
+  potentials.
 
-    Args:
-        potentials: Potentials of a graphical model.
-        total: Normalization constant.
-        jtree: Pre-computed junction tree (optional).
-        constraints: Structural constraints folded into potentials as
-            ``-inf``/``0`` factors before inference.
-        return_messages: If True, return ``(marginals, messages)`` where
-            *messages* is a dict mapping ``(clique_i, clique_j)`` to the
-            log-space message Factor sent from *i* to *j*.
-    """
-    potentials, input_cliques = _fold_constraints(potentials, constraints)
-    if len(potentials.cliques) == 0:
-        result = CliqueVector(potentials.domain, [], {})
-        return (result, {}) if return_messages else result
+  Args:
+      potentials: Potentials of a graphical model.
+      total: Normalization constant.
+      jtree: Pre-computed junction tree (optional).
+      constraints: Structural constraints folded into potentials as
+          ``-inf``/``0`` factors before inference.
+      return_messages: If True, return ``(marginals, messages)`` where
+          *messages* is a dict mapping ``(clique_i, clique_j)`` to the
+          log-space message Factor sent from *i* to *j*.
+  """
+  potentials, input_cliques = _fold_constraints(potentials, constraints)
+  if len(potentials.cliques) == 0:
+    result = CliqueVector(potentials.domain, [], {})
+    return (result, {}) if return_messages else result
 
-    domain, cliques = potentials.domain, potentials.cliques
+  domain, cliques = potentials.domain, potentials.cliques
 
-    if jtree is None:
-        jtree = junction_tree.make_junction_tree(domain, cliques)[0]
-    message_order = junction_tree.message_passing_order(jtree)
-    maximal_cliques = junction_tree.maximal_cliques(jtree)
+  if jtree is None:
+    jtree = junction_tree.make_junction_tree(domain, cliques)[0]
+  message_order = junction_tree.message_passing_order(jtree)
+  maximal_cliques = junction_tree.maximal_cliques(jtree)
 
-    initial_beliefs = potentials.expand(maximal_cliques)
+  initial_beliefs = potentials.expand(maximal_cliques)
 
-    messages = {}
-    neighbors = {cl: list(jtree.neighbors(cl)) for cl in maximal_cliques}
+  messages = {}
+  neighbors = {cl: list(jtree.neighbors(cl)) for cl in maximal_cliques}
 
-    for i, j in message_order:
-        tau = initial_beliefs[i]
-        for k in neighbors[i]:
-            if k == j:
-                continue
-            tau = tau + messages[(k, i)]
+  for i, j in message_order:
+    tau = initial_beliefs[i]
+    for k in neighbors[i]:
+      if k == j:
+        continue
+      tau = tau + messages[(k, i)]
 
-        sep = tau.domain.invert(tuple(set(i) & set(j)))
-        messages[(i, j)] = tau.logsumexp(sep)
+    sep = tau.domain.invert(tuple(set(i) & set(j)))
+    messages[(i, j)] = tau.logsumexp(sep)
 
-    beliefs = {}
-    for cl in maximal_cliques:
-        b = initial_beliefs[cl]
-        for k in neighbors[cl]:
-            b = b + messages[(k, cl)]
-        beliefs[cl] = b
+  beliefs = {}
+  for cl in maximal_cliques:
+    b = initial_beliefs[cl]
+    for k in neighbors[cl]:
+      b = b + messages[(k, cl)]
+    beliefs[cl] = b
 
-    beliefs = CliqueVector(potentials.domain, maximal_cliques, beliefs)
-    marginals = beliefs.normalize(total, log=True).exp().contract(input_cliques)
-    return (marginals, messages) if return_messages else marginals
+  beliefs = CliqueVector(potentials.domain, maximal_cliques, beliefs)
+  marginals = beliefs.normalize(total, log=True).exp().contract(input_cliques)
+  return (marginals, messages) if return_messages else marginals
 
 
 @jax.jit(static_argnames=["jtree", "contraction", "return_messages"])
@@ -357,85 +357,85 @@ def message_passing_implicit(
     contraction: Callable = einsum_materialized,
     return_messages: bool = False,
 ) -> CliqueVector | tuple[CliqueVector, dict]:
-    """Implicit-factor message passing using a contraction function.
+  """Implicit-factor message passing using a contraction function.
 
-    Keeps potentials in their original factored form and computes messages
-    via the given contraction function.  Most memory-efficient — never
-    materializes super-clique tables.
+  Keeps potentials in their original factored form and computes messages
+  via the given contraction function.  Most memory-efficient — never
+  materializes super-clique tables.
 
-    The default contraction (``einsum_materialized``) is the fastest on GPU.
-    For better ``-inf`` tolerance, use ``einsum_fused``.
+  The default contraction (``einsum_materialized``) is the fastest on GPU.
+  For better ``-inf`` tolerance, use ``einsum_fused``.
 
-    Args:
-        potentials: Potentials of a graphical model.
-        total: Normalization constant.
-        jtree: Pre-computed junction tree (optional).
-        constraints: Structural constraints folded into potentials as
-            ``-inf``/``0`` factors before inference.
-        contraction: Contraction function for log-space sum-product.
-        return_messages: If True, return ``(marginals, messages)`` where
-            *messages* is a dict mapping ``(clique_i, clique_j)`` to the
-            log-space message Factor sent from *i* to *j*.
-    """
-    if constraints and contraction is einsum_semistable:
-        raise ValueError(
-            "einsum_semistable is not compatible with constraints"
-            " (-inf potentials). Use einsum_fused or the default"
-            " einsum_materialized instead."
-        )
-    potentials, input_cliques = _fold_constraints(potentials, constraints)
-    if len(potentials.cliques) == 0:
-        result = CliqueVector(potentials.domain, [], {})
-        return (result, {}) if return_messages else result
+  Args:
+      potentials: Potentials of a graphical model.
+      total: Normalization constant.
+      jtree: Pre-computed junction tree (optional).
+      constraints: Structural constraints folded into potentials as
+          ``-inf``/``0`` factors before inference.
+      contraction: Contraction function for log-space sum-product.
+      return_messages: If True, return ``(marginals, messages)`` where
+          *messages* is a dict mapping ``(clique_i, clique_j)`` to the
+          log-space message Factor sent from *i* to *j*.
+  """
+  if constraints and contraction is einsum_semistable:
+    raise ValueError(
+        "einsum_semistable is not compatible with constraints"
+        " (-inf potentials). Use einsum_fused or the default"
+        " einsum_materialized instead."
+    )
+  potentials, input_cliques = _fold_constraints(potentials, constraints)
+  if len(potentials.cliques) == 0:
+    result = CliqueVector(potentials.domain, [], {})
+    return (result, {}) if return_messages else result
 
-    domain, cliques = potentials.active_domain, potentials.cliques
+  domain, cliques = potentials.active_domain, potentials.cliques
 
-    if jtree is None:
-        jtree = junction_tree.make_junction_tree(domain, cliques)[0]
-    message_order = junction_tree.message_passing_order(jtree)
-    maximal_cliques = junction_tree.maximal_cliques(jtree)
+  if jtree is None:
+    jtree = junction_tree.make_junction_tree(domain, cliques)[0]
+  message_order = junction_tree.message_passing_order(jtree)
+  maximal_cliques = junction_tree.maximal_cliques(jtree)
 
-    mapping = clique_mapping(maximal_cliques, cliques, domain=domain)
-    inverse_mapping = collections.defaultdict(list)
-    incoming_messages = collections.defaultdict(list)
-    potential_mapping = collections.defaultdict(list)
+  mapping = clique_mapping(maximal_cliques, cliques, domain=domain)
+  inverse_mapping = collections.defaultdict(list)
+  incoming_messages = collections.defaultdict(list)
+  potential_mapping = collections.defaultdict(list)
 
-    for cl in cliques:
-        potential_mapping[mapping[cl]].append(potentials[cl])
-        inverse_mapping[mapping[cl]].append(cl)
+  for cl in cliques:
+    potential_mapping[mapping[cl]].append(potentials[cl])
+    inverse_mapping[mapping[cl]].append(cl)
 
-    for i, msg in enumerate(message_order):
-        for j in range(i):
-            msg2 = message_order[j]
-            if msg[0] == msg2[1] and msg[1] != msg2[0]:
-                incoming_messages[msg].append(msg2)
+  for i, msg in enumerate(message_order):
+    for j in range(i):
+      msg2 = message_order[j]
+      if msg[0] == msg2[1] and msg[1] != msg2[0]:
+        incoming_messages[msg].append(msg2)
 
-    messages = {}
-    for i, j in message_order:
-        shared = domain.project(tuple(set(i) & set(j)))
-        input_potentials = potential_mapping[i]
-        input_messages = [messages[key] for key in incoming_messages[(i, j)]]
-        inputs = input_potentials + input_messages
+  messages = {}
+  for i, j in message_order:
+    shared = domain.project(tuple(set(i) & set(j)))
+    input_potentials = potential_mapping[i]
+    input_messages = [messages[key] for key in incoming_messages[(i, j)]]
+    inputs = input_potentials + input_messages
 
-        for attr in shared.attributes:
-            if not any(attr in input.domain.attributes for input in inputs):
-                inputs.append(Factor.zeros(domain.project([attr])))
+    for attr in shared.attributes:
+      if not any(attr in input.domain.attributes for input in inputs):
+        inputs.append(Factor.zeros(domain.project([attr])))
 
-        messages[(i, j)] = contraction(inputs, shared)
+    messages[(i, j)] = contraction(inputs, shared)
 
-    beliefs = {}
-    for cl in maximal_cliques:
-        input_potentials = potential_mapping[cl]
-        input_messages = [val for key, val in messages.items() if key[1] == cl]
-        inputs = input_potentials + input_messages
-        for cl2 in inverse_mapping[cl]:
-            if cl2 not in input_cliques:
-                continue
-            belief = contraction(inputs, domain.project(cl2))
-            beliefs[cl2] = belief.normalize(total, log=True).exp()
+  beliefs = {}
+  for cl in maximal_cliques:
+    input_potentials = potential_mapping[cl]
+    input_messages = [val for key, val in messages.items() if key[1] == cl]
+    inputs = input_potentials + input_messages
+    for cl2 in inverse_mapping[cl]:
+      if cl2 not in input_cliques:
+        continue
+      belief = contraction(inputs, domain.project(cl2))
+      beliefs[cl2] = belief.normalize(total, log=True).exp()
 
-    marginals = CliqueVector(potentials.domain, input_cliques, beliefs)
-    return (marginals, messages) if return_messages else marginals
+  marginals = CliqueVector(potentials.domain, input_cliques, beliefs)
+  return (marginals, messages) if return_messages else marginals
 
 
 # Backward-compatible aliases.
@@ -451,97 +451,97 @@ def default_oracle(
     backend: str | None = None,
     has_constraints: bool = True,
 ) -> MarginalOracle:
-    """Select the best oracle for the given setting.
+  """Select the best oracle for the given setting.
 
-    Chooses based on hardware backend, clique structure, and whether the
-    potentials may contain ``-inf`` entries:
+  Chooses based on hardware backend, clique structure, and whether the
+  potentials may contain ``-inf`` entries:
 
-    - **CPU**: ``message_passing_shafer_shenoy`` (has_constraints=True) or
-      ``message_passing_hugin`` (has_constraints=False). Implicit is not used on
-      CPU because the XLA compiler is less effective there.
-    - **GPU/TPU, memory-limited**: ``message_passing_implicit`` when the total
-      beliefs memory would exceed ~40% of estimated device HBM.  Implicit
-      keeps factors in their original low-dimensional form and only
-      materializes one super-clique at a time, using orders of magnitude
-      less memory than Hugin/SS which materialize all super-clique arrays
-      simultaneously.
-    - **GPU/TPU, huge but few super-cliques**: ``message_passing_implicit``
-      when individual super-cliques exceed 50M entries but there are fewer
-      than 30 nodes.  With few messages, implicit moves less data per
-      message by contracting small input factors rather than operating on
-      huge belief arrays.
-    - **GPU/TPU, has_constraints=True** (default):
-      ``message_passing_shafer_shenoy`` (numerically robust).
-    - **GPU/TPU, has_constraints=False**: ``message_passing_hugin`` (faster when
-      ``-inf`` is absent).
+  - **CPU**: ``message_passing_shafer_shenoy`` (has_constraints=True) or
+    ``message_passing_hugin`` (has_constraints=False). Implicit is not used on
+    CPU because the XLA compiler is less effective there.
+  - **GPU/TPU, memory-limited**: ``message_passing_implicit`` when the total
+    beliefs memory would exceed ~40% of estimated device HBM.  Implicit
+    keeps factors in their original low-dimensional form and only
+    materializes one super-clique at a time, using orders of magnitude
+    less memory than Hugin/SS which materialize all super-clique arrays
+    simultaneously.
+  - **GPU/TPU, huge but few super-cliques**: ``message_passing_implicit``
+    when individual super-cliques exceed 50M entries but there are fewer
+    than 30 nodes.  With few messages, implicit moves less data per
+    message by contracting small input factors rather than operating on
+    huge belief arrays.
+  - **GPU/TPU, has_constraints=True** (default):
+    ``message_passing_shafer_shenoy`` (numerically robust).
+  - **GPU/TPU, has_constraints=False**: ``message_passing_hugin`` (faster when
+    ``-inf`` is absent).
 
-    The heuristic is based on systematic A100 benchmarks across varied
-    graph structures (cardinality 4-256, bandwidth 1-3, 32-256 attributes).
-    When super-cliques are large but the junction tree has many nodes, Hugin
-    and Shafer-Shenoy outperform implicit by 30-40% because their uniform
-    add/logsumexp kernel pattern fuses better in XLA over many sequential
-    messages.  Implicit only wins when individual super-cliques are very
-    large (>50M entries) and the tree is small (<30 nodes), or when
-    Hugin/SS would exceed device memory.
+  The heuristic is based on systematic A100 benchmarks across varied
+  graph structures (cardinality 4-256, bandwidth 1-3, 32-256 attributes).
+  When super-cliques are large but the junction tree has many nodes, Hugin
+  and Shafer-Shenoy outperform implicit by 30-40% because their uniform
+  add/logsumexp kernel pattern fuses better in XLA over many sequential
+  messages.  Implicit only wins when individual super-cliques are very
+  large (>50M entries) and the tree is small (<30 nodes), or when
+  Hugin/SS would exceed device memory.
 
-    Args:
-        cliques: Cliques of the graphical model. Used to estimate max clique
-            size when ``domain`` is also provided.
-        domain: Domain of the graphical model. Used with ``cliques`` to
-            estimate max clique size.
-        backend: JAX backend string ('cpu', 'gpu', 'tpu'). If None, uses
-            ``jax.default_backend()``.
-        has_constraints: Whether potentials may contain ``-inf`` entries (e.g. from
-            deterministic constraints or structural zeros). When True
-            (default), Shafer-Shenoy is preferred for numerical robustness.
-            When False, Hugin may be used for better performance.
+  Args:
+      cliques: Cliques of the graphical model. Used to estimate max clique
+          size when ``domain`` is also provided.
+      domain: Domain of the graphical model. Used with ``cliques`` to
+          estimate max clique size.
+      backend: JAX backend string ('cpu', 'gpu', 'tpu'). If None, uses
+          ``jax.default_backend()``.
+      has_constraints: Whether potentials may contain ``-inf`` entries (e.g. from
+          deterministic constraints or structural zeros). When True
+          (default), Shafer-Shenoy is preferred for numerical robustness.
+          When False, Hugin may be used for better performance.
 
-    Returns:
-        A callable satisfying the ``MarginalOracle`` protocol.
+  Returns:
+      A callable satisfying the ``MarginalOracle`` protocol.
 
-    Example::
+  Example::
 
-        oracle = default_oracle(cliques=model.cliques, domain=model.domain)
-        marginals = oracle(potentials)
-    """
-    if backend is None:
-        backend = jax.default_backend()
+      oracle = default_oracle(cliques=model.cliques, domain=model.domain)
+      marginals = oracle(potentials)
+  """
+  if backend is None:
+    backend = jax.default_backend()
 
-    # CPU: SS or Hugin always (XLA compiler less effective on CPU).
-    if backend == "cpu":
-        if has_constraints:
-            return message_passing_shafer_shenoy
-        return message_passing_hugin
-
-    # GPU/TPU: consider memory pressure and per-message data movement.
-    if cliques is not None and domain is not None:
-        jtree = junction_tree.make_junction_tree(domain, cliques)[0]
-        max_cliques = junction_tree.maximal_cliques(jtree)
-        sc_sizes = [domain.project(cl).size() for cl in max_cliques]
-        max_size = max(sc_sizes)
-        num_nodes = len(max_cliques)
-
-        # Estimate total beliefs memory for Hugin/SS (4 bytes per float32).
-        total_beliefs_bytes = sum(sc_sizes) * 4
-
-        # Memory-limited: use implicit to avoid OOM.  The 40% threshold
-        # leaves room for messages, temporaries, and JAX runtime overhead.
-        # Estimate 80 GB for A100; could be refined per device.
-        estimated_hbm = 80e9
-        if total_beliefs_bytes > estimated_hbm * 0.4:
-            return message_passing_implicit
-
-        # Few large super-cliques: implicit wins on data movement.
-        # With <30 SC nodes there are few messages, so kernel launch overhead
-        # is negligible, and implicit contracts small input factors instead
-        # of operating on huge belief arrays.
-        if max_size >= 50_000_000 and num_nodes < 30:
-            return message_passing_implicit
-
-    # GPU/TPU with moderate cliques: SS for constraints, Hugin otherwise.
+  # CPU: SS or Hugin always (XLA compiler less effective on CPU).
+  if backend == "cpu":
     if has_constraints:
-        return message_passing_shafer_shenoy
+      return message_passing_shafer_shenoy
     return message_passing_hugin
+
+  # GPU/TPU: consider memory pressure and per-message data movement.
+  if cliques is not None and domain is not None:
+    jtree = junction_tree.make_junction_tree(domain, cliques)[0]
+    max_cliques = junction_tree.maximal_cliques(jtree)
+    sc_sizes = [domain.project(cl).size() for cl in max_cliques]
+    max_size = max(sc_sizes)
+    num_nodes = len(max_cliques)
+
+    # Estimate total beliefs memory for Hugin/SS (4 bytes per float32).
+    total_beliefs_bytes = sum(sc_sizes) * 4
+
+    # Memory-limited: use implicit to avoid OOM.  The 40% threshold
+    # leaves room for messages, temporaries, and JAX runtime overhead.
+    # Estimate 80 GB for A100; could be refined per device.
+    estimated_hbm = 80e9
+    if total_beliefs_bytes > estimated_hbm * 0.4:
+      return message_passing_implicit
+
+    # Few large super-cliques: implicit wins on data movement.
+    # With <30 SC nodes there are few messages, so kernel launch overhead
+    # is negligible, and implicit contracts small input factors instead
+    # of operating on huge belief arrays.
+    if max_size >= 50_000_000 and num_nodes < 30:
+      return message_passing_implicit
+
+  # GPU/TPU with moderate cliques: SS for constraints, Hugin otherwise.
+  if has_constraints:
+    return message_passing_shafer_shenoy
+  return message_passing_hugin
 
 
 def brute_force_marginals(
@@ -550,21 +550,21 @@ def brute_force_marginals(
     *,
     constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
-    """Compute marginals from (log-space) potentials by materializing the full joint distribution.
+  """Compute marginals from (log-space) potentials by materializing the full joint distribution.
 
-    Args:
-        potentials: Potentials of a graphical model.
-        total: Normalization constant.
-        constraints: Structural constraints folded into potentials as
-            ``-inf``/``0`` factors before inference.
-    """
-    potentials, input_cliques = _fold_constraints(potentials, constraints)
-    if len(potentials.cliques) == 0:
-        return CliqueVector(potentials.domain, [], {})
+  Args:
+      potentials: Potentials of a graphical model.
+      total: Normalization constant.
+      constraints: Structural constraints folded into potentials as
+          ``-inf``/``0`` factors before inference.
+  """
+  potentials, input_cliques = _fold_constraints(potentials, constraints)
+  if len(potentials.cliques) == 0:
+    return CliqueVector(potentials.domain, [], {})
 
-    P = sum(potentials.tables.values()).normalize(total, log=True).exp()
-    marginals = {cl: P.project(cl) for cl in input_cliques}
-    return CliqueVector(potentials.domain, input_cliques, marginals)
+  P = sum(potentials.tables.values()).normalize(total, log=True).exp()
+  marginals = {cl: P.project(cl) for cl in input_cliques}
+  return CliqueVector(potentials.domain, input_cliques, marginals)
 
 
 def einsum_marginals(
@@ -574,41 +574,41 @@ def einsum_marginals(
     *,
     constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
-    """Compute marginals from (log-space) potentials by using einsum.
+  """Compute marginals from (log-space) potentials by using einsum.
 
-    This is a "brute-force" approach and is not recommended in practice.
+  This is a "brute-force" approach and is not recommended in practice.
 
-    Args:
-        potentials: Potentials of a graphical model.
-        total: Normalization constant.
-        einsum_fn: Einsum function to use.
-        constraints: Structural constraints. Raises ValueError if non-empty.
-    """
-    if constraints:
-        raise ValueError(
-            "einsum_marginals does not support constraints. Use"
-            " message_passing_shafer_shenoy or"
-            " extensions.message_passing.shafer_shenoy."
-        )
-    # not strictly necessary, but consistent
-    if len(potentials.cliques) == 0:
-        return CliqueVector(potentials.domain, [], {})
-
-    inputs = list(potentials.tables.values())
-    return CliqueVector(
-        potentials.domain,
-        potentials.cliques,
-        {
-            cl: (
-                einsum_semistable(
-                    inputs, potentials[cl].domain, einsum_fn=einsum_fn
-                )
-                .normalize(total, log=True)
-                .exp()
-            )
-            for cl in potentials.cliques
-        },
+  Args:
+      potentials: Potentials of a graphical model.
+      total: Normalization constant.
+      einsum_fn: Einsum function to use.
+      constraints: Structural constraints. Raises ValueError if non-empty.
+  """
+  if constraints:
+    raise ValueError(
+        "einsum_marginals does not support constraints. Use"
+        " message_passing_shafer_shenoy or"
+        " extensions.message_passing.shafer_shenoy."
     )
+  # not strictly necessary, but consistent
+  if len(potentials.cliques) == 0:
+    return CliqueVector(potentials.domain, [], {})
+
+  inputs = list(potentials.tables.values())
+  return CliqueVector(
+      potentials.domain,
+      potentials.cliques,
+      {
+          cl: (
+              einsum_semistable(
+                  inputs, potentials[cl].domain, einsum_fn=einsum_fn
+              )
+              .normalize(total, log=True)
+              .exp()
+          )
+          for cl in potentials.cliques
+      },
+  )
 
 
 def variable_elimination(
@@ -619,47 +619,47 @@ def variable_elimination(
     *,
     constraints: Sequence[Constraint] = (),
 ) -> Factor:
-    """Compute an out-of-model/unsupported marginal from the potentials.
+  """Compute an out-of-model/unsupported marginal from the potentials.
 
-    Args:
-        potentials: The (log-space) potentials of a Graphical Model.
-        clique: The subset of attributes whose marginal you want.
-        total: The normalization factor.
-        evidence: Mapping from attribute names to observed scalar int values.
-        constraints: Structural constraints folded into potentials as
-            ``-inf``/``0`` factors before inference.
+  Args:
+      potentials: The (log-space) potentials of a Graphical Model.
+      clique: The subset of attributes whose marginal you want.
+      total: The normalization factor.
+      evidence: Mapping from attribute names to observed scalar int values.
+      constraints: Structural constraints folded into potentials as
+          ``-inf``/``0`` factors before inference.
 
-    Returns:
-        The marginal defined over the domain of the input clique, where
-        each entry is non-negative and sums to the input total.
-    """
-    potentials, _ = _fold_constraints(potentials, constraints)
-    clique = tuple(clique)
-    evidence = evidence or {}
-    if set(clique) & set(evidence.keys()):
-        raise ValueError("Evidence attributes cannot be in the query clique.")
+  Returns:
+      The marginal defined over the domain of the input clique, where
+      each entry is non-negative and sums to the input total.
+  """
+  potentials, _ = _fold_constraints(potentials, constraints)
+  clique = tuple(clique)
+  evidence = evidence or {}
+  if set(clique) & set(evidence.keys()):
+    raise ValueError("Evidence attributes cannot be in the query clique.")
 
-    k = len(potentials.cliques)
-    psi = dict(zip(range(k), potentials.tables.values()))
+  k = len(potentials.cliques)
+  psi = dict(zip(range(k), potentials.tables.values()))
 
-    if evidence:
-        for i in list(psi.keys()):
-            psi[i] = psi[i].slice(evidence)
+  if evidence:
+    for i in list(psi.keys()):
+      psi[i] = psi[i].slice(evidence)
 
-    domain = potentials.active_domain.marginalize(evidence.keys())
-    cliques = [psi[i].domain.attributes for i in psi] + [clique]
-    elim = domain.invert(clique)
-    elim_order, _ = junction_tree.greedy_order(domain, cliques, elim=elim)
+  domain = potentials.active_domain.marginalize(evidence.keys())
+  cliques = [psi[i].domain.attributes for i in psi] + [clique]
+  elim = domain.invert(clique)
+  elim_order, _ = junction_tree.greedy_order(domain, cliques, elim=elim)
 
-    for z in elim_order:
-        psi2 = [psi.pop(i) for i in list(psi.keys()) if z in psi[i].domain]
-        psi[k] = sum(psi2).logsumexp([z])
-        k += 1
+  for z in elim_order:
+    psi2 = [psi.pop(i) for i in list(psi.keys()) if z in psi[i].domain]
+    psi[k] = sum(psi2).logsumexp([z])
+    k += 1
 
-    newdom = potentials.domain.project(clique)
-    zero = Factor(Domain([], []), jnp.asarray(0.0))
-    unnormalized = sum(psi.values(), start=zero).expand(newdom)
-    return unnormalized.normalize(total, log=True).exp().project(clique)
+  newdom = potentials.domain.project(clique)
+  zero = Factor(Domain([], []), jnp.asarray(0.0))
+  unnormalized = sum(psi.values(), start=zero).expand(newdom)
+  return unnormalized.normalize(total, log=True).exp().project(clique)
 
 
 def bulk_variable_elimination(
@@ -669,42 +669,42 @@ def bulk_variable_elimination(
     *,
     constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
-    """Compute the marginals of the graphical model with the given potentials.
+  """Compute the marginals of the graphical model with the given potentials.
 
-    Unlike other marginal oracles, which only compute marginals for cliques
-    in the potentials vector, this function can compute arbitrary marginals
-    from an arbitrary model. Both runtime and compilation time can be expensive
-    when there are a large number of marginal queries. This function compiles
-    and runs variable_elimination for one query at a time, using parallelism
-    and asyncronous computation do do the compilation in the background, while
-    running variable_eliminatoin sequentially one query at a time.
+  Unlike other marginal oracles, which only compute marginals for cliques
+  in the potentials vector, this function can compute arbitrary marginals
+  from an arbitrary model. Both runtime and compilation time can be expensive
+  when there are a large number of marginal queries. This function compiles
+  and runs variable_elimination for one query at a time, using parallelism
+  and asyncronous computation do do the compilation in the background, while
+  running variable_eliminatoin sequentially one query at a time.
 
-    Args:
-      potentials: The (log-space) potentials of a Graphical Model.
-      marginal_queries: A list of cliques to obtain marginals for.
-      total: The normalization factor.
-      constraints: Structural constraints folded into potentials as
-          ``-inf``/``0`` factors before inference.
+  Args:
+    potentials: The (log-space) potentials of a Graphical Model.
+    marginal_queries: A list of cliques to obtain marginals for.
+    total: The normalization factor.
+    constraints: Structural constraints folded into potentials as
+        ``-inf``/``0`` factors before inference.
 
-    Returns:
-      A CliqueVector with the marginals computed over the specified cliques.
-    """
-    potentials, _ = _fold_constraints(potentials, constraints)
-    jitted = jax.jit(variable_elimination, static_argnums=(1,))
+  Returns:
+    A CliqueVector with the marginals computed over the specified cliques.
+  """
+  potentials, _ = _fold_constraints(potentials, constraints)
+  jitted = jax.jit(variable_elimination, static_argnums=(1,))
 
-    # Async + parallel precompilation.
-    def _precompile(query):
-        return query, jitted.lower(potentials, query, total).compile()
+  # Async + parallel precompilation.
+  def _precompile(query):
+    return query, jitted.lower(potentials, query, total).compile()
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        futures = [executor.submit(_precompile, cl) for cl in marginal_queries]
+  with concurrent.futures.ThreadPoolExecutor() as executor:
+    futures = [executor.submit(_precompile, cl) for cl in marginal_queries]
 
-        results = {}
-        for future in concurrent.futures.as_completed(futures):
-            query, compiled_fn = future.result()
-            results[query] = compiled_fn(potentials, total)
+    results = {}
+    for future in concurrent.futures.as_completed(futures):
+      query, compiled_fn = future.result()
+      results[query] = compiled_fn(potentials, total)
 
-        return CliqueVector(potentials.domain, marginal_queries, results)
+    return CliqueVector(potentials.domain, marginal_queries, results)
 
 
 def calculate_many_marginals(
@@ -715,90 +715,88 @@ def calculate_many_marginals(
     *,
     constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
-    """Calculate marginals for all projections using belief propagation.
+  """Calculate marginals for all projections using belief propagation.
 
-    Implements Algorithm from section 10.3 in Koller and Friedman.
-    This method may be faster than calling variable_elimination many times.
-    Note: this implementation is experimental, and further work may be needed
-    to optimize it. Contributions are welcome.
+  Implements Algorithm from section 10.3 in Koller and Friedman.
+  This method may be faster than calling variable_elimination many times.
+  Note: this implementation is experimental, and further work may be needed
+  to optimize it. Contributions are welcome.
 
-    Args:
-        potentials: Potentials of a graphical model.
-        marginal_queries: a list of cliques whose marginals are desired.
-        constraints: Structural constraints folded into potentials as
-            ``-inf``/``0`` factors before inference.
+  Args:
+      potentials: Potentials of a graphical model.
+      marginal_queries: a list of cliques whose marginals are desired.
+      constraints: Structural constraints folded into potentials as
+          ``-inf``/``0`` factors before inference.
 
-    Returns:
-        A CliqueVector, where each defined over the list of input marginal_queries.
-    """
-    potentials, _ = _fold_constraints(potentials, constraints)
+  Returns:
+      A CliqueVector, where each defined over the list of input marginal_queries.
+  """
+  potentials, _ = _fold_constraints(potentials, constraints)
 
-    domain = potentials.domain
-    jtree = junction_tree.make_junction_tree(
-        potentials.domain, potentials.cliques
-    )[0]
-    max_cliques = junction_tree.maximal_cliques(jtree)
-    neighbors = {i: tuple(jtree.neighbors(i)) for i in max_cliques}
+  domain = potentials.domain
+  jtree = junction_tree.make_junction_tree(
+      potentials.domain, potentials.cliques
+  )[0]
+  max_cliques = junction_tree.maximal_cliques(jtree)
+  neighbors = {i: tuple(jtree.neighbors(i)) for i in max_cliques}
 
-    # TODO: let's see if we can get rid of this similar to message_passing_fast
-    potentials = potentials.expand(max_cliques)
+  # TODO: let's see if we can get rid of this similar to message_passing_fast
+  potentials = potentials.expand(max_cliques)
 
-    # TODO: allow these to take in an optional junction tree
-    marginals = belief_propagation_oracle(potentials, total)
+  # TODO: allow these to take in an optional junction tree
+  marginals = belief_propagation_oracle(potentials, total)
 
-    # first calculate P(Cj | Ci) for all neighbors Ci, Cj
-    conditional = {}
-    for Ci in max_cliques:
-        for Cj in neighbors[Ci]:
-            Cj: Clique  # networkx lacks a precise type annotation.
-            Sij = tuple(set(Cj) & set(Ci))
-            Z = marginals.project(Cj)
-            Z_sep = Z.project(Sij)
-            denom = Z_sep.expand(Z.domain)
-            safe_div = jnp.where(
-                denom.values != 0, Z.values / denom.values, 0.0
-            )
-            conditional[(Cj, Ci)] = Factor(Z.domain, safe_div)
+  # first calculate P(Cj | Ci) for all neighbors Ci, Cj
+  conditional = {}
+  for Ci in max_cliques:
+    for Cj in neighbors[Ci]:
+      Cj: Clique  # networkx lacks a precise type annotation.
+      Sij = tuple(set(Cj) & set(Ci))
+      Z = marginals.project(Cj)
+      Z_sep = Z.project(Sij)
+      denom = Z_sep.expand(Z.domain)
+      safe_div = jnp.where(denom.values != 0, Z.values / denom.values, 0.0)
+      conditional[(Cj, Ci)] = Factor(Z.domain, safe_div)
 
-    # now iterate through pairs of cliques in order of distance
-    # not sure why this API changed and why we need to do this hack.
-    nx.set_edge_attributes(jtree, values=1.0, name="weight")  # type: ignore
-    pred, dist = nx.floyd_warshall_predecessor_and_distance(
-        jtree
-    )  # , weight=None)
+  # now iterate through pairs of cliques in order of distance
+  # not sure why this API changed and why we need to do this hack.
+  nx.set_edge_attributes(jtree, values=1.0, name="weight")  # type: ignore
+  pred, dist = nx.floyd_warshall_predecessor_and_distance(
+      jtree
+  )  # , weight=None)
 
-    def order_fn(x):
-        return dist[x[0]][x[1]]
+  def order_fn(x):
+    return dist[x[0]][x[1]]
 
-    results = {}
-    for Ci, Cj in sorted(itertools.combinations(max_cliques, 2), key=order_fn):
-        if dist[Ci][Cj] == math.inf:
-            continue
-        Cl = pred[Ci][Cj]
-        Y = conditional[(Cj, Cl)]
-        if Cl == Ci:
-            X = marginals[Ci]
-            results[(Ci, Cj)] = results[(Cj, Ci)] = X * Y
-        else:
-            X = results[(Ci, Cl)]
-            S = set(Cl) - set(Ci) - set(Cj)
-            results[(Ci, Cj)] = results[(Cj, Ci)] = (X * Y).sum(S)
+  results = {}
+  for Ci, Cj in sorted(itertools.combinations(max_cliques, 2), key=order_fn):
+    if dist[Ci][Cj] == math.inf:
+      continue
+    Cl = pred[Ci][Cj]
+    Y = conditional[(Cj, Cl)]
+    if Cl == Ci:
+      X = marginals[Ci]
+      results[(Ci, Cj)] = results[(Cj, Ci)] = X * Y
+    else:
+      X = results[(Ci, Cl)]
+      S = set(Cl) - set(Ci) - set(Cj)
+      results[(Ci, Cj)] = results[(Cj, Ci)] = (X * Y).sum(S)
 
-    results = {
-        domain.canonical(key[0] + key[1]): val for key, val in results.items()
-    }
+  results = {
+      domain.canonical(key[0] + key[1]): val for key, val in results.items()
+  }
 
-    answers = {}
-    for cl in marginal_queries:
-        for attr in results:
-            if set(cl) <= set(attr):
-                answers[cl] = results[attr].project(cl)
-                break
-        if cl not in answers:
-            # just use variable elimination
-            answers[cl] = variable_elimination(potentials, cl, total)
+  answers = {}
+  for cl in marginal_queries:
+    for attr in results:
+      if set(cl) <= set(attr):
+        answers[cl] = results[attr].project(cl)
+        break
+    if cl not in answers:
+      # just use variable elimination
+      answers[cl] = variable_elimination(potentials, cl, total)
 
-    return CliqueVector(domain, marginal_queries, answers)
+  return CliqueVector(domain, marginal_queries, answers)
 
 
 def kron_query(
@@ -809,35 +807,35 @@ def kron_query(
     *,
     constraints: Sequence[Constraint] = (),
 ) -> Factor:
-    """Compute a Kronecker-product query.
+  """Compute a Kronecker-product query.
 
-    Args:
-        potentials: Potentials of a graphical model.
-        query_factors: Mapping from attribute names to query matrices.
-        total: Normalization constant.
-        suffix: Suffix for the answer attributes.
-        constraints: Structural constraints. Raises ValueError if non-empty.
-    """
-    if constraints:
-        raise ValueError(
-            "kron_query does not support constraints. Fold them into"
-            " potentials before calling kron_query."
-        )
-    new_factors = {}
-    extra_domain = {}
-    extra_cliques = []
-    target_clique = []
+  Args:
+      potentials: Potentials of a graphical model.
+      query_factors: Mapping from attribute names to query matrices.
+      total: Normalization constant.
+      suffix: Suffix for the answer attributes.
+      constraints: Structural constraints. Raises ValueError if non-empty.
+  """
+  if constraints:
+    raise ValueError(
+        "kron_query does not support constraints. Fold them into"
+        " potentials before calling kron_query."
+    )
+  new_factors = {}
+  extra_domain = {}
+  extra_cliques = []
+  target_clique = []
 
-    for key in query_factors:
-        key2 = key + suffix
-        values = query_factors[key]
-        dom = Domain([key2, key], values.shape)
-        new_factors[(key2, key)] = Factor(dom, values).log()
-        extra_domain[key2] = values.shape[0]
-        extra_cliques.append((key2, key))
-        target_clique.append(key2)
+  for key in query_factors:
+    key2 = key + suffix
+    values = query_factors[key]
+    dom = Domain([key2, key], values.shape)
+    new_factors[(key2, key)] = Factor(dom, values).log()
+    extra_domain[key2] = values.shape[0]
+    extra_cliques.append((key2, key))
+    target_clique.append(key2)
 
-    domain = potentials.domain.merge(Domain.fromdict(extra_domain))
-    cliques = potentials.cliques + tuple(extra_cliques)
-    inputs = CliqueVector(domain, cliques, new_factors)
-    return variable_elimination(inputs, tuple(target_clique), total)
+  domain = potentials.domain.merge(Domain.fromdict(extra_domain))
+  cliques = potentials.cliques + tuple(extra_cliques)
+  inputs = CliqueVector(domain, cliques, new_factors)
+  return variable_elimination(inputs, tuple(target_clique), total)

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -22,196 +22,188 @@ from .factor import Factor
 
 @chex.dataclass(frozen=True, kw_only=False)
 class MarkovRandomField:
-    """Represents a learned graphical model.
+  """Represents a learned graphical model.
 
-    This class encapsulates the components of a Markov Random Field that has been
-    learned from data. It stores the learned potentials, the resulting marginal
-    distributions over specified cliques, and the total count (e.g., number of
-    records or equivalent sample size) associated with the model.
+  This class encapsulates the components of a Markov Random Field that has been
+  learned from data. It stores the learned potentials, the resulting marginal
+  distributions over specified cliques, and the total count (e.g., number of
+  records or equivalent sample size) associated with the model.
 
-    Attributes:
-        potentials (CliqueVector): A `CliqueVector` containing the learned
-            potential functions for the cliques in the model.
-        marginals (CliqueVector): A `CliqueVector` containing the marginal
-            distributions for a set of cliques, derived from the potentials.
-        total (chex.Numeric): The total count or effective sample size
-            represented by the model. This is often used for scaling or
-            interpreting the marginals.
+  Attributes:
+      potentials (CliqueVector): A `CliqueVector` containing the learned
+          potential functions for the cliques in the model.
+      marginals (CliqueVector): A `CliqueVector` containing the marginal
+          distributions for a set of cliques, derived from the potentials.
+      total (chex.Numeric): The total count or effective sample size
+          represented by the model. This is often used for scaling or
+          interpreting the marginals.
+  """
+
+  potentials: CliqueVector
+  marginals: CliqueVector
+  total: chex.Numeric = 1
+
+  def project(self, attrs: str | Sequence[str]) -> Factor:
+    if isinstance(attrs, str):
+      attrs = (attrs,)
+    attrs = tuple(attrs)
+    if self.marginals.supports(attrs):
+      return self.marginals.project(attrs)
+    return marginal_oracles.variable_elimination(
+        self.potentials, attrs, self.total
+    )
+
+  def supports(self, attrs: str | Sequence[str]) -> bool:
+    return self.marginals.domain.supports(attrs)
+
+  def synthetic_data(
+      self, rows: int | None = None, method: str = "round"
+  ) -> Dataset:
+    """Generates synthetic data based on the learned model's marginals.
+
+    Args:
+        rows: The number of rows to generate. If not provided, uses the
+              model total, which is usually estimated automatically.
+        method: Specification for strategy to use to generate records.
+                - "round" for randomized rounding
+                - "sample" for i.i.d sampling
+
+    Returns:
+        A synthetic dataset whose marginals should closely match those of the
+        model.
     """
+    total = max(1, int(rows or self.total))
+    domain = self.domain
+    jtree, elimination_order = junction_tree.make_junction_tree(
+        domain, [set(cl) for cl in self.cliques]
+    )
 
-    potentials: CliqueVector
-    marginals: CliqueVector
-    total: chex.Numeric = 1
+    # Use maximal cliques from the junction tree for conditioning
+    # decisions (not the original measurement cliques).  The junction
+    # tree merges overlapping cliques into super-cliques that capture
+    # the full dependency structure of the model.
+    cliques = [set(cl) for cl in jtree.nodes]
 
-    def project(self, attrs: str | Sequence[str]) -> Factor:
-        if isinstance(attrs, str):
-            attrs = (attrs,)
-        attrs = tuple(attrs)
-        if self.marginals.supports(attrs):
-            return self.marginals.project(attrs)
-        return marginal_oracles.variable_elimination(
-            self.potentials, attrs, self.total
+    potentials = self.potentials.expand(list(jtree.nodes))
+    marginals = marginal_oracles.message_passing_stable(potentials, self.total)
+
+    def synthetic_col(counts, total):
+      """Generates a synthetic column by sampling or rounding based on counts and total."""
+      counts = np.asarray(counts, dtype=np.float64)
+      dtype = np.min_scalar_type(counts.size)
+      options = np.arange(counts.size, dtype=dtype)
+      if total == 0:
+        return np.array([], dtype=int)
+      if method == "sample":
+        probas = counts / counts.sum()
+        return np.random.choice(options, total, True, probas)
+      counts *= total / counts.sum()
+      frac, integ = np.modf(counts)
+      integ = integ.astype(int)
+      extra = total - integ.sum()
+      if extra > 0:
+        idx = np.random.choice(options, extra, False, frac / frac.sum())
+        integ[idx] += 1
+      vals = np.repeat(options, integ)
+      np.random.shuffle(vals)
+      return vals
+
+    data = {}
+    order = elimination_order[::-1]
+    col = order[0]
+    marg = marginals.project((col,)).datavector(flatten=False)
+    data[col] = synthetic_col(marg, total)
+    used = {col}
+
+    for col in order[1:]:
+      relevant = [cl for cl in cliques if col in cl]
+      relevant = used.intersection(set().union(*relevant))
+      proj = tuple(relevant)
+      used.add(col)
+
+      if len(proj) >= 1:
+        current_proj_data = np.stack(tuple(data[col] for col in proj), -1)
+
+        marg = np.asarray(
+            marginals.project(proj + (col,)).datavector(flatten=False)
         )
 
-    def supports(self, attrs: str | Sequence[str]) -> bool:
-        return self.marginals.domain.supports(attrs)
+        marg_parents = marg.sum(axis=-1, keepdims=True)
+        cond_probs = np.divide(
+            marg,
+            marg_parents,
+            out=np.zeros_like(marg),
+            where=marg_parents != 0,
+        )
+        cond_cdfs = cond_probs.cumsum(axis=-1)
 
-    def synthetic_data(
-        self, rows: int | None = None, method: str = "round"
-    ) -> Dataset:
-        """Generates synthetic data based on the learned model's marginals.
-
-        Args:
-            rows: The number of rows to generate. If not provided, uses the
-                  model total, which is usually estimated automatically.
-            method: Specification for strategy to use to generate records.
-                    - "round" for randomized rounding
-                    - "sample" for i.i.d sampling
-
-        Returns:
-            A synthetic dataset whose marginals should closely match those of the
-            model.
-        """
-        total = max(1, int(rows or self.total))
-        domain = self.domain
-        jtree, elimination_order = junction_tree.make_junction_tree(
-            domain, [set(cl) for cl in self.cliques]
+        uniques, inverse, counts = np.unique(
+            current_proj_data,
+            axis=0,
+            return_inverse=True,
+            return_counts=True,
         )
 
-        # Use maximal cliques from the junction tree for conditioning
-        # decisions (not the original measurement cliques).  The junction
-        # tree merges overlapping cliques into super-cliques that capture
-        # the full dependency structure of the model.
-        cliques = [set(cl) for cl in jtree.nodes]
+        perm = np.argsort(inverse, kind="stable")
+        if method == "sample":
+          u = np.random.rand(total)
+        else:
+          group_starts = np.zeros(len(counts), dtype=int)
+          np.cumsum(counts[:-1], out=group_starts[1:])
 
-        potentials = self.potentials.expand(list(jtree.nodes))
-        marginals = marginal_oracles.message_passing_stable(
-            potentials, self.total
-        )
+          # Shuffle within each parent group to break
+          # spurious correlations with previously generated
+          # columns that shared the same parent set.
+          for gi in range(len(counts)):
+            s = group_starts[gi]
+            e = s + counts[gi]
+            np.random.shuffle(perm[s:e])
 
-        def synthetic_col(counts, total):
-            """Generates a synthetic column by sampling or rounding based on counts and total."""
-            counts = np.asarray(counts, dtype=np.float64)
-            dtype = np.min_scalar_type(counts.size)
-            options = np.arange(counts.size, dtype=dtype)
-            if total == 0:
-                return np.array([], dtype=int)
-            if method == "sample":
-                probas = counts / counts.sum()
-                return np.random.choice(options, total, True, probas)
-            counts *= total / counts.sum()
-            frac, integ = np.modf(counts)
-            integ = integ.astype(int)
-            extra = total - integ.sum()
-            if extra > 0:
-                idx = np.random.choice(options, extra, False, frac / frac.sum())
-                integ[idx] += 1
-            vals = np.repeat(options, integ)
-            np.random.shuffle(vals)
-            return vals
+          inverse_sorted = inverse[perm]
+          sorted_indices = np.arange(total)
 
-        data = {}
-        order = elimination_order[::-1]
-        col = order[0]
+          ranks_sorted = sorted_indices - group_starts[inverse_sorted]
+
+          ranks = np.empty(total, dtype=int)
+          ranks[perm] = ranks_sorted
+
+          noise = np.random.rand(total)
+          u = (ranks + noise) / counts[inverse]
+
+        indices = tuple(uniques.T)
+        unique_cdfs = cond_cdfs[indices]
+
+        choices = np.empty(total, dtype=np.min_scalar_type(self.domain[col]))
+        domain_size = self.domain[col]
+
+        u_sorted = u[perm]
+
+        start = 0
+        for i, count in enumerate(counts):
+          end = start + count
+          cdf = unique_cdfs[i]
+          indices_chunk = np.searchsorted(
+              cdf, u_sorted[start:end], side="right"
+          )
+          if len(indices_chunk) > 0:
+            np.minimum(indices_chunk, domain_size - 1, out=indices_chunk)
+            choices[perm[start:end]] = indices_chunk
+          start = end
+
+        data[col] = choices
+
+      else:
         marg = marginals.project((col,)).datavector(flatten=False)
         data[col] = synthetic_col(marg, total)
-        used = {col}
 
-        for col in order[1:]:
-            relevant = [cl for cl in cliques if col in cl]
-            relevant = used.intersection(set().union(*relevant))
-            proj = tuple(relevant)
-            used.add(col)
+    return Dataset(data, domain)
 
-            if len(proj) >= 1:
-                current_proj_data = np.stack(
-                    tuple(data[col] for col in proj), -1
-                )
+  @property
+  def domain(self) -> Domain:
+    """Returns the Domain object associated with this graphical model."""
+    return self.potentials.domain
 
-                marg = np.asarray(
-                    marginals.project(proj + (col,)).datavector(flatten=False)
-                )
-
-                marg_parents = marg.sum(axis=-1, keepdims=True)
-                cond_probs = np.divide(
-                    marg,
-                    marg_parents,
-                    out=np.zeros_like(marg),
-                    where=marg_parents != 0,
-                )
-                cond_cdfs = cond_probs.cumsum(axis=-1)
-
-                uniques, inverse, counts = np.unique(
-                    current_proj_data,
-                    axis=0,
-                    return_inverse=True,
-                    return_counts=True,
-                )
-
-                perm = np.argsort(inverse, kind="stable")
-                if method == "sample":
-                    u = np.random.rand(total)
-                else:
-                    group_starts = np.zeros(len(counts), dtype=int)
-                    np.cumsum(counts[:-1], out=group_starts[1:])
-
-                    # Shuffle within each parent group to break
-                    # spurious correlations with previously generated
-                    # columns that shared the same parent set.
-                    for gi in range(len(counts)):
-                        s = group_starts[gi]
-                        e = s + counts[gi]
-                        np.random.shuffle(perm[s:e])
-
-                    inverse_sorted = inverse[perm]
-                    sorted_indices = np.arange(total)
-
-                    ranks_sorted = sorted_indices - group_starts[inverse_sorted]
-
-                    ranks = np.empty(total, dtype=int)
-                    ranks[perm] = ranks_sorted
-
-                    noise = np.random.rand(total)
-                    u = (ranks + noise) / counts[inverse]
-
-                indices = tuple(uniques.T)
-                unique_cdfs = cond_cdfs[indices]
-
-                choices = np.empty(
-                    total, dtype=np.min_scalar_type(self.domain[col])
-                )
-                domain_size = self.domain[col]
-
-                u_sorted = u[perm]
-
-                start = 0
-                for i, count in enumerate(counts):
-                    end = start + count
-                    cdf = unique_cdfs[i]
-                    indices_chunk = np.searchsorted(
-                        cdf, u_sorted[start:end], side="right"
-                    )
-                    if len(indices_chunk) > 0:
-                        np.minimum(
-                            indices_chunk, domain_size - 1, out=indices_chunk
-                        )
-                        choices[perm[start:end]] = indices_chunk
-                    start = end
-
-                data[col] = choices
-
-            else:
-                marg = marginals.project((col,)).datavector(flatten=False)
-                data[col] = synthetic_col(marg, total)
-
-        return Dataset(data, domain)
-
-    @property
-    def domain(self) -> Domain:
-        """Returns the Domain object associated with this graphical model."""
-        return self.potentials.domain
-
-    @property
-    def cliques(self) -> list[Clique]:
-        """Returns the list of cliques the model's potentials are defined over."""
-        return self.potentials.cliques
+  @property
+  def cliques(self) -> list[Clique]:
+    """Returns the list of cliques the model's potentials are defined over."""
+    return self.potentials.cliques

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,11 +4,11 @@ import jax
 
 
 def pytest_configure(config):
-    """Disable JAX persistent compilation cache.
+  """Disable JAX persistent compilation cache.
 
-    MBI tests produce many small jitted programs (one per unique clique
-    structure / domain combination), which makes the persistent cache
-    expensive to maintain and slow to populate.
-    """
-    del config  # Unused.
-    jax.config.update("jax_enable_compilation_cache", False)
+  MBI tests produce many small jitted programs (one per unique clique
+  structure / domain combination), which makes the persistent cache
+  expensive to maintain and slow to populate.
+  """
+  del config  # Unused.
+  jax.config.update("jax_enable_compilation_cache", False)

--- a/test/test_approximate_oracles.py
+++ b/test/test_approximate_oracles.py
@@ -27,60 +27,60 @@ _CLIQUE_SETS = [
 
 
 def fake_measurements(cliques):
-    P = Factor.random(_DOMAIN)
-    P = P / P.sum()
-    measurements = []
-    for cl in cliques:
-        y = P.project(cl).datavector()
-        measurements.append(LinearMeasurement(y, cl))
-    return measurements
+  P = Factor.random(_DOMAIN)
+  P = P / P.sum()
+  measurements = []
+  for cl in cliques:
+    y = P.project(cl).datavector()
+    measurements.append(LinearMeasurement(y, cl))
+  return measurements
 
 
 class TestApproximateOracles(unittest.TestCase):
 
-    @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS))
-    def test_shapes(self, oracle, cliques):
-        zeros = CliqueVector.zeros(_DOMAIN, cliques)
-        marginals, _ = oracle(zeros)
-        self.assertEqual(marginals.domain, _DOMAIN)
-        self.assertEqual(marginals.cliques, tuple(cliques))
-        self.assertEqual(set(zeros.tables.keys()), set(marginals.tables.keys()))
-        for cl in cliques:
-            self.assertEqual(marginals[cl].domain.attributes, cl)
+  @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS))
+  def test_shapes(self, oracle, cliques):
+    zeros = CliqueVector.zeros(_DOMAIN, cliques)
+    marginals, _ = oracle(zeros)
+    self.assertEqual(marginals.domain, _DOMAIN)
+    self.assertEqual(marginals.cliques, tuple(cliques))
+    self.assertEqual(set(zeros.tables.keys()), set(marginals.tables.keys()))
+    for cl in cliques:
+      self.assertEqual(marginals[cl].domain.attributes, cl)
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_mirror_descent(self, cliques):
-        # Here we check that the mirror descent algorithm converges to
-        # the true marginals even with an approximate marginal oracle.
-        measurements = fake_measurements(cliques)
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_mirror_descent(self, cliques):
+    # Here we check that the mirror descent algorithm converges to
+    # the true marginals even with an approximate marginal oracle.
+    measurements = fake_measurements(cliques)
 
-        mu = approximate_oracles.mirror_descent(
-            _DOMAIN,
-            measurements,
-            known_total=1.0,
-            iters=250,
-            stepsize=1.0,
-        )
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = mu.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=1e-2)
+    mu = approximate_oracles.mirror_descent(
+        _DOMAIN,
+        measurements,
+        known_total=1.0,
+        iters=250,
+        stepsize=1.0,
+    )
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = mu.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=1e-2)
 
-    def test_precompile(self):
-        """precompile() with concrete measurements should not raise."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements = fake_measurements(cliques)
-        est = approximate_oracles.ApproxMirrorDescent(stepsize=1.0)
-        est.precompile(_DOMAIN, measurements)
+  def test_precompile(self):
+    """precompile() with concrete measurements should not raise."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements = fake_measurements(cliques)
+    est = approximate_oracles.ApproxMirrorDescent(stepsize=1.0)
+    est.precompile(_DOMAIN, measurements)
 
-    def test_precompile_with_extra_cliques(self):
-        """precompile() with both measurements and extra_cliques."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements = fake_measurements(cliques)
-        est = approximate_oracles.ApproxMirrorDescent(stepsize=1.0)
-        est.precompile(_DOMAIN, measurements, extra_cliques=[("c", "d")])
+  def test_precompile_with_extra_cliques(self):
+    """precompile() with both measurements and extra_cliques."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements = fake_measurements(cliques)
+    est = approximate_oracles.ApproxMirrorDescent(stepsize=1.0)
+    est.precompile(_DOMAIN, measurements, extra_cliques=[("c", "d")])
 
-    def test_precompile_extra_cliques_only(self):
-        """precompile() with only extra_cliques (no concrete measurements)."""
-        est = approximate_oracles.ApproxMirrorDescent(stepsize=1.0)
-        est.precompile(_DOMAIN, extra_cliques=[("a", "b"), ("b", "c")])
+  def test_precompile_extra_cliques_only(self):
+    """precompile() with only extra_cliques (no concrete measurements)."""
+    est = approximate_oracles.ApproxMirrorDescent(stepsize=1.0)
+    est.precompile(_DOMAIN, extra_cliques=[("a", "b"), ("b", "c")])

--- a/test/test_clique_utils.py
+++ b/test/test_clique_utils.py
@@ -5,76 +5,72 @@ from mbi.domain import Domain
 
 class TestCliqueUtils(unittest.TestCase):
 
-    def test_clique_mapping_no_domain(self):
-        # M1: Length 3
-        # M2: Length 4
-        # Target: ('A', 'B') supported by both.
-        # Should pick M1 (fewest elements).
+  def test_clique_mapping_no_domain(self):
+    # M1: Length 3
+    # M2: Length 4
+    # Target: ('A', 'B') supported by both.
+    # Should pick M1 (fewest elements).
 
-        M1 = ('A', 'B', 'C')
-        M2 = ('A', 'B', 'D', 'E')
-        maximal_cliques = [M2, M1]  # M2 comes first
-        all_cliques = [('A', 'B')]
+    M1 = ('A', 'B', 'C')
+    M2 = ('A', 'B', 'D', 'E')
+    maximal_cliques = [M2, M1]  # M2 comes first
+    all_cliques = [('A', 'B')]
 
-        # clique_mapping
-        mapping = clique_mapping(maximal_cliques, all_cliques)
-        self.assertEqual(
-            mapping[('A', 'B')], M1, 'Should pick M1 (len 3) over M2 (len 4)'
-        )
+    # clique_mapping
+    mapping = clique_mapping(maximal_cliques, all_cliques)
+    self.assertEqual(
+        mapping[('A', 'B')], M1, 'Should pick M1 (len 3) over M2 (len 4)'
+    )
 
-        # reverse_clique_mapping
-        rev_mapping = reverse_clique_mapping(maximal_cliques, all_cliques)
-        self.assertEqual(
-            rev_mapping[M1], [('A', 'B')], 'M1 should contain the clique'
-        )
-        self.assertEqual(
-            rev_mapping[M2], [], 'M2 should not contain the clique'
-        )
+    # reverse_clique_mapping
+    rev_mapping = reverse_clique_mapping(maximal_cliques, all_cliques)
+    self.assertEqual(
+        rev_mapping[M1], [('A', 'B')], 'M1 should contain the clique'
+    )
+    self.assertEqual(rev_mapping[M2], [], 'M2 should not contain the clique')
 
-    def test_clique_mapping_with_domain(self):
-        # M1: Length 3, Size 400
-        # M2: Length 4, Size 16
-        # Target: ('A', 'B')
-        # If domain provided, should pick M2 (Size 16 < 400).
-        # If domain NOT provided, should pick M1 (Length 3 < 4).
+  def test_clique_mapping_with_domain(self):
+    # M1: Length 3, Size 400
+    # M2: Length 4, Size 16
+    # Target: ('A', 'B')
+    # If domain provided, should pick M2 (Size 16 < 400).
+    # If domain NOT provided, should pick M1 (Length 3 < 4).
 
-        M1 = ('A', 'B', 'X')
-        M2 = ('A', 'B', 'C', 'D')
+    M1 = ('A', 'B', 'X')
+    M2 = ('A', 'B', 'C', 'D')
 
-        attrs = ['A', 'B', 'C', 'D', 'X']
-        shape = [2, 2, 2, 2, 100]
-        config = dict(zip(attrs, shape))
-        domain = Domain.fromdict(config)
+    attrs = ['A', 'B', 'C', 'D', 'X']
+    shape = [2, 2, 2, 2, 100]
+    config = dict(zip(attrs, shape))
+    domain = Domain.fromdict(config)
 
-        # Check sizes
-        self.assertEqual(domain.size(M1), 400)
-        self.assertEqual(domain.size(M2), 16)
+    # Check sizes
+    self.assertEqual(domain.size(M1), 400)
+    self.assertEqual(domain.size(M2), 16)
 
-        maximal_cliques = [M1, M2]  # M1 comes first and is shorter.
-        all_cliques = [('A', 'B')]
+    maximal_cliques = [M1, M2]  # M1 comes first and is shorter.
+    all_cliques = [('A', 'B')]
 
-        # Test WITH domain
-        try:
-            mapping = clique_mapping(
-                maximal_cliques, all_cliques, domain=domain
-            )
-            self.assertEqual(
-                mapping[('A', 'B')],
-                M2,
-                'Should pick M2 (size 16) over M1 (size 400)',
-            )
+    # Test WITH domain
+    try:
+      mapping = clique_mapping(maximal_cliques, all_cliques, domain=domain)
+      self.assertEqual(
+          mapping[('A', 'B')],
+          M2,
+          'Should pick M2 (size 16) over M1 (size 400)',
+      )
 
-            rev_mapping = reverse_clique_mapping(
-                maximal_cliques, all_cliques, domain=domain
-            )
-            self.assertEqual(rev_mapping[M2], [('A', 'B')])
-            self.assertEqual(rev_mapping[M1], [])
-        except TypeError:
-            self.fail(
-                'clique_mapping or reverse_clique_mapping raised TypeError,'
-                ' likely due to missing domain argument support'
-            )
+      rev_mapping = reverse_clique_mapping(
+          maximal_cliques, all_cliques, domain=domain
+      )
+      self.assertEqual(rev_mapping[M2], [('A', 'B')])
+      self.assertEqual(rev_mapping[M1], [])
+    except TypeError:
+      self.fail(
+          'clique_mapping or reverse_clique_mapping raised TypeError,'
+          ' likely due to missing domain argument support'
+      )
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -24,54 +24,54 @@ from parameterized import parameterized
 
 
 def _mapping_constraint(fine, coarse, mapping):
-    """Shorthand: build a Constraint from variable names and a mapping array."""
-    n_fine = len(mapping)
-    n_coarse = int(np.max(mapping)) + 1
-    return Constraint(
-        domain=Domain([fine, coarse], [n_fine, n_coarse]), mapping=mapping
-    )
+  """Shorthand: build a Constraint from variable names and a mapping array."""
+  n_fine = len(mapping)
+  n_coarse = int(np.max(mapping)) + 1
+  return Constraint(
+      domain=Domain([fine, coarse], [n_fine, n_coarse]), mapping=mapping
+  )
 
 
 def _make_constraint_factor(domain, constraint):
-    """Build the explicit 0/-inf constraint factor for baseline comparison."""
-    fine, coarse = constraint.domain.attributes
-    n_fine, n_coarse = constraint.domain.shape
-    shape = (n_fine, n_coarse)
-    vals = np.full(shape, -np.inf)
-    for a, a_prime in enumerate(constraint.mapping):
-        vals[a, a_prime] = 0.0
-    dom = Domain([fine, coarse], list(shape))
-    return Factor(dom, jnp.array(vals)).transpose(
-        domain.canonical(constraint.clique)
-    )
+  """Build the explicit 0/-inf constraint factor for baseline comparison."""
+  fine, coarse = constraint.domain.attributes
+  n_fine, n_coarse = constraint.domain.shape
+  shape = (n_fine, n_coarse)
+  vals = np.full(shape, -np.inf)
+  for a, a_prime in enumerate(constraint.mapping):
+    vals[a, a_prime] = 0.0
+  dom = Domain([fine, coarse], list(shape))
+  return Factor(dom, jnp.array(vals)).transpose(
+      domain.canonical(constraint.clique)
+  )
 
 
 def _baseline_marginals(domain, cliques, potentials, constraints, total=10.0):
-    """Marginals via standard Shafer-Shenoy with explicit -inf constraints."""
-    if isinstance(constraints, Constraint):
-        constraints = [constraints]
-    arrays = {cl: potentials[cl] for cl in cliques}
-    all_cliques = list(cliques)
-    for c in constraints:
-        con_cl = domain.canonical(c.clique)
-        con_factor = _make_constraint_factor(domain, c)
-        if con_cl in arrays:
-            arrays[con_cl] = arrays[con_cl] + con_factor
-        else:
-            arrays[con_cl] = con_factor
-            all_cliques.append(con_cl)
-    return message_passing_shafer_shenoy(
-        CliqueVector(domain, all_cliques, arrays), total
-    )
+  """Marginals via standard Shafer-Shenoy with explicit -inf constraints."""
+  if isinstance(constraints, Constraint):
+    constraints = [constraints]
+  arrays = {cl: potentials[cl] for cl in cliques}
+  all_cliques = list(cliques)
+  for c in constraints:
+    con_cl = domain.canonical(c.clique)
+    con_factor = _make_constraint_factor(domain, c)
+    if con_cl in arrays:
+      arrays[con_cl] = arrays[con_cl] + con_factor
+    else:
+      arrays[con_cl] = con_factor
+      all_cliques.append(con_cl)
+  return message_passing_shafer_shenoy(
+      CliqueVector(domain, all_cliques, arrays), total
+  )
 
 
 def _random_surjection(n_domain, n_range, rng):
-    """Generate a random surjective mapping from [n_domain] to [n_range]."""
-    mapping = np.zeros(n_domain, dtype=int)
-    mapping[:n_range] = np.arange(n_range)
-    mapping[n_range:] = rng.integers(0, n_range, size=n_domain - n_range)
-    rng.shuffle(mapping)
-    return mapping
+  """Generate a random surjective mapping from [n_domain] to [n_range]."""
+  mapping = np.zeros(n_domain, dtype=int)
+  mapping[:n_range] = np.arange(n_range)
+  mapping[n_range:] = rng.integers(0, n_range, size=n_domain - n_range)
+  rng.shuffle(mapping)
+  return mapping
 
 
 _EXTENSION_ORACLES = [ext_shafer_shenoy, ext_implicit]
@@ -80,25 +80,25 @@ _EXTENSION_ORACLES = [ext_shafer_shenoy, ext_implicit]
 def _assert_matches_baseline(
     test, domain, cliques, constraints, total=10.0, seed=None, oracle=None
 ):
-    """Assert constraint-aware message passing matches the -inf baseline."""
-    if seed is not None:
-        np.random.seed(seed)
-    potentials = CliqueVector.random(domain, cliques)
-    cons = tuple(
-        constraints if isinstance(constraints, (list, tuple)) else [constraints]
-    )
-    baseline = _baseline_marginals(
-        domain, cliques, potentials, constraints, total
-    )
-    for fn in [oracle] if oracle else _EXTENSION_ORACLES:
-        result = fn(potentials, total, constraints=cons)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                result[cl].datavector(),
-                baseline[cl].datavector(),
-                atol=1e-4,
-                err_msg=f'Mismatch at {cl} with {fn.__name__}',
-            )
+  """Assert constraint-aware message passing matches the -inf baseline."""
+  if seed is not None:
+    np.random.seed(seed)
+  potentials = CliqueVector.random(domain, cliques)
+  cons = tuple(
+      constraints if isinstance(constraints, (list, tuple)) else [constraints]
+  )
+  baseline = _baseline_marginals(
+      domain, cliques, potentials, constraints, total
+  )
+  for fn in [oracle] if oracle else _EXTENSION_ORACLES:
+    result = fn(potentials, total, constraints=cons)
+    for cl in cliques:
+      np.testing.assert_allclose(
+          result[cl].datavector(),
+          baseline[cl].datavector(),
+          atol=1e-4,
+          err_msg=f'Mismatch at {cl} with {fn.__name__}',
+      )
 
 
 # ---------------------------------------------------------------------------
@@ -108,56 +108,56 @@ def _assert_matches_baseline(
 
 class TestConstraintConstruction(unittest.TestCase):
 
-    def test_valid(self):
-        domain = Domain(['a', 'b'], [3, 4])
-        valid = np.array([[0, 0], [1, 2], [2, 3]])
-        c = Constraint(domain=domain, valid=valid)
-        self.assertIsNotNone(c.valid)
-        self.assertIsNone(c.invalid)
-        self.assertIsNone(c.mapping)
+  def test_valid(self):
+    domain = Domain(['a', 'b'], [3, 4])
+    valid = np.array([[0, 0], [1, 2], [2, 3]])
+    c = Constraint(domain=domain, valid=valid)
+    self.assertIsNotNone(c.valid)
+    self.assertIsNone(c.invalid)
+    self.assertIsNone(c.mapping)
 
-    def test_invalid(self):
-        domain = Domain(['a', 'b'], [3, 4])
-        invalid = np.array([[0, 1]])
-        c = Constraint(domain=domain, invalid=invalid)
-        self.assertIsNone(c.valid)
-        self.assertIsNotNone(c.invalid)
+  def test_invalid(self):
+    domain = Domain(['a', 'b'], [3, 4])
+    invalid = np.array([[0, 1]])
+    c = Constraint(domain=domain, invalid=invalid)
+    self.assertIsNone(c.valid)
+    self.assertIsNotNone(c.invalid)
 
-    def test_mapping(self):
-        domain = Domain(['fine', 'coarse'], [6, 3])
-        mapping = np.array([0, 0, 1, 1, 2, 2])
-        c = Constraint(domain=domain, mapping=mapping)
-        self.assertIsNone(c.valid)
-        self.assertTrue(c.is_deterministic)
+  def test_mapping(self):
+    domain = Domain(['fine', 'coarse'], [6, 3])
+    mapping = np.array([0, 0, 1, 1, 2, 2])
+    c = Constraint(domain=domain, mapping=mapping)
+    self.assertIsNone(c.valid)
+    self.assertTrue(c.is_deterministic)
 
-    def test_none_specified_raises(self):
-        domain = Domain(['a'], [3])
-        with self.assertRaises(ValueError):
-            Constraint(domain=domain)
+  def test_none_specified_raises(self):
+    domain = Domain(['a'], [3])
+    with self.assertRaises(ValueError):
+      Constraint(domain=domain)
 
-    def test_multiple_specified_raises(self):
-        domain = Domain(['a', 'b'], [3, 4])
-        with self.assertRaises(ValueError):
-            Constraint(
-                domain=domain,
-                valid=np.array([[0, 0]]),
-                invalid=np.array([[1, 1]]),
-            )
+  def test_multiple_specified_raises(self):
+    domain = Domain(['a', 'b'], [3, 4])
+    with self.assertRaises(ValueError):
+      Constraint(
+          domain=domain,
+          valid=np.array([[0, 0]]),
+          invalid=np.array([[1, 1]]),
+      )
 
-    def test_valid_wrong_columns_raises(self):
-        domain = Domain(['a', 'b'], [3, 4])
-        with self.assertRaises(ValueError):
-            Constraint(domain=domain, valid=np.array([[0, 0, 0]]))
+  def test_valid_wrong_columns_raises(self):
+    domain = Domain(['a', 'b'], [3, 4])
+    with self.assertRaises(ValueError):
+      Constraint(domain=domain, valid=np.array([[0, 0, 0]]))
 
-    def test_mapping_wrong_size_raises(self):
-        domain = Domain(['fine', 'coarse'], [6, 3])
-        with self.assertRaises(ValueError):
-            Constraint(domain=domain, mapping=np.array([0, 0, 1]))
+  def test_mapping_wrong_size_raises(self):
+    domain = Domain(['fine', 'coarse'], [6, 3])
+    with self.assertRaises(ValueError):
+      Constraint(domain=domain, mapping=np.array([0, 0, 1]))
 
-    def test_mapping_requires_two_attributes(self):
-        domain = Domain(['a', 'b', 'c'], [3, 3, 3])
-        with self.assertRaises(ValueError):
-            Constraint(domain=domain, mapping=np.array([0, 1, 2]))
+  def test_mapping_requires_two_attributes(self):
+    domain = Domain(['a', 'b', 'c'], [3, 3, 3])
+    with self.assertRaises(ValueError):
+      Constraint(domain=domain, mapping=np.array([0, 1, 2]))
 
 
 # ---------------------------------------------------------------------------
@@ -167,24 +167,24 @@ class TestConstraintConstruction(unittest.TestCase):
 
 class TestConstraintProperties(unittest.TestCase):
 
-    def test_clique(self):
-        domain = Domain(['b', 'a'], [3, 4])
-        c = Constraint(domain=domain, valid=np.array([[0, 0]]))
-        self.assertEqual(c.clique, ('a', 'b'))
+  def test_clique(self):
+    domain = Domain(['b', 'a'], [3, 4])
+    c = Constraint(domain=domain, valid=np.array([[0, 0]]))
+    self.assertEqual(c.clique, ('a', 'b'))
 
-    def test_is_deterministic(self):
-        domain = Domain(['fine', 'coarse'], [4, 2])
-        c_map = Constraint(domain=domain, mapping=np.array([0, 0, 1, 1]))
-        c_valid = Constraint(domain=domain, valid=np.array([[0, 0], [1, 0]]))
-        self.assertTrue(c_map.is_deterministic)
-        self.assertFalse(c_valid.is_deterministic)
+  def test_is_deterministic(self):
+    domain = Domain(['fine', 'coarse'], [4, 2])
+    c_map = Constraint(domain=domain, mapping=np.array([0, 0, 1, 1]))
+    c_valid = Constraint(domain=domain, valid=np.array([[0, 0], [1, 0]]))
+    self.assertTrue(c_map.is_deterministic)
+    self.assertFalse(c_valid.is_deterministic)
 
-    def test_mapping_sizes(self):
-        c = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
-        self.assertEqual(c.domain.shape[0], 6)
-        self.assertEqual(c.domain.shape[1], 3)
-        self.assertEqual(c.clique, ('A', 'Ap'))
-        self.assertTrue(c.is_deterministic)
+  def test_mapping_sizes(self):
+    c = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
+    self.assertEqual(c.domain.shape[0], 6)
+    self.assertEqual(c.domain.shape[1], 3)
+    self.assertEqual(c.clique, ('A', 'Ap'))
+    self.assertTrue(c.is_deterministic)
 
 
 # ---------------------------------------------------------------------------
@@ -194,69 +194,69 @@ class TestConstraintProperties(unittest.TestCase):
 
 class TestAsPotential(unittest.TestCase):
 
-    def test_valid_potential(self):
-        domain = Domain(['a', 'b'], [3, 3])
-        valid = np.array([[0, 0], [1, 1], [2, 2]])
-        c = Constraint(domain=domain, valid=valid)
-        f = c.potential
-        self.assertEqual(f.domain, domain)
-        vals = np.asarray(f.values)
-        for i in range(3):
-            for j in range(3):
-                if i == j:
-                    self.assertEqual(vals[i, j], 0.0)
-                else:
-                    self.assertEqual(vals[i, j], -np.inf)
+  def test_valid_potential(self):
+    domain = Domain(['a', 'b'], [3, 3])
+    valid = np.array([[0, 0], [1, 1], [2, 2]])
+    c = Constraint(domain=domain, valid=valid)
+    f = c.potential
+    self.assertEqual(f.domain, domain)
+    vals = np.asarray(f.values)
+    for i in range(3):
+      for j in range(3):
+        if i == j:
+          self.assertEqual(vals[i, j], 0.0)
+        else:
+          self.assertEqual(vals[i, j], -np.inf)
 
-    def test_invalid_potential(self):
-        domain = Domain(['a', 'b'], [2, 2])
-        invalid = np.array([[0, 1]])
-        c = Constraint(domain=domain, invalid=invalid)
-        f = c.potential
-        vals = np.asarray(f.values)
-        self.assertEqual(vals[0, 1], -np.inf)
-        self.assertEqual(vals[0, 0], 0.0)
-        self.assertEqual(vals[1, 0], 0.0)
-        self.assertEqual(vals[1, 1], 0.0)
+  def test_invalid_potential(self):
+    domain = Domain(['a', 'b'], [2, 2])
+    invalid = np.array([[0, 1]])
+    c = Constraint(domain=domain, invalid=invalid)
+    f = c.potential
+    vals = np.asarray(f.values)
+    self.assertEqual(vals[0, 1], -np.inf)
+    self.assertEqual(vals[0, 0], 0.0)
+    self.assertEqual(vals[1, 0], 0.0)
+    self.assertEqual(vals[1, 1], 0.0)
 
-    def test_mapping_potential(self):
-        domain = Domain(['fine', 'coarse'], [4, 2])
-        mapping = np.array([0, 0, 1, 1])
-        c = Constraint(domain=domain, mapping=mapping)
-        f = c.potential
-        vals = np.asarray(f.values)
-        self.assertEqual(vals[0, 0], 0.0)
-        self.assertEqual(vals[1, 0], 0.0)
-        self.assertEqual(vals[2, 1], 0.0)
-        self.assertEqual(vals[3, 1], 0.0)
-        self.assertEqual(vals[0, 1], -np.inf)
-        self.assertEqual(vals[2, 0], -np.inf)
+  def test_mapping_potential(self):
+    domain = Domain(['fine', 'coarse'], [4, 2])
+    mapping = np.array([0, 0, 1, 1])
+    c = Constraint(domain=domain, mapping=mapping)
+    f = c.potential
+    vals = np.asarray(f.values)
+    self.assertEqual(vals[0, 0], 0.0)
+    self.assertEqual(vals[1, 0], 0.0)
+    self.assertEqual(vals[2, 1], 0.0)
+    self.assertEqual(vals[3, 1], 0.0)
+    self.assertEqual(vals[0, 1], -np.inf)
+    self.assertEqual(vals[2, 0], -np.inf)
 
-    def test_valid_and_mapping_produce_same_potential(self):
-        """A mapping constraint should produce the same factor as the
-        equivalent valid-combos constraint."""
-        domain = Domain(['fine', 'coarse'], [6, 3])
-        mapping = np.array([0, 0, 1, 1, 2, 2])
-        valid = np.column_stack([np.arange(6), mapping])
+  def test_valid_and_mapping_produce_same_potential(self):
+    """A mapping constraint should produce the same factor as the
+    equivalent valid-combos constraint."""
+    domain = Domain(['fine', 'coarse'], [6, 3])
+    mapping = np.array([0, 0, 1, 1, 2, 2])
+    valid = np.column_stack([np.arange(6), mapping])
 
-        c_map = Constraint(domain=domain, mapping=mapping)
-        c_valid = Constraint(domain=domain, valid=valid)
+    c_map = Constraint(domain=domain, mapping=mapping)
+    c_valid = Constraint(domain=domain, valid=valid)
 
-        np.testing.assert_array_equal(
-            c_map.potential.values, c_valid.potential.values
-        )
+    np.testing.assert_array_equal(
+        c_map.potential.values, c_valid.potential.values
+    )
 
-    def test_three_way_valid(self):
-        """Constraints over 3+ attributes should work."""
-        domain = Domain(['a', 'b', 'c'], [2, 2, 2])
-        valid = np.array([[0, 0, 0], [1, 1, 1]])
-        c = Constraint(domain=domain, valid=valid)
-        f = c.potential
-        vals = np.asarray(f.values)
-        self.assertEqual(vals[0, 0, 0], 0.0)
-        self.assertEqual(vals[1, 1, 1], 0.0)
-        self.assertEqual(vals[0, 0, 1], -np.inf)
-        self.assertEqual(vals[1, 0, 0], -np.inf)
+  def test_three_way_valid(self):
+    """Constraints over 3+ attributes should work."""
+    domain = Domain(['a', 'b', 'c'], [2, 2, 2])
+    valid = np.array([[0, 0, 0], [1, 1, 1]])
+    c = Constraint(domain=domain, valid=valid)
+    f = c.potential
+    vals = np.asarray(f.values)
+    self.assertEqual(vals[0, 0, 0], 0.0)
+    self.assertEqual(vals[1, 1, 1], 0.0)
+    self.assertEqual(vals[0, 0, 1], -np.inf)
+    self.assertEqual(vals[1, 0, 0], -np.inf)
 
 
 # ---------------------------------------------------------------------------
@@ -265,133 +265,129 @@ class TestAsPotential(unittest.TestCase):
 
 
 class TestOracleIntegration(unittest.TestCase):
-    """Test that constraints flow through core marginal oracles correctly."""
+  """Test that constraints flow through core marginal oracles correctly."""
 
-    def _make_model(self):
-        domain = Domain(['A', 'B', 'C'], [3, 3, 4])
-        cliques = [('A', 'C'), ('B', 'C')]
-        np.random.seed(42)
-        arrays = {
-            cl: Factor(
-                domain.project(cl),
-                jnp.array(np.random.randn(*domain.project(cl).shape)),
-            )
-            for cl in cliques
-        }
-        return domain, cliques, CliqueVector(domain, cliques, arrays)
-
-    def _diagonal_constraint(self, domain):
-        """A=B constraint (diagonal only)."""
-        valid = np.array([[i, i] for i in range(3)])
-        return Constraint(domain=domain.project(('A', 'B')), valid=valid)
-
-    def test_shafer_shenoy_with_constraints(self):
-        from mbi import marginal_oracles
-
-        domain, cliques, potentials = self._make_model()
-        c = self._diagonal_constraint(domain)
-
-        result = marginal_oracles.message_passing_shafer_shenoy(
-            potentials, total=1.0, constraints=(c,)
+  def _make_model(self):
+    domain = Domain(['A', 'B', 'C'], [3, 3, 4])
+    cliques = [('A', 'C'), ('B', 'C')]
+    np.random.seed(42)
+    arrays = {
+        cl: Factor(
+            domain.project(cl),
+            jnp.array(np.random.randn(*domain.project(cl).shape)),
         )
-        for cl in cliques:
-            np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
+        for cl in cliques
+    }
+    return domain, cliques, CliqueVector(domain, cliques, arrays)
 
-    def test_shafer_shenoy_constraints_match_manual(self):
-        """constraints= should match manually adding the factor."""
-        from mbi import marginal_oracles
+  def _diagonal_constraint(self, domain):
+    """A=B constraint (diagonal only)."""
+    valid = np.array([[i, i] for i in range(3)])
+    return Constraint(domain=domain.project(('A', 'B')), valid=valid)
 
-        domain, cliques, potentials = self._make_model()
-        c = self._diagonal_constraint(domain)
+  def test_shafer_shenoy_with_constraints(self):
+    from mbi import marginal_oracles
 
-        result1 = marginal_oracles.message_passing_shafer_shenoy(
-            potentials, total=1.0, constraints=(c,)
+    domain, cliques, potentials = self._make_model()
+    c = self._diagonal_constraint(domain)
+
+    result = marginal_oracles.message_passing_shafer_shenoy(
+        potentials, total=1.0, constraints=(c,)
+    )
+    for cl in cliques:
+      np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
+
+  def test_shafer_shenoy_constraints_match_manual(self):
+    """constraints= should match manually adding the factor."""
+    from mbi import marginal_oracles
+
+    domain, cliques, potentials = self._make_model()
+    c = self._diagonal_constraint(domain)
+
+    result1 = marginal_oracles.message_passing_shafer_shenoy(
+        potentials, total=1.0, constraints=(c,)
+    )
+
+    # Manually add the constraint factor.
+    con_cl = domain.canonical(c.clique)
+    arrays = {cl: potentials[cl] for cl in cliques}
+    arrays[con_cl] = c.potential
+    potentials2 = CliqueVector(domain, list(cliques) + [con_cl], arrays)
+    result2 = marginal_oracles.message_passing_shafer_shenoy(
+        potentials2, total=1.0
+    )
+
+    for cl in cliques:
+      np.testing.assert_allclose(
+          np.array(result1[cl].values),
+          np.array(result2.project(cl).values),
+          atol=1e-5,
+      )
+
+  def test_implicit_with_constraints(self):
+    from mbi import marginal_oracles
+
+    domain, cliques, potentials = self._make_model()
+    c = self._diagonal_constraint(domain)
+
+    result = marginal_oracles.message_passing_implicit(
+        potentials, total=1.0, constraints=(c,)
+    )
+    for cl in cliques:
+      np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
+
+  def test_implicit_einsum_semistable_raises(self):
+    from mbi import marginal_oracles
+
+    domain, cliques, potentials = self._make_model()
+    c = self._diagonal_constraint(domain)
+
+    with self.assertRaises(ValueError):
+      marginal_oracles.message_passing_implicit(
+          potentials,
+          total=1.0,
+          constraints=(c,),
+          contraction=marginal_oracles.einsum_semistable,
+      )
+
+  def test_hugin_warns(self):
+    import warnings as w
+    from mbi import marginal_oracles
+
+    domain, cliques, potentials = self._make_model()
+    c = self._diagonal_constraint(domain)
+
+    with w.catch_warnings(record=True) as caught:
+      w.simplefilter('always')
+      marginal_oracles.message_passing_hugin(
+          potentials, total=1.0, constraints=(c,)
+      )
+    self.assertTrue(any('HUGIN' in str(warning.message) for warning in caught))
+
+  def test_mapping_constraint_through_oracle(self):
+    """Mapping constraints work through oracles."""
+    from mbi import marginal_oracles
+
+    domain = Domain(['fine', 'coarse', 'X'], [6, 3, 4])
+    mapping = np.array([0, 0, 1, 1, 2, 2])
+    c = Constraint(domain=domain.project(('fine', 'coarse')), mapping=mapping)
+
+    np.random.seed(0)
+    cliques = [('fine', 'X'), ('coarse', 'X')]
+    arrays = {
+        cl: Factor(
+            domain.project(cl),
+            jnp.array(np.random.randn(*domain.project(cl).shape)),
         )
+        for cl in cliques
+    }
+    potentials = CliqueVector(domain, cliques, arrays)
 
-        # Manually add the constraint factor.
-        con_cl = domain.canonical(c.clique)
-        arrays = {cl: potentials[cl] for cl in cliques}
-        arrays[con_cl] = c.potential
-        potentials2 = CliqueVector(domain, list(cliques) + [con_cl], arrays)
-        result2 = marginal_oracles.message_passing_shafer_shenoy(
-            potentials2, total=1.0
-        )
-
-        for cl in cliques:
-            np.testing.assert_allclose(
-                np.array(result1[cl].values),
-                np.array(result2.project(cl).values),
-                atol=1e-5,
-            )
-
-    def test_implicit_with_constraints(self):
-        from mbi import marginal_oracles
-
-        domain, cliques, potentials = self._make_model()
-        c = self._diagonal_constraint(domain)
-
-        result = marginal_oracles.message_passing_implicit(
-            potentials, total=1.0, constraints=(c,)
-        )
-        for cl in cliques:
-            np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
-
-    def test_implicit_einsum_semistable_raises(self):
-        from mbi import marginal_oracles
-
-        domain, cliques, potentials = self._make_model()
-        c = self._diagonal_constraint(domain)
-
-        with self.assertRaises(ValueError):
-            marginal_oracles.message_passing_implicit(
-                potentials,
-                total=1.0,
-                constraints=(c,),
-                contraction=marginal_oracles.einsum_semistable,
-            )
-
-    def test_hugin_warns(self):
-        import warnings as w
-        from mbi import marginal_oracles
-
-        domain, cliques, potentials = self._make_model()
-        c = self._diagonal_constraint(domain)
-
-        with w.catch_warnings(record=True) as caught:
-            w.simplefilter('always')
-            marginal_oracles.message_passing_hugin(
-                potentials, total=1.0, constraints=(c,)
-            )
-        self.assertTrue(
-            any('HUGIN' in str(warning.message) for warning in caught)
-        )
-
-    def test_mapping_constraint_through_oracle(self):
-        """Mapping constraints work through oracles."""
-        from mbi import marginal_oracles
-
-        domain = Domain(['fine', 'coarse', 'X'], [6, 3, 4])
-        mapping = np.array([0, 0, 1, 1, 2, 2])
-        c = Constraint(
-            domain=domain.project(('fine', 'coarse')), mapping=mapping
-        )
-
-        np.random.seed(0)
-        cliques = [('fine', 'X'), ('coarse', 'X')]
-        arrays = {
-            cl: Factor(
-                domain.project(cl),
-                jnp.array(np.random.randn(*domain.project(cl).shape)),
-            )
-            for cl in cliques
-        }
-        potentials = CliqueVector(domain, cliques, arrays)
-
-        result = marginal_oracles.message_passing_shafer_shenoy(
-            potentials, total=1.0, constraints=(c,)
-        )
-        for cl in cliques:
-            np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
+    result = marginal_oracles.message_passing_shafer_shenoy(
+        potentials, total=1.0, constraints=(c,)
+    )
+    for cl in cliques:
+      np.testing.assert_allclose(float(result[cl].sum()), 1.0, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------
@@ -401,97 +397,87 @@ class TestOracleIntegration(unittest.TestCase):
 
 class TestCoarsenRefine(unittest.TestCase):
 
-    def setUp(self):
-        self.mapping = np.array([0, 0, 1, 1, 2, 2])
-        self.constraint = _mapping_constraint('A', 'Ap', self.mapping)
+  def setUp(self):
+    self.mapping = np.array([0, 0, 1, 1, 2, 2])
+    self.constraint = _mapping_constraint('A', 'Ap', self.mapping)
 
-    def test_coarsen_1d(self):
-        dom = Domain(['A'], [6])
-        vals = jnp.log(jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
-        result = coarsen(Factor(dom, vals), self.constraint)
-        self.assertEqual(result.domain.attributes, ('Ap',))
-        np.testing.assert_allclose(jnp.exp(result.values), [3.0, 7.0, 11.0])
+  def test_coarsen_1d(self):
+    dom = Domain(['A'], [6])
+    vals = jnp.log(jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+    result = coarsen(Factor(dom, vals), self.constraint)
+    self.assertEqual(result.domain.attributes, ('Ap',))
+    np.testing.assert_allclose(jnp.exp(result.values), [3.0, 7.0, 11.0])
 
-    def test_refine_1d(self):
-        dom = Domain(['Ap'], [3])
-        result = refine(
-            Factor(dom, jnp.array([10.0, 20.0, 30.0])), self.constraint
-        )
-        self.assertEqual(result.domain.attributes, ('A',))
-        np.testing.assert_allclose(result.values, [10, 10, 20, 20, 30, 30])
+  def test_refine_1d(self):
+    dom = Domain(['Ap'], [3])
+    result = refine(Factor(dom, jnp.array([10.0, 20.0, 30.0])), self.constraint)
+    self.assertEqual(result.domain.attributes, ('A',))
+    np.testing.assert_allclose(result.values, [10, 10, 20, 20, 30, 30])
 
-    def test_coarsen_2d(self):
-        dom = Domain(['A', 'B'], [6, 2])
-        result = coarsen(
-            Factor(dom, jnp.log(jnp.ones((6, 2)))), self.constraint
-        )
-        self.assertEqual(result.domain.attributes, ('Ap', 'B'))
-        np.testing.assert_allclose(
-            jnp.exp(result.values), 2.0 * jnp.ones((3, 2))
-        )
+  def test_coarsen_2d(self):
+    dom = Domain(['A', 'B'], [6, 2])
+    result = coarsen(Factor(dom, jnp.log(jnp.ones((6, 2)))), self.constraint)
+    self.assertEqual(result.domain.attributes, ('Ap', 'B'))
+    np.testing.assert_allclose(jnp.exp(result.values), 2.0 * jnp.ones((3, 2)))
 
-    def test_refine_2d(self):
-        dom = Domain(['Ap', 'C'], [3, 4])
-        result = refine(
-            Factor(dom, jnp.arange(12.0).reshape(3, 4)), self.constraint
-        )
-        self.assertEqual(result.domain.attributes, ('A', 'C'))
-        # Rows 0,1 match Ap=0; rows 2,3 match Ap=1; rows 4,5 match Ap=2
-        np.testing.assert_allclose(result.values[0], result.values[1])
-        np.testing.assert_allclose(result.values[2], result.values[3])
-        np.testing.assert_allclose(result.values[4], result.values[5])
+  def test_refine_2d(self):
+    dom = Domain(['Ap', 'C'], [3, 4])
+    result = refine(
+        Factor(dom, jnp.arange(12.0).reshape(3, 4)), self.constraint
+    )
+    self.assertEqual(result.domain.attributes, ('A', 'C'))
+    # Rows 0,1 match Ap=0; rows 2,3 match Ap=1; rows 4,5 match Ap=2
+    np.testing.assert_allclose(result.values[0], result.values[1])
+    np.testing.assert_allclose(result.values[2], result.values[3])
+    np.testing.assert_allclose(result.values[4], result.values[5])
 
-    def test_roundtrip_coarsen_refine(self):
-        dom = Domain(['Ap'], [3])
-        vals = jnp.array([1.0, 2.0, 3.0])
-        recovered = coarsen(
-            refine(Factor(dom, vals), self.constraint), self.constraint
-        )
-        np.testing.assert_allclose(
-            recovered.values, vals + jnp.log(2.0), atol=1e-6
-        )
+  def test_roundtrip_coarsen_refine(self):
+    dom = Domain(['Ap'], [3])
+    vals = jnp.array([1.0, 2.0, 3.0])
+    recovered = coarsen(
+        refine(Factor(dom, vals), self.constraint), self.constraint
+    )
+    np.testing.assert_allclose(recovered.values, vals + jnp.log(2.0), atol=1e-6)
 
-    def test_project_to_coarse(self):
-        dom = Domain(['A', 'B'], [6, 2])
-        result = project_to_coarse(
-            Factor(dom, jnp.ones((6, 2))), self.constraint
-        )
-        self.assertEqual(result.domain.attributes, ('Ap', 'B'))
-        np.testing.assert_allclose(result.values, 2.0 * jnp.ones((3, 2)))
+  def test_project_to_coarse(self):
+    dom = Domain(['A', 'B'], [6, 2])
+    result = project_to_coarse(Factor(dom, jnp.ones((6, 2))), self.constraint)
+    self.assertEqual(result.domain.attributes, ('Ap', 'B'))
+    np.testing.assert_allclose(result.values, 2.0 * jnp.ones((3, 2)))
 
 
 class TestCoarsenRefineRandomized(unittest.TestCase):
-    """Property-based tests: coarsen matches explicit constraint + logsumexp."""
+  """Property-based tests: coarsen matches explicit constraint + logsumexp."""
 
-    @parameterized.expand(range(10))
-    def test_coarsen_matches_explicit(self, seed):
-        rng = np.random.default_rng(seed)
-        n_fine = rng.integers(4, 20)
-        n_coarse = rng.integers(2, n_fine)
-        mapping = _random_surjection(n_fine, n_coarse, rng)
-        constraint = _mapping_constraint('X', 'Y', mapping)
+  @parameterized.expand(range(10))
+  def test_coarsen_matches_explicit(self, seed):
+    rng = np.random.default_rng(seed)
+    n_fine = rng.integers(4, 20)
+    n_coarse = rng.integers(2, n_fine)
+    mapping = _random_surjection(n_fine, n_coarse, rng)
+    constraint = _mapping_constraint('X', 'Y', mapping)
 
-        n_other = rng.integers(2, 6)
-        dom = Domain(['X', 'Z'], [n_fine, n_other])
-        factor = Factor(dom, jnp.array(rng.standard_normal((n_fine, n_other))))
+    n_other = rng.integers(2, 6)
+    dom = Domain(['X', 'Z'], [n_fine, n_other])
+    factor = Factor(dom, jnp.array(rng.standard_normal((n_fine, n_other))))
 
-        result = coarsen(factor, constraint)
+    result = coarsen(factor, constraint)
 
-        # Reference: explicit constraint factor + logsumexp
-        con_vals = np.full((n_fine, n_coarse), -np.inf)
-        for a in range(n_fine):
-            con_vals[a, mapping[a]] = 0.0
-        joint_dom = Domain(['X', 'Y', 'Z'], [n_fine, n_coarse, n_other])
-        joint = factor.expand(joint_dom) + Factor(
-            Domain(['X', 'Y'], [n_fine, n_coarse]), jnp.array(con_vals)
-        ).expand(joint_dom)
-        reference = joint.logsumexp(['X'])
+    # Reference: explicit constraint factor + logsumexp
+    con_vals = np.full((n_fine, n_coarse), -np.inf)
+    for a in range(n_fine):
+      con_vals[a, mapping[a]] = 0.0
+    joint_dom = Domain(['X', 'Y', 'Z'], [n_fine, n_coarse, n_other])
+    joint = factor.expand(joint_dom) + Factor(
+        Domain(['X', 'Y'], [n_fine, n_coarse]), jnp.array(con_vals)
+    ).expand(joint_dom)
+    reference = joint.logsumexp(['X'])
 
-        np.testing.assert_allclose(
-            result.values,
-            reference.transpose(result.domain.attributes).values,
-            atol=1e-5,
-        )
+    np.testing.assert_allclose(
+        result.values,
+        reference.transpose(result.domain.attributes).values,
+        atol=1e-5,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -511,49 +497,43 @@ _CLIQUE_CONFIGS = [
 
 
 class TestExtensionMessagePassing(unittest.TestCase):
-    """Extension oracles match the -inf baseline."""
+  """Extension oracles match the -inf baseline."""
 
-    @parameterized.expand([
-        (fn, cliques, total)
-        for fn in _EXTENSION_ORACLES
-        for cliques in _CLIQUE_CONFIGS
-        for total in [1.0, 10.0, 100.0]
-    ])
-    def test_uniform_sums_to_total(self, fn, cliques, total):
-        potentials = CliqueVector.zeros(_SIMPLE_DOMAIN, cliques)
-        result = fn(potentials, total, constraints=(_SIMPLE_CONSTRAINT,))
-        for cl in cliques:
-            np.testing.assert_allclose(
-                result[cl].values.sum(), total, atol=1e-4
-            )
+  @parameterized.expand([
+      (fn, cliques, total)
+      for fn in _EXTENSION_ORACLES
+      for cliques in _CLIQUE_CONFIGS
+      for total in [1.0, 10.0, 100.0]
+  ])
+  def test_uniform_sums_to_total(self, fn, cliques, total):
+    potentials = CliqueVector.zeros(_SIMPLE_DOMAIN, cliques)
+    result = fn(potentials, total, constraints=(_SIMPLE_CONSTRAINT,))
+    for cl in cliques:
+      np.testing.assert_allclose(result[cl].values.sum(), total, atol=1e-4)
 
-    @parameterized.expand([(c,) for c in _CLIQUE_CONFIGS])
-    def test_matches_baseline(self, cliques):
-        _assert_matches_baseline(
-            self, _SIMPLE_DOMAIN, cliques, _SIMPLE_CONSTRAINT, total=10.0
-        )
+  @parameterized.expand([(c,) for c in _CLIQUE_CONFIGS])
+  def test_matches_baseline(self, cliques):
+    _assert_matches_baseline(
+        self, _SIMPLE_DOMAIN, cliques, _SIMPLE_CONSTRAINT, total=10.0
+    )
 
-    @parameterized.expand([
-        (fn, cliques)
-        for fn in _EXTENSION_ORACLES
-        for cliques in _CLIQUE_CONFIGS
-    ])
-    def test_no_nans(self, fn, cliques):
-        potentials = CliqueVector.random(_SIMPLE_DOMAIN, cliques)
-        result = fn(potentials, 10.0, constraints=(_SIMPLE_CONSTRAINT,))
-        for cl in cliques:
-            self.assertFalse(jnp.isnan(result[cl].values).any())
+  @parameterized.expand([
+      (fn, cliques) for fn in _EXTENSION_ORACLES for cliques in _CLIQUE_CONFIGS
+  ])
+  def test_no_nans(self, fn, cliques):
+    potentials = CliqueVector.random(_SIMPLE_DOMAIN, cliques)
+    result = fn(potentials, 10.0, constraints=(_SIMPLE_CONSTRAINT,))
+    for cl in cliques:
+      self.assertFalse(jnp.isnan(result[cl].values).any())
 
-    @parameterized.expand([
-        (fn, cliques)
-        for fn in _EXTENSION_ORACLES
-        for cliques in _CLIQUE_CONFIGS
-    ])
-    def test_non_negative(self, fn, cliques):
-        potentials = CliqueVector.random(_SIMPLE_DOMAIN, cliques)
-        result = fn(potentials, 10.0, constraints=(_SIMPLE_CONSTRAINT,))
-        for cl in cliques:
-            self.assertTrue((result[cl].values >= -1e-10).all())
+  @parameterized.expand([
+      (fn, cliques) for fn in _EXTENSION_ORACLES for cliques in _CLIQUE_CONFIGS
+  ])
+  def test_non_negative(self, fn, cliques):
+    potentials = CliqueVector.random(_SIMPLE_DOMAIN, cliques)
+    result = fn(potentials, 10.0, constraints=(_SIMPLE_CONSTRAINT,))
+    for cl in cliques:
+      self.assertTrue((result[cl].values >= -1e-10).all())
 
 
 # ---------------------------------------------------------------------------
@@ -562,61 +542,57 @@ class TestExtensionMessagePassing(unittest.TestCase):
 
 
 class TestMultipleConstraints(unittest.TestCase):
-    """Tests with two deterministic constraints."""
+  """Tests with two deterministic constraints."""
 
-    def _two_constraint_setup(self):
-        domain = Domain(['A', 'Ap', 'B', 'Bp', 'C'], [6, 3, 8, 4, 5])
-        c1 = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
-        c2 = _mapping_constraint('B', 'Bp', np.array([0, 0, 1, 1, 2, 2, 3, 3]))
-        return domain, (c1, c2)
+  def _two_constraint_setup(self):
+    domain = Domain(['A', 'Ap', 'B', 'Bp', 'C'], [6, 3, 8, 4, 5])
+    c1 = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
+    c2 = _mapping_constraint('B', 'Bp', np.array([0, 0, 1, 1, 2, 2, 3, 3]))
+    return domain, (c1, c2)
 
-    def test_two_constraints_basic(self):
-        domain, constraints = self._two_constraint_setup()
-        _assert_matches_baseline(
-            self, domain, [('A', 'C'), ('Ap', 'Bp'), ('B',)], constraints
-        )
-
-    def test_two_constraints_shared_factor(self):
-        domain, constraints = self._two_constraint_setup()
-        _assert_matches_baseline(
-            self, domain, [('A',), ('B',), ('Ap', 'Bp')], constraints
-        )
-
-    def test_two_constraints_fine_and_coarse_mixed(self):
-        domain, constraints = self._two_constraint_setup()
-        _assert_matches_baseline(
-            self, domain, [('A', 'Bp'), ('B', 'Ap')], constraints
-        )
-
-    @parameterized.expand(
-        [(fn, seed) for fn in _EXTENSION_ORACLES for seed in range(10)]
+  def test_two_constraints_basic(self):
+    domain, constraints = self._two_constraint_setup()
+    _assert_matches_baseline(
+        self, domain, [('A', 'C'), ('Ap', 'Bp'), ('B',)], constraints
     )
-    def test_two_constraints_randomized(self, fn, seed):
-        rng = np.random.default_rng(seed)
-        n_a, n_ap = rng.integers(4, 12), rng.integers(2, 4)
-        n_b, n_bp = rng.integers(4, 12), rng.integers(2, 4)
-        n_c = rng.integers(2, 6)
 
-        domain = Domain(
-            ['A', 'Ap', 'B', 'Bp', 'C'], [n_a, n_ap, n_b, n_bp, n_c]
-        )
-        c1 = _mapping_constraint('A', 'Ap', _random_surjection(n_a, n_ap, rng))
-        c2 = _mapping_constraint('B', 'Bp', _random_surjection(n_b, n_bp, rng))
-        cliques = [('A', 'C'), ('Bp',)]
-        total = 10.0
+  def test_two_constraints_shared_factor(self):
+    domain, constraints = self._two_constraint_setup()
+    _assert_matches_baseline(
+        self, domain, [('A',), ('B',), ('Ap', 'Bp')], constraints
+    )
 
-        potentials = CliqueVector.random(domain, cliques)
-        baseline = _baseline_marginals(
-            domain, cliques, potentials, [c1, c2], total
-        )
-        result = fn(potentials, total, constraints=(c1, c2))
-        for cl in cliques:
-            np.testing.assert_allclose(
-                result[cl].datavector(),
-                baseline[cl].datavector(),
-                atol=1e-4,
-                err_msg=f'Seed {seed}, clique {cl}, {fn.__name__}',
-            )
+  def test_two_constraints_fine_and_coarse_mixed(self):
+    domain, constraints = self._two_constraint_setup()
+    _assert_matches_baseline(
+        self, domain, [('A', 'Bp'), ('B', 'Ap')], constraints
+    )
+
+  @parameterized.expand(
+      [(fn, seed) for fn in _EXTENSION_ORACLES for seed in range(10)]
+  )
+  def test_two_constraints_randomized(self, fn, seed):
+    rng = np.random.default_rng(seed)
+    n_a, n_ap = rng.integers(4, 12), rng.integers(2, 4)
+    n_b, n_bp = rng.integers(4, 12), rng.integers(2, 4)
+    n_c = rng.integers(2, 6)
+
+    domain = Domain(['A', 'Ap', 'B', 'Bp', 'C'], [n_a, n_ap, n_b, n_bp, n_c])
+    c1 = _mapping_constraint('A', 'Ap', _random_surjection(n_a, n_ap, rng))
+    c2 = _mapping_constraint('B', 'Bp', _random_surjection(n_b, n_bp, rng))
+    cliques = [('A', 'C'), ('Bp',)]
+    total = 10.0
+
+    potentials = CliqueVector.random(domain, cliques)
+    baseline = _baseline_marginals(domain, cliques, potentials, [c1, c2], total)
+    result = fn(potentials, total, constraints=(c1, c2))
+    for cl in cliques:
+      np.testing.assert_allclose(
+          result[cl].datavector(),
+          baseline[cl].datavector(),
+          atol=1e-4,
+          err_msg=f'Seed {seed}, clique {cl}, {fn.__name__}',
+      )
 
 
 # ---------------------------------------------------------------------------
@@ -625,110 +601,110 @@ class TestMultipleConstraints(unittest.TestCase):
 
 
 class TestComplexTopologies(unittest.TestCase):
-    """Tests with more complex graph structures."""
+  """Tests with more complex graph structures."""
 
-    _CONSTRAINT = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
+  _CONSTRAINT = _mapping_constraint('A', 'Ap', np.array([0, 0, 1, 1, 2, 2]))
 
-    def _check(self, domain, cliques, constraint=None):
-        _assert_matches_baseline(
-            self, domain, cliques, constraint or self._CONSTRAINT
-        )
+  def _check(self, domain, cliques, constraint=None):
+    _assert_matches_baseline(
+        self, domain, cliques, constraint or self._CONSTRAINT
+    )
 
-    def test_many_neighbors(self):
-        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [6, 3, 4, 5, 3])
-        self._check(domain, [('A', 'B'), ('A', 'C'), ('Ap', 'D')])
+  def test_many_neighbors(self):
+    domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [6, 3, 4, 5, 3])
+    self._check(domain, [('A', 'B'), ('A', 'C'), ('Ap', 'D')])
 
-    def test_singletons(self):
-        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
-        self._check(domain, [('A',), ('Ap',), ('B',)])
+  def test_singletons(self):
+    domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+    self._check(domain, [('A',), ('Ap',), ('B',)])
 
-    def test_fine_in_multiple_factors(self):
-        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
-        constraint = _mapping_constraint(
-            'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
-        )
-        self._check(
-            domain, [('A', 'B'), ('A', 'C'), ('A', 'D'), ('Ap',)], constraint
-        )
+  def test_fine_in_multiple_factors(self):
+    domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
+    constraint = _mapping_constraint(
+        'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
+    )
+    self._check(
+        domain, [('A', 'B'), ('A', 'C'), ('A', 'D'), ('Ap',)], constraint
+    )
 
-    def test_coarse_in_multiple_factors(self):
-        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
-        constraint = _mapping_constraint(
-            'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
-        )
-        self._check(
-            domain, [('A',), ('Ap', 'B'), ('Ap', 'C'), ('Ap', 'D')], constraint
-        )
+  def test_coarse_in_multiple_factors(self):
+    domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [10, 3, 4, 5, 3])
+    constraint = _mapping_constraint(
+        'A', 'Ap', np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])
+    )
+    self._check(
+        domain, [('A',), ('Ap', 'B'), ('Ap', 'C'), ('Ap', 'D')], constraint
+    )
 
-    def test_uneven_groups(self):
-        domain = Domain(['A', 'Ap', 'B'], [10, 3, 4])
-        constraint = _mapping_constraint(
-            'A', 'Ap', np.array([0, 1, 2, 2, 2, 2, 2, 2, 2, 2])
-        )
-        self._check(domain, [('A', 'B'), ('Ap',)], constraint)
+  def test_uneven_groups(self):
+    domain = Domain(['A', 'Ap', 'B'], [10, 3, 4])
+    constraint = _mapping_constraint(
+        'A', 'Ap', np.array([0, 1, 2, 2, 2, 2, 2, 2, 2, 2])
+    )
+    self._check(domain, [('A', 'B'), ('Ap',)], constraint)
 
-    def test_large_ratio(self):
-        n_fine, n_coarse = 50, 5
-        mapping = np.repeat(np.arange(n_coarse), n_fine // n_coarse)
-        domain = Domain(['A', 'Ap', 'B'], [n_fine, n_coarse, 8])
-        constraint = _mapping_constraint('A', 'Ap', mapping)
-        self._check(domain, [('A', 'B'), ('Ap',)], constraint)
+  def test_large_ratio(self):
+    n_fine, n_coarse = 50, 5
+    mapping = np.repeat(np.arange(n_coarse), n_fine // n_coarse)
+    domain = Domain(['A', 'Ap', 'B'], [n_fine, n_coarse, 8])
+    constraint = _mapping_constraint('A', 'Ap', mapping)
+    self._check(domain, [('A', 'B'), ('Ap',)], constraint)
 
-    def test_disconnected_components(self):
-        domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [6, 3, 4, 5, 3])
-        self._check(domain, [('A', 'B'), ('Ap',), ('C', 'D')])
+  def test_disconnected_components(self):
+    domain = Domain(['A', 'Ap', 'B', 'C', 'D'], [6, 3, 4, 5, 3])
+    self._check(domain, [('A', 'B'), ('Ap',), ('C', 'D')])
 
-    def test_user_clique_spans_constraint_pair(self):
-        """User provides a clique (A, Ap) that matches the constraint pair."""
-        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
-        self._check(domain, [('A', 'Ap'), ('A', 'B')])
+  def test_user_clique_spans_constraint_pair(self):
+    """User provides a clique (A, Ap) that matches the constraint pair."""
+    domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+    self._check(domain, [('A', 'Ap'), ('A', 'B')])
 
-    def test_user_clique_is_fine_coarse_plus_extra(self):
-        """User clique (A, Ap, B) embeds constraint in a 3-way factor."""
-        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
-        self._check(domain, [('A', 'Ap', 'B')])
+  def test_user_clique_is_fine_coarse_plus_extra(self):
+    """User clique (A, Ap, B) embeds constraint in a 3-way factor."""
+    domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+    self._check(domain, [('A', 'Ap', 'B')])
 
-    def test_identity_mapping(self):
-        """1:1 mapping (permutation) — degenerate constraint."""
-        domain = Domain(['A', 'Ap', 'B'], [4, 4, 5])
-        constraint = _mapping_constraint('A', 'Ap', np.array([0, 1, 2, 3]))
-        self._check(domain, [('A', 'B'), ('Ap',)], constraint)
+  def test_identity_mapping(self):
+    """1:1 mapping (permutation) — degenerate constraint."""
+    domain = Domain(['A', 'Ap', 'B'], [4, 4, 5])
+    constraint = _mapping_constraint('A', 'Ap', np.array([0, 1, 2, 3]))
+    self._check(domain, [('A', 'B'), ('Ap',)], constraint)
 
-    def test_orphan_coarse_variable(self):
-        """Coarse variable appears only via constraint, not in any user clique."""
-        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
-        self._check(domain, [('A', 'B')])
+  def test_orphan_coarse_variable(self):
+    """Coarse variable appears only via constraint, not in any user clique."""
+    domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+    self._check(domain, [('A', 'B')])
 
-    def test_orphan_fine_variable(self):
-        """Fine variable appears only via constraint, not in any user clique."""
-        domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
-        self._check(domain, [('Ap', 'B')])
+  def test_orphan_fine_variable(self):
+    """Fine variable appears only via constraint, not in any user clique."""
+    domain = Domain(['A', 'Ap', 'B'], [6, 3, 4])
+    self._check(domain, [('Ap', 'B')])
 
-    def test_cyclic_model(self):
-        """Cyclic model structure (requires triangulation)."""
-        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
-        self._check(domain, [('A', 'B'), ('B', 'C'), ('Ap', 'C')])
+  def test_cyclic_model(self):
+    """Cyclic model structure (requires triangulation)."""
+    domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+    self._check(domain, [('A', 'B'), ('B', 'C'), ('Ap', 'C')])
 
-    def test_only_constraint_variables(self):
-        """All cliques reference only constraint variables."""
-        domain = Domain(['A', 'Ap'], [6, 3])
-        self._check(domain, [('A',), ('Ap',)])
+  def test_only_constraint_variables(self):
+    """All cliques reference only constraint variables."""
+    domain = Domain(['A', 'Ap'], [6, 3])
+    self._check(domain, [('A',), ('Ap',)])
 
-    def test_fine_and_coarse_singletons(self):
-        """Both fine and coarse as singleton user cliques."""
-        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
-        self._check(domain, [('A',), ('Ap',), ('A', 'B'), ('Ap', 'C')])
+  def test_fine_and_coarse_singletons(self):
+    """Both fine and coarse as singleton user cliques."""
+    domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+    self._check(domain, [('A',), ('Ap',), ('A', 'B'), ('Ap', 'C')])
 
-    def test_all_variables_in_one_clique(self):
-        """All variables including constraint pair in a single clique."""
-        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
-        self._check(domain, [('A', 'Ap', 'B', 'C')])
+  def test_all_variables_in_one_clique(self):
+    """All variables including constraint pair in a single clique."""
+    domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+    self._check(domain, [('A', 'Ap', 'B', 'C')])
 
-    def test_shared_constraint_separator(self):
-        """Two embedded cliques sharing (fine, coarse) as the separator."""
-        domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
-        self._check(domain, [('A', 'Ap', 'B'), ('A', 'Ap', 'C')])
+  def test_shared_constraint_separator(self):
+    """Two embedded cliques sharing (fine, coarse) as the separator."""
+    domain = Domain(['A', 'Ap', 'B', 'C'], [6, 3, 4, 5])
+    self._check(domain, [('A', 'Ap', 'B'), ('A', 'Ap', 'C')])
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -8,241 +8,231 @@ from mbi.dataset import Dataset, JaxDataset
 
 class TestDomain(unittest.TestCase):
 
-    def setUp(self):
-        attrs = ['a', 'b', 'c', 'd']
-        shape = [3, 4, 5, 6]
-        domain = Domain(attrs, shape)
-        self.data = Dataset.synthetic(domain, 100)
+  def setUp(self):
+    attrs = ['a', 'b', 'c', 'd']
+    shape = [3, 4, 5, 6]
+    domain = Domain(attrs, shape)
+    self.data = Dataset.synthetic(domain, 100)
 
-    def test_project(self):
-        proj = self.data.project(['a', 'b'])
-        ans = Domain(['a', 'b'], [3, 4])
-        self.assertEqual(proj.domain, ans)
-        proj = self.data.project(('a', 'b'))
-        self.assertEqual(proj.domain, ans)
-        proj = self.data.project('c')
-        self.assertEqual(proj.domain, Domain(['c'], [5]))
+  def test_project(self):
+    proj = self.data.project(['a', 'b'])
+    ans = Domain(['a', 'b'], [3, 4])
+    self.assertEqual(proj.domain, ans)
+    proj = self.data.project(('a', 'b'))
+    self.assertEqual(proj.domain, ans)
+    proj = self.data.project('c')
+    self.assertEqual(proj.domain, Domain(['c'], [5]))
 
-    def test_datavector(self):
-        vec = self.data.datavector()
-        self.assertTrue(vec.size, 3 * 4 * 5 * 6)
+  def test_datavector(self):
+    vec = self.data.datavector()
+    self.assertTrue(vec.size, 3 * 4 * 5 * 6)
 
 
 class TestDatasetDeterministic(unittest.TestCase):
 
-    def setUp(self):
-        attrs = ['A', 'B']
-        shape = [2, 3]
-        self.domain = Domain(attrs, shape)
+  def setUp(self):
+    attrs = ['A', 'B']
+    shape = [2, 3]
+    self.domain = Domain(attrs, shape)
 
-        self.data_dict = {
-            'A': np.array([0, 0, 1, 0]),
-            'B': np.array([0, 1, 2, 0]),
-        }
-        self.dataset = Dataset(self.data_dict, self.domain)
+    self.data_dict = {
+        'A': np.array([0, 0, 1, 0]),
+        'B': np.array([0, 1, 2, 0]),
+    }
+    self.dataset = Dataset(self.data_dict, self.domain)
 
-        self.weights = np.array([1.0, 2.0, 0.5, 1.0])
-        self.weighted_dataset = Dataset(
-            self.data_dict, self.domain, self.weights
-        )
+    self.weights = np.array([1.0, 2.0, 0.5, 1.0])
+    self.weighted_dataset = Dataset(self.data_dict, self.domain, self.weights)
 
-    def test_datavector_unweighted(self):
-        expected = np.array([2, 1, 0, 0, 0, 1])
-        result = self.dataset.datavector(flatten=True)
-        np.testing.assert_array_equal(result, expected)
+  def test_datavector_unweighted(self):
+    expected = np.array([2, 1, 0, 0, 0, 1])
+    result = self.dataset.datavector(flatten=True)
+    np.testing.assert_array_equal(result, expected)
 
-        expected_unflat = np.array([[2, 1, 0], [0, 0, 1]])
-        result_unflat = self.dataset.datavector(flatten=False)
-        np.testing.assert_array_equal(result_unflat, expected_unflat)
+    expected_unflat = np.array([[2, 1, 0], [0, 0, 1]])
+    result_unflat = self.dataset.datavector(flatten=False)
+    np.testing.assert_array_equal(result_unflat, expected_unflat)
 
-    def test_project_unweighted(self):
-        expected_A = np.array([3, 1])
-        proj_A = self.dataset.project('A')
-        np.testing.assert_array_equal(proj_A.datavector(), expected_A)
-        self.assertEqual(proj_A.domain.attributes, ('A',))
+  def test_project_unweighted(self):
+    expected_A = np.array([3, 1])
+    proj_A = self.dataset.project('A')
+    np.testing.assert_array_equal(proj_A.datavector(), expected_A)
+    self.assertEqual(proj_A.domain.attributes, ('A',))
 
-        expected_B = np.array([2, 1, 1])
-        proj_B = self.dataset.project('B')
-        np.testing.assert_array_equal(proj_B.datavector(), expected_B)
-        self.assertEqual(proj_B.domain.attributes, ('B',))
+    expected_B = np.array([2, 1, 1])
+    proj_B = self.dataset.project('B')
+    np.testing.assert_array_equal(proj_B.datavector(), expected_B)
+    self.assertEqual(proj_B.domain.attributes, ('B',))
 
-    def test_datavector_weighted(self):
-        expected = np.array([2.0, 2.0, 0, 0, 0, 0.5])
-        result = self.weighted_dataset.datavector(flatten=True)
-        np.testing.assert_array_equal(result, expected)
+  def test_datavector_weighted(self):
+    expected = np.array([2.0, 2.0, 0, 0, 0, 0.5])
+    result = self.weighted_dataset.datavector(flatten=True)
+    np.testing.assert_array_equal(result, expected)
 
-    def test_project_weighted(self):
-        expected_A = np.array([4.0, 0.5])
-        proj_A = self.weighted_dataset.project('A')
-        np.testing.assert_array_equal(proj_A.datavector(), expected_A)
+  def test_project_weighted(self):
+    expected_A = np.array([4.0, 0.5])
+    proj_A = self.weighted_dataset.project('A')
+    np.testing.assert_array_equal(proj_A.datavector(), expected_A)
 
-        expected_B = np.array([2.0, 2.0, 0.5])
-        proj_B = self.weighted_dataset.project('B')
-        np.testing.assert_array_equal(proj_B.datavector(), expected_B)
+    expected_B = np.array([2.0, 2.0, 0.5])
+    proj_B = self.weighted_dataset.project('B')
+    np.testing.assert_array_equal(proj_B.datavector(), expected_B)
 
-    def test_project_multiple_columns(self):
-        expected = np.array([2, 1, 0, 0, 0, 1])
-        proj = self.dataset.project(['A', 'B'])
-        np.testing.assert_array_equal(proj.datavector(), expected)
+  def test_project_multiple_columns(self):
+    expected = np.array([2, 1, 0, 0, 0, 1])
+    proj = self.dataset.project(['A', 'B'])
+    np.testing.assert_array_equal(proj.datavector(), expected)
 
-    def test_compress(self):
-        domain = Domain(['a', 'b'], [3, 2])
-        data = {'a': np.array([0, 1, 2, 0, 1]), 'b': np.array([0, 1, 0, 1, 0])}
-        dataset = Dataset(data, domain)
+  def test_compress(self):
+    domain = Domain(['a', 'b'], [3, 2])
+    data = {'a': np.array([0, 1, 2, 0, 1]), 'b': np.array([0, 1, 0, 1, 0])}
+    dataset = Dataset(data, domain)
 
-        mapping = {'a': np.array([0, 1, 1])}
+    mapping = {'a': np.array([0, 1, 1])}
 
-        compressed_dataset = dataset.compress(mapping)
+    compressed_dataset = dataset.compress(mapping)
 
-        self.assertEqual(compressed_dataset.domain['a'], 2)
-        self.assertEqual(compressed_dataset.domain['b'], 2)
+    self.assertEqual(compressed_dataset.domain['a'], 2)
+    self.assertEqual(compressed_dataset.domain['b'], 2)
 
-        expected_a = np.array([0, 1, 1, 0, 1])
-        expected_b = np.array([0, 1, 0, 1, 0])
+    expected_a = np.array([0, 1, 1, 0, 1])
+    expected_b = np.array([0, 1, 0, 1, 0])
 
-        np.testing.assert_array_equal(
-            compressed_dataset.to_dict()['a'], expected_a
-        )
-        np.testing.assert_array_equal(
-            compressed_dataset.to_dict()['b'], expected_b
-        )
+    np.testing.assert_array_equal(compressed_dataset.to_dict()['a'], expected_a)
+    np.testing.assert_array_equal(compressed_dataset.to_dict()['b'], expected_b)
 
-        np.testing.assert_array_equal(
-            compressed_dataset.weights, dataset.weights
-        )
+    np.testing.assert_array_equal(compressed_dataset.weights, dataset.weights)
 
-    def test_decompress(self):
-        domain = Domain(['a', 'b'], [2, 2])
-        data = {'a': np.array([0, 1, 1, 0, 1]), 'b': np.array([0, 1, 0, 1, 0])}
-        compressed_dataset = Dataset(data, domain)
+  def test_decompress(self):
+    domain = Domain(['a', 'b'], [2, 2])
+    data = {'a': np.array([0, 1, 1, 0, 1]), 'b': np.array([0, 1, 0, 1, 0])}
+    compressed_dataset = Dataset(data, domain)
 
-        mapping = {'a': np.array([0, 1, 1])}
+    mapping = {'a': np.array([0, 1, 1])}
 
-        decompressed_dataset = compressed_dataset.decompress(mapping)
+    decompressed_dataset = compressed_dataset.decompress(mapping)
 
-        self.assertEqual(decompressed_dataset.domain['a'], 3)
-        self.assertEqual(decompressed_dataset.domain['b'], 2)
+    self.assertEqual(decompressed_dataset.domain['a'], 3)
+    self.assertEqual(decompressed_dataset.domain['b'], 2)
 
-        new_a = decompressed_dataset.to_dict()['a']
+    new_a = decompressed_dataset.to_dict()['a']
 
-        self.assertEqual(new_a[0], 0)
-        self.assertEqual(new_a[3], 0)
+    self.assertEqual(new_a[0], 0)
+    self.assertEqual(new_a[3], 0)
 
-        for i in [1, 2, 4]:
-            self.assertIn(new_a[i], [1, 2])
+    for i in [1, 2, 4]:
+      self.assertIn(new_a[i], [1, 2])
 
-        large_N = 10000
-        large_domain = Domain(['a'], [2])
-        large_data = {'a': np.ones(large_N, dtype=int)}
-        large_dataset = Dataset(large_data, large_domain)
+    large_N = 10000
+    large_domain = Domain(['a'], [2])
+    large_data = {'a': np.ones(large_N, dtype=int)}
+    large_dataset = Dataset(large_data, large_domain)
 
-        decompressed_large = large_dataset.decompress(mapping)
-        vals = decompressed_large.to_dict()['a']
-        count_1 = np.sum(vals == 1)
-        count_2 = np.sum(vals == 2)
+    decompressed_large = large_dataset.decompress(mapping)
+    vals = decompressed_large.to_dict()['a']
+    count_1 = np.sum(vals == 1)
+    count_2 = np.sum(vals == 2)
 
-        diff = abs(count_1 - count_2)
-        self.assertTrue(
-            diff < large_N * 0.1,
-            f'Difference {diff} is too large for uniform distribution',
-        )
+    diff = abs(count_1 - count_2)
+    self.assertTrue(
+        diff < large_N * 0.1,
+        f'Difference {diff} is too large for uniform distribution',
+    )
 
-    def test_validation(self):
-        domain = Domain(['a'], [3])
-        data = {'a': np.array([0, 1, 2])}
-        dataset = Dataset(data, domain)
+  def test_validation(self):
+    domain = Domain(['a'], [3])
+    data = {'a': np.array([0, 1, 2])}
+    dataset = Dataset(data, domain)
 
-        with self.assertRaises(ValueError):
-            dataset.compress({'a': np.array([0, 1])})
+    with self.assertRaises(ValueError):
+      dataset.compress({'a': np.array([0, 1])})
 
-        with self.assertRaises(ValueError):
-            dataset.compress({'a': np.array([0, -1, 1])})
+    with self.assertRaises(ValueError):
+      dataset.compress({'a': np.array([0, -1, 1])})
 
-        with self.assertRaises(ValueError):
-            dataset.compress({'a': np.array([0, 1.5, 1])})
+    with self.assertRaises(ValueError):
+      dataset.compress({'a': np.array([0, 1.5, 1])})
 
-    def test_compress_empty(self):
-        domain = Domain(['a'], [3])
-        data = {'a': np.array([], dtype=int)}
-        dataset = Dataset(data, domain, weights=np.array([]))
+  def test_compress_empty(self):
+    domain = Domain(['a'], [3])
+    data = {'a': np.array([], dtype=int)}
+    dataset = Dataset(data, domain, weights=np.array([]))
 
-        mapping = {'a': np.array([0, 1, 1])}
+    mapping = {'a': np.array([0, 1, 1])}
 
-        compressed = dataset.compress(mapping)
-        self.assertEqual(compressed.domain['a'], 2)
-        self.assertEqual(len(compressed.to_dict()['a']), 0)
+    compressed = dataset.compress(mapping)
+    self.assertEqual(compressed.domain['a'], 2)
+    self.assertEqual(len(compressed.to_dict()['a']), 0)
 
-    def test_decompress_empty(self):
-        domain = Domain(['a'], [2])
-        data = {'a': np.array([], dtype=int)}
-        dataset = Dataset(data, domain, weights=np.array([]))
+  def test_decompress_empty(self):
+    domain = Domain(['a'], [2])
+    data = {'a': np.array([], dtype=int)}
+    dataset = Dataset(data, domain, weights=np.array([]))
 
-        mapping = {'a': np.array([0, 1, 1])}
+    mapping = {'a': np.array([0, 1, 1])}
 
-        decompressed = dataset.decompress(mapping)
-        self.assertEqual(decompressed.domain['a'], 3)
-        self.assertEqual(len(decompressed.to_dict()['a']), 0)
+    decompressed = dataset.decompress(mapping)
+    self.assertEqual(decompressed.domain['a'], 3)
+    self.assertEqual(len(decompressed.to_dict()['a']), 0)
 
 
 class TestJaxDataset(unittest.TestCase):
 
-    def setUp(self):
-        self.attrs = ['a', 'b']
-        self.shape = [3, 4]
-        self.domain = Domain(self.attrs, self.shape)
+  def setUp(self):
+    self.attrs = ['a', 'b']
+    self.shape = [3, 4]
+    self.domain = Domain(self.attrs, self.shape)
 
-        # Dict input
-        self.data_dict = {'a': jnp.array([0, 1, 2]), 'b': jnp.array([0, 2, 3])}
-        self.dataset = JaxDataset(self.data_dict, self.domain)
+    # Dict input
+    self.data_dict = {'a': jnp.array([0, 1, 2]), 'b': jnp.array([0, 2, 3])}
+    self.dataset = JaxDataset(self.data_dict, self.domain)
 
-    def test_init(self):
-        # Test with dict input
-        self.assertEqual(self.dataset.records, 3)
-        self.assertTrue(isinstance(self.dataset.data, dict))
-        self.assertEqual(len(self.dataset.data), 2)
-        self.assertTrue('a' in self.dataset.data)
-        self.assertTrue('b' in self.dataset.data)
+  def test_init(self):
+    # Test with dict input
+    self.assertEqual(self.dataset.records, 3)
+    self.assertTrue(isinstance(self.dataset.data, dict))
+    self.assertEqual(len(self.dataset.data), 2)
+    self.assertTrue('a' in self.dataset.data)
+    self.assertTrue('b' in self.dataset.data)
 
-    def test_project(self):
-        # Project on "a"
-        proj = self.dataset.project(['a'])
-        self.assertEqual(proj.domain.attributes, ('a',))
-        # Factor uses flattened datavector
-        self.assertEqual(proj.datavector().size, 3)
-        np.testing.assert_array_equal(proj.datavector(), np.array([1, 1, 1]))
+  def test_project(self):
+    # Project on "a"
+    proj = self.dataset.project(['a'])
+    self.assertEqual(proj.domain.attributes, ('a',))
+    # Factor uses flattened datavector
+    self.assertEqual(proj.datavector().size, 3)
+    np.testing.assert_array_equal(proj.datavector(), np.array([1, 1, 1]))
 
-        # Project on "b"
-        proj_b = self.dataset.project(['b'])
-        # b domain size is 4. Data has 0, 2, 3.
-        # counts: 0->1, 1->0, 2->1, 3->1
-        np.testing.assert_array_equal(
-            proj_b.datavector(), np.array([1, 0, 1, 1])
-        )
+    # Project on "b"
+    proj_b = self.dataset.project(['b'])
+    # b domain size is 4. Data has 0, 2, 3.
+    # counts: 0->1, 1->0, 2->1, 3->1
+    np.testing.assert_array_equal(proj_b.datavector(), np.array([1, 0, 1, 1]))
 
-    def test_synthetic(self):
-        syn = JaxDataset.synthetic(self.domain, 10)
-        self.assertEqual(syn.records, 10)
-        self.assertTrue(isinstance(syn.data, dict))
-        self.assertEqual(len(syn.data), 2)
+  def test_synthetic(self):
+    syn = JaxDataset.synthetic(self.domain, 10)
+    self.assertEqual(syn.records, 10)
+    self.assertTrue(isinstance(syn.data, dict))
+    self.assertEqual(len(syn.data), 2)
 
-    def test_weights(self):
-        weights = jnp.array([2.0, 1.0, 0.5])
-        w_dataset = JaxDataset(self.data_dict, self.domain, weights=weights)
-        # Factor datavector matches weights
-        proj = w_dataset.project(['a', 'b'])
-        vec = proj.datavector(flatten=True)
-        # index 0 (0,0) -> weight 2.0
-        # index 6 (1,2) -> weight 1.0
-        # index 11 (2,3) -> weight 0.5
-        self.assertEqual(vec[0], 2.0)
-        self.assertEqual(vec[6], 1.0)
-        self.assertEqual(vec[11], 0.5)
+  def test_weights(self):
+    weights = jnp.array([2.0, 1.0, 0.5])
+    w_dataset = JaxDataset(self.data_dict, self.domain, weights=weights)
+    # Factor datavector matches weights
+    proj = w_dataset.project(['a', 'b'])
+    vec = proj.datavector(flatten=True)
+    # index 0 (0,0) -> weight 2.0
+    # index 6 (1,2) -> weight 1.0
+    # index 11 (2,3) -> weight 0.5
+    self.assertEqual(vec[0], 2.0)
+    self.assertEqual(vec[6], 1.0)
+    self.assertEqual(vec[11], 0.5)
 
-    def test_records_empty(self):
-        empty_dataset = JaxDataset({}, self.domain)
-        with self.assertRaises(ValueError):
-            _ = empty_dataset.records
+  def test_records_empty(self):
+    empty_dataset = JaxDataset({}, self.domain)
+    with self.assertRaises(ValueError):
+      _ = empty_dataset.records
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -4,122 +4,122 @@ from mbi.domain import Domain
 
 class TestDomain(unittest.TestCase):
 
-    def setUp(self):
-        attrs = ["a", "b", "c", "d"]
-        shape = [10, 20, 30, 40]
-        self.domain = Domain(attrs, shape)
+  def setUp(self):
+    attrs = ["a", "b", "c", "d"]
+    shape = [10, 20, 30, 40]
+    self.domain = Domain(attrs, shape)
 
-    def test_eq(self):
-        attrs = ["a", "b", "c", "d"]
-        shape = [10, 20, 30, 40]
-        ans = Domain(attrs, shape)
-        self.assertEqual(self.domain, ans)
+  def test_eq(self):
+    attrs = ["a", "b", "c", "d"]
+    shape = [10, 20, 30, 40]
+    ans = Domain(attrs, shape)
+    self.assertEqual(self.domain, ans)
 
-        attrs = ["b", "a", "c", "d"]
-        ans = Domain(attrs, shape)
-        self.assertNotEqual(self.domain, ans)
+    attrs = ["b", "a", "c", "d"]
+    ans = Domain(attrs, shape)
+    self.assertNotEqual(self.domain, ans)
 
-    def test_project(self):
-        ans = Domain(["a", "b"], [10, 20])
-        res = self.domain.project(["a", "b"])
-        self.assertEqual(ans, res)
+  def test_project(self):
+    ans = Domain(["a", "b"], [10, 20])
+    res = self.domain.project(["a", "b"])
+    self.assertEqual(ans, res)
 
-        ans = Domain(["c", "b"], [30, 20])
-        res = self.domain.project(["c", "b"])
-        self.assertEqual(ans, res)
+    ans = Domain(["c", "b"], [30, 20])
+    res = self.domain.project(["c", "b"])
+    self.assertEqual(ans, res)
 
-    def test_marginalize(self):
-        ans = Domain(["a", "b"], [10, 20])
-        res = self.domain.marginalize(["c", "d"])
-        self.assertEqual(ans, res)
+  def test_marginalize(self):
+    ans = Domain(["a", "b"], [10, 20])
+    res = self.domain.marginalize(["c", "d"])
+    self.assertEqual(ans, res)
 
-        res = self.domain.marginalize(["c", "d", "e"])
-        self.assertEqual(ans, res)
+    res = self.domain.marginalize(["c", "d", "e"])
+    self.assertEqual(ans, res)
 
-    def test_axes(self):
-        ans = (1, 3)
-        res = self.domain.axes(["b", "d"])
-        self.assertEqual(ans, res)
+  def test_axes(self):
+    ans = (1, 3)
+    res = self.domain.axes(["b", "d"])
+    self.assertEqual(ans, res)
 
-    def test_transpose(self):
-        ans = Domain(["b", "d", "a", "c"], [20, 40, 10, 30])
-        res = self.domain.project(["b", "d", "a", "c"])
-        self.assertEqual(ans, res)
+  def test_transpose(self):
+    ans = Domain(["b", "d", "a", "c"], [20, 40, 10, 30])
+    res = self.domain.project(["b", "d", "a", "c"])
+    self.assertEqual(ans, res)
 
-    def test_merge(self):
-        ans = Domain(["a", "b", "c", "d", "e", "f"], [10, 20, 30, 40, 50, 60])
-        new = Domain(["b", "d", "e", "f"], [20, 40, 50, 60])
-        res = self.domain.merge(new)
-        self.assertEqual(ans, res)
+  def test_merge(self):
+    ans = Domain(["a", "b", "c", "d", "e", "f"], [10, 20, 30, 40, 50, 60])
+    new = Domain(["b", "d", "e", "f"], [20, 40, 50, 60])
+    res = self.domain.merge(new)
+    self.assertEqual(ans, res)
 
-    def test_contains(self):
-        new = Domain(["b", "d"], [20, 40])
-        self.assertTrue(self.domain.contains(new))
+  def test_contains(self):
+    new = Domain(["b", "d"], [20, 40])
+    self.assertTrue(self.domain.contains(new))
 
-        new = Domain(["b", "e"], [20, 50])
-        self.assertFalse(self.domain.contains(new))
+    new = Domain(["b", "e"], [20, 50])
+    self.assertFalse(self.domain.contains(new))
 
-    def test_iter(self):
-        self.assertEqual(len(self.domain), 4)
-        for a, b, c in zip(self.domain, ["a", "b", "c", "d"], [10, 20, 30, 40]):
-            self.assertEqual(a, b)
-            self.assertEqual(self.domain[a], c)
+  def test_iter(self):
+    self.assertEqual(len(self.domain), 4)
+    for a, b, c in zip(self.domain, ["a", "b", "c", "d"], [10, 20, 30, 40]):
+      self.assertEqual(a, b)
+      self.assertEqual(self.domain[a], c)
 
-    def test_repeated_attributes(self):
-        with self.assertRaises(ValueError):
-            Domain(["a", "a"], [10, 20])
+  def test_repeated_attributes(self):
+    with self.assertRaises(ValueError):
+      Domain(["a", "a"], [10, 20])
 
-    def test_intersect_disjoint_domains(self):
-        other_domain = Domain(["e", "f"], [5, 6])
-        intersection = self.domain.intersect(other_domain)
-        self.assertEqual(intersection.attributes, ())
-        self.assertEqual(intersection.shape, ())
+  def test_intersect_disjoint_domains(self):
+    other_domain = Domain(["e", "f"], [5, 6])
+    intersection = self.domain.intersect(other_domain)
+    self.assertEqual(intersection.attributes, ())
+    self.assertEqual(intersection.shape, ())
 
-    def test_labels(self):
-        attrs = ["a", "b"]
-        shape = [2, 3]
-        labels = [["yes", "no"], ["small", "medium", "large"]]
-        dom = Domain(attrs, shape, labels=labels)
-        self.assertIsNotNone(dom.labels)
-        self.assertEqual(dom.labels, tuple(tuple(l) for l in labels))
+  def test_labels(self):
+    attrs = ["a", "b"]
+    shape = [2, 3]
+    labels = [["yes", "no"], ["small", "medium", "large"]]
+    dom = Domain(attrs, shape, labels=labels)
+    self.assertIsNotNone(dom.labels)
+    self.assertEqual(dom.labels, tuple(tuple(l) for l in labels))
 
-        # Test project
-        proj = dom.project(["b"])
-        self.assertEqual(proj.labels, (("small", "medium", "large"),))
+    # Test project
+    proj = dom.project(["b"])
+    self.assertEqual(proj.labels, (("small", "medium", "large"),))
 
-        # Test merge
-        dom2 = Domain(
-            ["b", "c"],
-            [3, 2],
-            labels=[["small", "medium", "large"], ["up", "down"]],
-        )
-        merged = dom.merge(dom2)
-        # expected: a, b, c
-        self.assertEqual(merged.attributes, ("a", "b", "c"))
-        # labels should be preserved
-        expected_labels = (
-            ("yes", "no"),
-            ("small", "medium", "large"),
-            ("up", "down"),
-        )
-        self.assertEqual(merged.labels, expected_labels)
+    # Test merge
+    dom2 = Domain(
+        ["b", "c"],
+        [3, 2],
+        labels=[["small", "medium", "large"], ["up", "down"]],
+    )
+    merged = dom.merge(dom2)
+    # expected: a, b, c
+    self.assertEqual(merged.attributes, ("a", "b", "c"))
+    # labels should be preserved
+    expected_labels = (
+        ("yes", "no"),
+        ("small", "medium", "large"),
+        ("up", "down"),
+    )
+    self.assertEqual(merged.labels, expected_labels)
 
-        # Test merge mismatch
-        dom3 = Domain(["c"], [2])  # no labels
-        merged_mismatch = dom.merge(dom3)
-        self.assertIsNone(merged_mismatch.labels)
+    # Test merge mismatch
+    dom3 = Domain(["c"], [2])  # no labels
+    merged_mismatch = dom.merge(dom3)
+    self.assertIsNone(merged_mismatch.labels)
 
-        # Test invalid labels
-        with self.assertRaises(ValueError):
-            Domain(
-                attrs, shape, labels=[["yes"], ["small", "medium", "large"]]
-            )  # wrong length for 'a'
+    # Test invalid labels
+    with self.assertRaises(ValueError):
+      Domain(
+          attrs, shape, labels=[["yes"], ["small", "medium", "large"]]
+      )  # wrong length for 'a'
 
-        with self.assertRaises(ValueError):
-            Domain(
-                attrs, shape, labels=[["yes", "no"]]
-            )  # wrong number of label lists
+    with self.assertRaises(ValueError):
+      Domain(
+          attrs, shape, labels=[["yes", "no"]]
+      )  # wrong number of label lists
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -9,534 +9,512 @@ np.random.seed(0)
 
 class TestCustomDotGeneral(unittest.TestCase):
 
-    def test_standard_vector_vector_inner_product(self):
-        lhs = np.array([1.0, 2.0, 3.0])
-        rhs = np.array([4.0, 5.0, 6.0])
-        expected = np.array(32.0)
-        dims = (([0], [0]), ([], []))
-        res = custom_dot_general(lhs, rhs, dims)
-        np.testing.assert_allclose(
-            res, expected, err_msg="Std Vec-Vec Inner Product"
-        )
+  def test_standard_vector_vector_inner_product(self):
+    lhs = np.array([1.0, 2.0, 3.0])
+    rhs = np.array([4.0, 5.0, 6.0])
+    expected = np.array(32.0)
+    dims = (([0], [0]), ([], []))
+    res = custom_dot_general(lhs, rhs, dims)
+    np.testing.assert_allclose(
+        res, expected, err_msg="Std Vec-Vec Inner Product"
+    )
 
-    def test_standard_matrix_vector_product(self):
-        lhs = np.array([[1.0, 2.0], [3.0, 4.0]])
-        rhs = np.array([5.0, 6.0])
-        expected = np.array([17.0, 39.0])
-        dims = (([1], [0]), ([], []))
-        res = custom_dot_general(lhs, rhs, dims)
-        np.testing.assert_allclose(res, expected, err_msg="Std Mat-Vec Product")
+  def test_standard_matrix_vector_product(self):
+    lhs = np.array([[1.0, 2.0], [3.0, 4.0]])
+    rhs = np.array([5.0, 6.0])
+    expected = np.array([17.0, 39.0])
+    dims = (([1], [0]), ([], []))
+    res = custom_dot_general(lhs, rhs, dims)
+    np.testing.assert_allclose(res, expected, err_msg="Std Mat-Vec Product")
 
-    def test_standard_matrix_matrix_product(self):
-        lhs = np.array([[1.0, 2.0], [3.0, 4.0]])
-        rhs = np.array([[5.0, 6.0], [7.0, 8.0]])
-        expected = np.array([[19.0, 22.0], [43.0, 50.0]])
-        dims = (([1], [0]), ([], []))
-        res = custom_dot_general(lhs, rhs, dims)
-        np.testing.assert_allclose(res, expected, err_msg="Std Mat-Mat Product")
+  def test_standard_matrix_matrix_product(self):
+    lhs = np.array([[1.0, 2.0], [3.0, 4.0]])
+    rhs = np.array([[5.0, 6.0], [7.0, 8.0]])
+    expected = np.array([[19.0, 22.0], [43.0, 50.0]])
+    dims = (([1], [0]), ([], []))
+    res = custom_dot_general(lhs, rhs, dims)
+    np.testing.assert_allclose(res, expected, err_msg="Std Mat-Mat Product")
 
-    def test_standard_batch_matrix_matrix(self):
-        lhs = np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
-        rhs = np.array([[[1.0, 0.0], [0.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
-        expected = np.array(
-            [[[1.0, 2.0], [3.0, 4.0]], [[11.0, 11.0], [15.0, 15.0]]]
-        )
-        dims = (([2], [1]), ([0], [0]))
-        res = custom_dot_general(lhs, rhs, dims)
-        np.testing.assert_allclose(res, expected, err_msg="Std Batch Mat-Mat")
+  def test_standard_batch_matrix_matrix(self):
+    lhs = np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+    rhs = np.array([[[1.0, 0.0], [0.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
+    expected = np.array(
+        [[[1.0, 2.0], [3.0, 4.0]], [[11.0, 11.0], [15.0, 15.0]]]
+    )
+    dims = (([2], [1]), ([0], [0]))
+    res = custom_dot_general(lhs, rhs, dims)
+    np.testing.assert_allclose(res, expected, err_msg="Std Batch Mat-Mat")
 
-    def test_log_space_vector_vector(self):
-        lhs = np.log(np.array([1.0, 2.0]))
-        rhs = np.log(np.array([3.0, 4.0]))
-        expected = np.log(11.0)
-        dims = (([0], [0]), ([], []))
-        res = custom_dot_general(
-            lhs,
-            rhs,
-            dims,
-            combine_fn=np.add,
-            reduce_fn=jax.scipy.special.logsumexp,
-        )
-        np.testing.assert_allclose(res, expected, err_msg="Log-Space Vec-Vec")
+  def test_log_space_vector_vector(self):
+    lhs = np.log(np.array([1.0, 2.0]))
+    rhs = np.log(np.array([3.0, 4.0]))
+    expected = np.log(11.0)
+    dims = (([0], [0]), ([], []))
+    res = custom_dot_general(
+        lhs,
+        rhs,
+        dims,
+        combine_fn=np.add,
+        reduce_fn=jax.scipy.special.logsumexp,
+    )
+    np.testing.assert_allclose(res, expected, err_msg="Log-Space Vec-Vec")
 
-    def test_custom_max_min_product(self):
-        lhs = np.array([[1, 6], [5, 2]])
-        rhs = np.array([[4, 3], [0, 7]])
-        expected = np.array([[4, 3], [2, 5]])
-        dims = (([1], [0]), ([], []))
-        res = custom_dot_general(
-            lhs, rhs, dims, combine_fn=np.maximum, reduce_fn=np.min
-        )
-        np.testing.assert_equal(res, expected, err_msg="Custom Max-Min Product")
+  def test_custom_max_min_product(self):
+    lhs = np.array([[1, 6], [5, 2]])
+    rhs = np.array([[4, 3], [0, 7]])
+    expected = np.array([[4, 3], [2, 5]])
+    dims = (([1], [0]), ([], []))
+    res = custom_dot_general(
+        lhs, rhs, dims, combine_fn=np.maximum, reduce_fn=np.min
+    )
+    np.testing.assert_equal(res, expected, err_msg="Custom Max-Min Product")
 
-    def test_outer_product_no_contraction(self):
-        lhs = np.array([1, 2])
-        rhs = np.array([3, 4, 5])
-        expected = np.array([[3, 4, 5], [6, 8, 10]])
-        dims = (([], []), ([], []))
-        res = custom_dot_general(lhs, rhs, dims)
-        np.testing.assert_equal(res, expected, err_msg="Outer Product")
+  def test_outer_product_no_contraction(self):
+    lhs = np.array([1, 2])
+    rhs = np.array([3, 4, 5])
+    expected = np.array([[3, 4, 5], [6, 8, 10]])
+    dims = (([], []), ([], []))
+    res = custom_dot_general(lhs, rhs, dims)
+    np.testing.assert_equal(res, expected, err_msg="Outer Product")
 
-    def test_scalar_inputs_default_ops(self):
-        lhs_s = np.array(2.0)
-        rhs_s = np.array(3.0)
-        rhs_v = np.array([3.0, 4.0])
+  def test_scalar_inputs_default_ops(self):
+    lhs_s = np.array(2.0)
+    rhs_s = np.array(3.0)
+    rhs_v = np.array([3.0, 4.0])
 
-        expected_ss = np.array(6.0)
-        dims_ss = (([], []), ([], []))
-        res_ss = custom_dot_general(lhs_s, rhs_s, dims_ss)
-        np.testing.assert_allclose(
-            res_ss, expected_ss, err_msg="Scalar-Scalar Outer"
-        )
-        assert res_ss.ndim == 0, "Scalar-Scalar output not scalar ndim"
+    expected_ss = np.array(6.0)
+    dims_ss = (([], []), ([], []))
+    res_ss = custom_dot_general(lhs_s, rhs_s, dims_ss)
+    np.testing.assert_allclose(
+        res_ss, expected_ss, err_msg="Scalar-Scalar Outer"
+    )
+    assert res_ss.ndim == 0, "Scalar-Scalar output not scalar ndim"
 
-        expected_sv = np.array([6.0, 8.0])
-        res_sv = custom_dot_general(lhs_s, rhs_v, dims_ss)
-        np.testing.assert_allclose(
-            res_sv, expected_sv, err_msg="Scalar-Vector Outer"
-        )
+    expected_sv = np.array([6.0, 8.0])
+    res_sv = custom_dot_general(lhs_s, rhs_v, dims_ss)
+    np.testing.assert_allclose(
+        res_sv, expected_sv, err_msg="Scalar-Vector Outer"
+    )
 
-        expected_vs = np.array([6.0, 8.0])
-        res_vs = custom_dot_general(rhs_v, lhs_s, dims_ss)
-        np.testing.assert_allclose(
-            res_vs, expected_vs, err_msg="Vector-Scalar Outer"
-        )
+    expected_vs = np.array([6.0, 8.0])
+    res_vs = custom_dot_general(rhs_v, lhs_s, dims_ss)
+    np.testing.assert_allclose(
+        res_vs, expected_vs, err_msg="Vector-Scalar Outer"
+    )
 
-        lhs_v_contract = np.array([2.0, 3.0])
-        rhs_v_contract = np.array([4.0, 5.0])
-        expected_contract_s = np.array(23.0)
-        dims_contract = (([0], [0]), ([], []))
-        res_contract_s = custom_dot_general(
-            lhs_v_contract, rhs_v_contract, dims_contract
-        )
-        np.testing.assert_allclose(
-            res_contract_s,
-            expected_contract_s,
-            err_msg="Scalar output from vector contraction",
-        )
-        assert (
-            res_contract_s.ndim == 0
-        ), "Scalar contraction output not scalar ndim"
+    lhs_v_contract = np.array([2.0, 3.0])
+    rhs_v_contract = np.array([4.0, 5.0])
+    expected_contract_s = np.array(23.0)
+    dims_contract = (([0], [0]), ([], []))
+    res_contract_s = custom_dot_general(
+        lhs_v_contract, rhs_v_contract, dims_contract
+    )
+    np.testing.assert_allclose(
+        res_contract_s,
+        expected_contract_s,
+        err_msg="Scalar output from vector contraction",
+    )
+    assert res_contract_s.ndim == 0, "Scalar contraction output not scalar ndim"
 
-    def test_empty_contract_batch_dims(self):
-        lhs = np.array([[1, 2], [3, 4]])
-        rhs = np.array([[5, 6], [7, 8]])
-        # For default multiply, this is equivalent to np.multiply.outer(lhs,rhs)
-        # The output of outer(a,b) is a.ravel()[:, newaxis] * b.ravel()[newaxis, :], then reshaped.
-        # Our function's output shape: (lhs_free_dims, rhs_free_dims) -> (2,2,2,2)
-        # The actual outer product `np.outer` is for vectors.
-        # A more general tensor product is:
-        expected = np.einsum(
-            "ab,cd->abcd", lhs, rhs
-        )  # This should be the correct comparison
+  def test_empty_contract_batch_dims(self):
+    lhs = np.array([[1, 2], [3, 4]])
+    rhs = np.array([[5, 6], [7, 8]])
+    # For default multiply, this is equivalent to np.multiply.outer(lhs,rhs)
+    # The output of outer(a,b) is a.ravel()[:, newaxis] * b.ravel()[newaxis, :], then reshaped.
+    # Our function's output shape: (lhs_free_dims, rhs_free_dims) -> (2,2,2,2)
+    # The actual outer product `np.outer` is for vectors.
+    # A more general tensor product is:
+    expected = np.einsum(
+        "ab,cd->abcd", lhs, rhs
+    )  # This should be the correct comparison
 
-        dims = (([], []), ([], []))
-        res = custom_dot_general(lhs, rhs, dims)
-        np.testing.assert_equal(
-            res, expected, err_msg="Tensor product via empty contract/batch"
-        )
+    dims = (([], []), ([], []))
+    res = custom_dot_general(lhs, rhs, dims)
+    np.testing.assert_equal(
+        res, expected, err_msg="Tensor product via empty contract/batch"
+    )
 
-    def test_complex_case_multiple_dims(self):
-        B, M, N, C1, C2, K_ = 2, 3, 4, 2, 2, 3
-        rng = np.random.default_rng(0)
-        lhs = rng.random((B, M, C1, C2, K_))
-        rhs = rng.random(
-            (B, N, C1, C2, K_)
-        )  # Note: original JAX test might have different shape for rhs free dim
+  def test_complex_case_multiple_dims(self):
+    B, M, N, C1, C2, K_ = 2, 3, 4, 2, 2, 3
+    rng = np.random.default_rng(0)
+    lhs = rng.random((B, M, C1, C2, K_))
+    rhs = rng.random(
+        (B, N, C1, C2, K_)
+    )  # Note: original JAX test might have different shape for rhs free dim
 
-        dims = (
-            ((2, 3, 4), (2, 3, 4)),
-            ((0,), (0,)),
-        )  # Contract C1,C2,K; Batch B
+    dims = (
+        ((2, 3, 4), (2, 3, 4)),
+        ((0,), (0,)),
+    )  # Contract C1,C2,K; Batch B
 
-        # Manual computation: res[b, m, n] = sum_{c1,c2,k} (lhs[b,m,c1,c2,k] * rhs[b,n,c1,c2,k])
-        # The free dimension of rhs is N at original index 1.
-        # After permutation, lhs_p: (B, M, C1,C2,K), rhs_p: (B, N, C1,C2,K)
-        # combine_fn (lhs_expanded(B,M,1,C1,C2,K), rhs_expanded(B,1,N,C1,C2,K))
-        # -> combined (B,M,N,C1,C2,K)
-        # reduce over last 3 dims (C1,C2,K) -> (B,M,N)
+    # Manual computation: res[b, m, n] = sum_{c1,c2,k} (lhs[b,m,c1,c2,k] * rhs[b,n,c1,c2,k])
+    # The free dimension of rhs is N at original index 1.
+    # After permutation, lhs_p: (B, M, C1,C2,K), rhs_p: (B, N, C1,C2,K)
+    # combine_fn (lhs_expanded(B,M,1,C1,C2,K), rhs_expanded(B,1,N,C1,C2,K))
+    # -> combined (B,M,N,C1,C2,K)
+    # reduce over last 3 dims (C1,C2,K) -> (B,M,N)
 
-        # This is equivalent to:
-        # einsum_path = 'bmcij,bncij->bmn' (if C1,C2,K are c,i,j respectively)
-        expected = np.einsum("bmcde,bncde->bmn", lhs, rhs)
+    # This is equivalent to:
+    # einsum_path = 'bmcij,bncij->bmn' (if C1,C2,K are c,i,j respectively)
+    expected = np.einsum("bmcde,bncde->bmn", lhs, rhs)
 
-        res = custom_dot_general(lhs, rhs, dims)
-        np.testing.assert_allclose(
-            res, expected, rtol=1e-6, err_msg="Complex multiple dim contraction"
-        )
+    res = custom_dot_general(lhs, rhs, dims)
+    np.testing.assert_allclose(
+        res, expected, rtol=1e-6, err_msg="Complex multiple dim contraction"
+    )
 
 
 class TestScanEinsum(unittest.TestCase):
 
-    def assertArraysAllClose(self, arr1, arr2, msg=None, rtol=1e-5, atol=1e-5):
-        self.assertTrue(jnp.allclose(arr1, arr2, rtol=rtol, atol=atol), msg=msg)
+  def assertArraysAllClose(self, arr1, arr2, msg=None, rtol=1e-5, atol=1e-5):
+    self.assertTrue(jnp.allclose(arr1, arr2, rtol=rtol, atol=atol), msg=msg)
 
-    def test_no_sequential(self):
-        A = jnp.arange(6, dtype=jnp.float64).reshape(2, 3)
-        B = jnp.arange(12, dtype=jnp.float64).reshape(3, 4)
-        # Matrix multiplication
-        expected = jnp.einsum("ij,jk->ik", A, B)
-        actual = scan_einsum("ij,jk->ik", A, B, sequential="")
-        self.assertArraysAllClose(expected, actual)
+  def test_no_sequential(self):
+    A = jnp.arange(6, dtype=jnp.float64).reshape(2, 3)
+    B = jnp.arange(12, dtype=jnp.float64).reshape(3, 4)
+    # Matrix multiplication
+    expected = jnp.einsum("ij,jk->ik", A, B)
+    actual = scan_einsum("ij,jk->ik", A, B, sequential="")
+    self.assertArraysAllClose(expected, actual)
 
-        # Dot product
-        x = jnp.array([1.0, 2.0, 3.0])
-        y = jnp.array([4.0, 5.0, 6.0])
-        expected_dot = jnp.einsum("i,i->", x, y)
-        actual_dot = scan_einsum("i,i->", x, y, sequential="")
-        self.assertArraysAllClose(expected_dot, actual_dot)
+    # Dot product
+    x = jnp.array([1.0, 2.0, 3.0])
+    y = jnp.array([4.0, 5.0, 6.0])
+    expected_dot = jnp.einsum("i,i->", x, y)
+    actual_dot = scan_einsum("i,i->", x, y, sequential="")
+    self.assertArraysAllClose(expected_dot, actual_dot)
 
-        # Outer product
-        expected_outer = jnp.einsum("i,j->ij", x, y)
-        actual_outer = scan_einsum("i,j->ij", x, y, sequential="")
-        self.assertArraysAllClose(expected_outer, actual_outer)
+    # Outer product
+    expected_outer = jnp.einsum("i,j->ij", x, y)
+    actual_outer = scan_einsum("i,j->ij", x, y, sequential="")
+    self.assertArraysAllClose(expected_outer, actual_outer)
 
-        # Transpose
-        expected_T = jnp.einsum("ij->ji", A)
-        actual_T = scan_einsum("ij->ji", A, sequential="")
-        self.assertArraysAllClose(expected_T, actual_T)
+    # Transpose
+    expected_T = jnp.einsum("ij->ji", A)
+    actual_T = scan_einsum("ij->ji", A, sequential="")
+    self.assertArraysAllClose(expected_T, actual_T)
 
-        # More complex
-        C = jnp.arange(8, dtype=jnp.float64).reshape(2, 4)
-        expected_complex = jnp.einsum(
-            "ij,jk,il->kl", A, B, C
-        )  # A(2,3) B(3,4) C(2,4) -> (4,4)
-        actual_complex = scan_einsum("ij,jk,il->kl", A, B, C, sequential="")
-        self.assertArraysAllClose(expected_complex, actual_complex)
+    # More complex
+    C = jnp.arange(8, dtype=jnp.float64).reshape(2, 4)
+    expected_complex = jnp.einsum(
+        "ij,jk,il->kl", A, B, C
+    )  # A(2,3) B(3,4) C(2,4) -> (4,4)
+    actual_complex = scan_einsum("ij,jk,il->kl", A, B, C, sequential="")
+    self.assertArraysAllClose(expected_complex, actual_complex)
 
-    def test_single_sequential_summed_out(self):
-        A = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(2, 3, 4)
-        B = jnp.arange(3 * 4 * 5, dtype=jnp.float64).reshape(3, 4, 5)
+  def test_single_sequential_summed_out(self):
+    A = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(2, 3, 4)
+    B = jnp.arange(3 * 4 * 5, dtype=jnp.float64).reshape(3, 4, 5)
 
-        # Sum over 'j': "ijk,jkl->il"
-        # Sequential 'j'
-        expected = jnp.einsum("ijk,jkl->il", A, B)
-        actual = scan_einsum("ijk,jkl->il", A, B, sequential="j")
-        self.assertArraysAllClose(expected, actual, msg="Sequential 'j'")
+    # Sum over 'j': "ijk,jkl->il"
+    # Sequential 'j'
+    expected = jnp.einsum("ijk,jkl->il", A, B)
+    actual = scan_einsum("ijk,jkl->il", A, B, sequential="j")
+    self.assertArraysAllClose(expected, actual, msg="Sequential 'j'")
 
-        # Sequential 'k'
-        actual_k = scan_einsum("ijk,jkl->il", A, B, sequential="k")
-        self.assertArraysAllClose(expected, actual_k, msg="Sequential 'k'")
+    # Sequential 'k'
+    actual_k = scan_einsum("ijk,jkl->il", A, B, sequential="k")
+    self.assertArraysAllClose(expected, actual_k, msg="Sequential 'k'")
 
-        # Test with a dimension of size 1
-        X = jnp.arange(2 * 1 * 3, dtype=jnp.float64).reshape(2, 1, 3)
-        Y = jnp.arange(1 * 3 * 4, dtype=jnp.float64).reshape(1, 3, 4)
-        expected_xy = jnp.einsum("ijk,jkl->il", X, Y)  # j is size 1
-        actual_xy_j = scan_einsum("ijk,jkl->il", X, Y, sequential="j")
-        self.assertArraysAllClose(
-            expected_xy, actual_xy_j, msg="Sequential 'j' with size 1"
-        )
-        actual_xy_k = scan_einsum(
-            "ijk,jkl->il", X, Y, sequential="k"
-        )  # k is size 3
-        self.assertArraysAllClose(
-            expected_xy, actual_xy_k, msg="Sequential 'k' with size 3"
-        )
+    # Test with a dimension of size 1
+    X = jnp.arange(2 * 1 * 3, dtype=jnp.float64).reshape(2, 1, 3)
+    Y = jnp.arange(1 * 3 * 4, dtype=jnp.float64).reshape(1, 3, 4)
+    expected_xy = jnp.einsum("ijk,jkl->il", X, Y)  # j is size 1
+    actual_xy_j = scan_einsum("ijk,jkl->il", X, Y, sequential="j")
+    self.assertArraysAllClose(
+        expected_xy, actual_xy_j, msg="Sequential 'j' with size 1"
+    )
+    actual_xy_k = scan_einsum(
+        "ijk,jkl->il", X, Y, sequential="k"
+    )  # k is size 3
+    self.assertArraysAllClose(
+        expected_xy, actual_xy_k, msg="Sequential 'k' with size 3"
+    )
 
-    def test_single_sequential_in_output(self):
-        A = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)
-        B = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)
+  def test_single_sequential_in_output(self):
+    A = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)
+    B = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)
 
-        # Element-wise product like: "ij,ij->ij"
-        # Sequential 'i'
-        expected = jnp.einsum("ij,ij->ij", A, B)
-        actual_i = scan_einsum("ij,ij->ij", A, B, sequential="i")
-        self.assertArraysAllClose(expected, actual_i, msg="Sequential 'i'")
+    # Element-wise product like: "ij,ij->ij"
+    # Sequential 'i'
+    expected = jnp.einsum("ij,ij->ij", A, B)
+    actual_i = scan_einsum("ij,ij->ij", A, B, sequential="i")
+    self.assertArraysAllClose(expected, actual_i, msg="Sequential 'i'")
 
-        # Sequential 'j'
-        actual_j = scan_einsum("ij,ij->ij", A, B, sequential="j")
-        self.assertArraysAllClose(expected, actual_j, msg="Sequential 'j'")
+    # Sequential 'j'
+    actual_j = scan_einsum("ij,ij->ij", A, B, sequential="j")
+    self.assertArraysAllClose(expected, actual_j, msg="Sequential 'j'")
 
-        # Broadcasting like: "i,j->ij" (sequential 'i')
-        x = jnp.array([1.0, 2.0])
-        y = jnp.array([10.0, 20.0, 30.0])
-        expected_broadcast = jnp.einsum("i,j->ij", x, y)
-        actual_broadcast_i = scan_einsum("i,j->ij", x, y, sequential="i")
-        self.assertArraysAllClose(
-            expected_broadcast, actual_broadcast_i, msg="Broadcast seq 'i'"
-        )
-        actual_broadcast_j = scan_einsum("i,j->ij", x, y, sequential="j")
-        self.assertArraysAllClose(
-            expected_broadcast, actual_broadcast_j, msg="Broadcast seq 'j'"
-        )
+    # Broadcasting like: "i,j->ij" (sequential 'i')
+    x = jnp.array([1.0, 2.0])
+    y = jnp.array([10.0, 20.0, 30.0])
+    expected_broadcast = jnp.einsum("i,j->ij", x, y)
+    actual_broadcast_i = scan_einsum("i,j->ij", x, y, sequential="i")
+    self.assertArraysAllClose(
+        expected_broadcast, actual_broadcast_i, msg="Broadcast seq 'i'"
+    )
+    actual_broadcast_j = scan_einsum("i,j->ij", x, y, sequential="j")
+    self.assertArraysAllClose(
+        expected_broadcast, actual_broadcast_j, msg="Broadcast seq 'j'"
+    )
 
-        # Batch matrix mul: "bij,bjk->bik"
-        # Sequential 'b' (batch dimension)
-        P = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(
-            2, 3, 4
-        )  # b=2, i=3, j=4
-        Q = jnp.arange(2 * 4 * 5, dtype=jnp.float64).reshape(
-            2, 4, 5
-        )  # b=2, j=4, k=5
-        expected_bmm = jnp.einsum("bij,bjk->bik", P, Q)
-        actual_bmm_b = scan_einsum("bij,bjk->bik", P, Q, sequential="b")
-        self.assertArraysAllClose(expected_bmm, actual_bmm_b, msg="BMM seq 'b'")
+    # Batch matrix mul: "bij,bjk->bik"
+    # Sequential 'b' (batch dimension)
+    P = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(
+        2, 3, 4
+    )  # b=2, i=3, j=4
+    Q = jnp.arange(2 * 4 * 5, dtype=jnp.float64).reshape(
+        2, 4, 5
+    )  # b=2, j=4, k=5
+    expected_bmm = jnp.einsum("bij,bjk->bik", P, Q)
+    actual_bmm_b = scan_einsum("bij,bjk->bik", P, Q, sequential="b")
+    self.assertArraysAllClose(expected_bmm, actual_bmm_b, msg="BMM seq 'b'")
 
-        # Sequential 'j' (summed out, but 'b' is in output) - covered by other test
-        # actual_bmm_j = scan_einsum("bij,bjk->bik", P, Q, sequential="j")
-        # self.assertArraysAllClose(expected_bmm, actual_bmm_j, msg="BMM seq 'j'")
+    # Sequential 'j' (summed out, but 'b' is in output) - covered by other test
+    # actual_bmm_j = scan_einsum("bij,bjk->bik", P, Q, sequential="j")
+    # self.assertArraysAllClose(expected_bmm, actual_bmm_j, msg="BMM seq 'j'")
 
-    def test_multiple_sequential_axes(self):
-        A = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(2, 3, 4)  # ijk
-        B = jnp.arange(3 * 4 * 5, dtype=jnp.float64).reshape(3, 4, 5)  # jkl
-        C = jnp.arange(2 * 5 * 6, dtype=jnp.float64).reshape(2, 5, 6)  # ilm
+  def test_multiple_sequential_axes(self):
+    A = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(2, 3, 4)  # ijk
+    B = jnp.arange(3 * 4 * 5, dtype=jnp.float64).reshape(3, 4, 5)  # jkl
+    C = jnp.arange(2 * 5 * 6, dtype=jnp.float64).reshape(2, 5, 6)  # ilm
 
-        # Formula: "ijk,jkl,ilm->km"
-        # i,j,l are summed out. k,m are output.
-        # Shapes: A(i=2,j=3,k=4), B(j=3,k=4,l=5), C(i=2,l=5,m=6) -> Output(k=4,m=6)
-        expected = jnp.einsum("ijk,jkl,ilm->km", A, B, C)
+    # Formula: "ijk,jkl,ilm->km"
+    # i,j,l are summed out. k,m are output.
+    # Shapes: A(i=2,j=3,k=4), B(j=3,k=4,l=5), C(i=2,l=5,m=6) -> Output(k=4,m=6)
+    expected = jnp.einsum("ijk,jkl,ilm->km", A, B, C)
 
-        # Seq "ij" (both summed out)
-        actual_ij = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="ij")
-        self.assertArraysAllClose(expected, actual_ij, msg="Sequential 'ij'")
+    # Seq "ij" (both summed out)
+    actual_ij = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="ij")
+    self.assertArraysAllClose(expected, actual_ij, msg="Sequential 'ij'")
 
-        # Seq "ji" (both summed out, order matters for scan)
-        actual_ji = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="ji")
-        self.assertArraysAllClose(expected, actual_ji, msg="Sequential 'ji'")
+    # Seq "ji" (both summed out, order matters for scan)
+    actual_ji = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="ji")
+    self.assertArraysAllClose(expected, actual_ji, msg="Sequential 'ji'")
 
-        # Seq "il" (both summed out)
-        actual_il = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="il")
-        self.assertArraysAllClose(expected, actual_il, msg="Sequential 'il'")
+    # Seq "il" (both summed out)
+    actual_il = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="il")
+    self.assertArraysAllClose(expected, actual_il, msg="Sequential 'il'")
 
-        # Seq "jl" (both summed out)
-        actual_jl = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="jl")
-        self.assertArraysAllClose(expected, actual_jl, msg="Sequential 'jl'")
+    # Seq "jl" (both summed out)
+    actual_jl = scan_einsum("ijk,jkl,ilm->km", A, B, C, sequential="jl")
+    self.assertArraysAllClose(expected, actual_jl, msg="Sequential 'jl'")
 
-        # Formula: "ijk,j->ik" (B is vector)
-        X = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(2, 3, 4)  # ijk
-        Y = jnp.arange(3, dtype=jnp.float64)  # j
-        expected_xy = jnp.einsum("ijk,j->ik", X, Y)
+    # Formula: "ijk,j->ik" (B is vector)
+    X = jnp.arange(2 * 3 * 4, dtype=jnp.float64).reshape(2, 3, 4)  # ijk
+    Y = jnp.arange(3, dtype=jnp.float64)  # j
+    expected_xy = jnp.einsum("ijk,j->ik", X, Y)
 
-        # Seq "j" (summed out) - i,k in output
-        actual_xy_j = scan_einsum("ijk,j->ik", X, Y, sequential="j")
-        self.assertArraysAllClose(
-            expected_xy, actual_xy_j, msg="Sequential 'j' for ijk,j->ik"
-        )
+    # Seq "j" (summed out) - i,k in output
+    actual_xy_j = scan_einsum("ijk,j->ik", X, Y, sequential="j")
+    self.assertArraysAllClose(
+        expected_xy, actual_xy_j, msg="Sequential 'j' for ijk,j->ik"
+    )
 
-        # Formula: "aij,bjk,ckl->abil" (a,b,c are batch dims, i,j,k are summed)
-        # Let a=2, b=2, c=2, i=3,j=4,k=5,l=3
-        T1 = jnp.array(np.random.rand(2, 3, 4), dtype=jnp.float64)  # aij
-        T2 = jnp.array(np.random.rand(2, 4, 5), dtype=jnp.float64)  # bjk
-        T3 = jnp.array(np.random.rand(2, 5, 3), dtype=jnp.float64)  # ckl
-        expected_abc = jnp.einsum("aij,bjk,ckl->abil", T1, T2, T3)
+    # Formula: "aij,bjk,ckl->abil" (a,b,c are batch dims, i,j,k are summed)
+    # Let a=2, b=2, c=2, i=3,j=4,k=5,l=3
+    T1 = jnp.array(np.random.rand(2, 3, 4), dtype=jnp.float64)  # aij
+    T2 = jnp.array(np.random.rand(2, 4, 5), dtype=jnp.float64)  # bjk
+    T3 = jnp.array(np.random.rand(2, 5, 3), dtype=jnp.float64)  # ckl
+    expected_abc = jnp.einsum("aij,bjk,ckl->abil", T1, T2, T3)
 
-        # Seq "jk" (summed out, a,b,c,l in output)
-        actual_abc_jk = scan_einsum(
-            "aij,bjk,ckl->abil", T1, T2, T3, sequential="jk"
-        )
-        self.assertArraysAllClose(
-            expected_abc,
-            actual_abc_jk,
-            msg="Sequential 'jk' for aij,bjk,ckl->abil",
-        )
+    # Seq "jk" (summed out, a,b,c,l in output)
+    actual_abc_jk = scan_einsum(
+        "aij,bjk,ckl->abil", T1, T2, T3, sequential="jk"
+    )
+    self.assertArraysAllClose(
+        expected_abc,
+        actual_abc_jk,
+        msg="Sequential 'jk' for aij,bjk,ckl->abil",
+    )
 
-        # Seq "ab" (in output)
-        actual_abc_ab = scan_einsum(
-            "aij,bjk,ckl->abil", T1, T2, T3, sequential="ab"
-        )
-        self.assertArraysAllClose(
-            expected_abc,
-            actual_abc_ab,
-            msg="Sequential 'ab' for aij,bjk,ckl->abil",
-        )
+    # Seq "ab" (in output)
+    actual_abc_ab = scan_einsum(
+        "aij,bjk,ckl->abil", T1, T2, T3, sequential="ab"
+    )
+    self.assertArraysAllClose(
+        expected_abc,
+        actual_abc_ab,
+        msg="Sequential 'ab' for aij,bjk,ckl->abil",
+    )
 
-        # Seq "aj" (a in output, j summed out)
-        actual_abc_aj = scan_einsum(
-            "aij,bjk,ckl->abil", T1, T2, T3, sequential="aj"
-        )
-        self.assertArraysAllClose(
-            expected_abc,
-            actual_abc_aj,
-            msg="Sequential 'aj' for aij,bjk,ckl->abil",
-        )
+    # Seq "aj" (a in output, j summed out)
+    actual_abc_aj = scan_einsum(
+        "aij,bjk,ckl->abil", T1, T2, T3, sequential="aj"
+    )
+    self.assertArraysAllClose(
+        expected_abc,
+        actual_abc_aj,
+        msg="Sequential 'aj' for aij,bjk,ckl->abil",
+    )
 
-        # Test all sequential axes "ijk"
-        D1 = jnp.arange(2 * 2 * 2, dtype=jnp.float64).reshape(2, 2, 2)  # ijk
-        D2 = jnp.arange(2 * 2 * 2, dtype=jnp.float64).reshape(2, 2, 2)  # jkl
-        D3 = jnp.arange(2 * 2 * 2, dtype=jnp.float64).reshape(2, 2, 2)  # kli
-        # ijk,jkl,kli -> (no output axes, scalar sum)
-        expected_all_seq = jnp.einsum("ijk,jkl,kli->", D1, D2, D3)
-        actual_all_seq_ijk = scan_einsum(
-            "ijk,jkl,kli->", D1, D2, D3, sequential="ijk"
-        )
-        self.assertArraysAllClose(
-            expected_all_seq, actual_all_seq_ijk, msg="Seq 'ijk' all summed"
-        )
-        actual_all_seq_ikj = scan_einsum(
-            "ijk,jkl,kli->", D1, D2, D3, sequential="ikj"
-        )  # order change
-        self.assertArraysAllClose(
-            expected_all_seq, actual_all_seq_ikj, msg="Seq 'ikj' all summed"
-        )
+    # Test all sequential axes "ijk"
+    D1 = jnp.arange(2 * 2 * 2, dtype=jnp.float64).reshape(2, 2, 2)  # ijk
+    D2 = jnp.arange(2 * 2 * 2, dtype=jnp.float64).reshape(2, 2, 2)  # jkl
+    D3 = jnp.arange(2 * 2 * 2, dtype=jnp.float64).reshape(2, 2, 2)  # kli
+    # ijk,jkl,kli -> (no output axes, scalar sum)
+    expected_all_seq = jnp.einsum("ijk,jkl,kli->", D1, D2, D3)
+    actual_all_seq_ijk = scan_einsum(
+        "ijk,jkl,kli->", D1, D2, D3, sequential="ijk"
+    )
+    self.assertArraysAllClose(
+        expected_all_seq, actual_all_seq_ijk, msg="Seq 'ijk' all summed"
+    )
+    actual_all_seq_ikj = scan_einsum(
+        "ijk,jkl,kli->", D1, D2, D3, sequential="ikj"
+    )  # order change
+    self.assertArraysAllClose(
+        expected_all_seq, actual_all_seq_ikj, msg="Seq 'ikj' all summed"
+    )
 
-    def test_readme_example(self):
-        # From the original problem description/context if any or a typical use case
-        # Example: trace of batch matrix products
-        # (B, N, M) @ (B, M, K) -> (B, N, K), then trace over N, K if N=K.
-        # Or contract more: A(b,i,j), C(b,j,k), D(b,k,l) -> E(b,i,l)
-        A = jnp.array(np.random.rand(2, 3, 4), dtype=jnp.float64)  # bij
-        B = jnp.array(np.random.rand(2, 4, 5), dtype=jnp.float64)  # bjk
-        C = jnp.array(np.random.rand(2, 5, 6), dtype=jnp.float64)  # bkl
-        # Result E(b,i,l) -> (2,3,6)
-        expected = jnp.einsum("bij,bjk,bkl->bil", A, B, C)
-        # Sequential over b
-        actual_b = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="b")
-        self.assertArraysAllClose(
-            expected, actual_b, msg="Chain product seq 'b'"
-        )
-        # Sequential over j
-        actual_j = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="j")
-        self.assertArraysAllClose(
-            expected, actual_j, msg="Chain product seq 'j'"
-        )
-        # Sequential over k
-        actual_k = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="k")
-        self.assertArraysAllClose(
-            expected, actual_k, msg="Chain product seq 'k'"
-        )
-        # Sequential over "jk"
-        actual_jk = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="jk")
-        self.assertArraysAllClose(
-            expected, actual_jk, msg="Chain product seq 'jk'"
-        )
-        # Sequential over "bj"
-        actual_bj = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="bj")
-        self.assertArraysAllClose(
-            expected, actual_bj, msg="Chain product seq 'bj'"
-        )
+  def test_readme_example(self):
+    # From the original problem description/context if any or a typical use case
+    # Example: trace of batch matrix products
+    # (B, N, M) @ (B, M, K) -> (B, N, K), then trace over N, K if N=K.
+    # Or contract more: A(b,i,j), C(b,j,k), D(b,k,l) -> E(b,i,l)
+    A = jnp.array(np.random.rand(2, 3, 4), dtype=jnp.float64)  # bij
+    B = jnp.array(np.random.rand(2, 4, 5), dtype=jnp.float64)  # bjk
+    C = jnp.array(np.random.rand(2, 5, 6), dtype=jnp.float64)  # bkl
+    # Result E(b,i,l) -> (2,3,6)
+    expected = jnp.einsum("bij,bjk,bkl->bil", A, B, C)
+    # Sequential over b
+    actual_b = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="b")
+    self.assertArraysAllClose(expected, actual_b, msg="Chain product seq 'b'")
+    # Sequential over j
+    actual_j = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="j")
+    self.assertArraysAllClose(expected, actual_j, msg="Chain product seq 'j'")
+    # Sequential over k
+    actual_k = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="k")
+    self.assertArraysAllClose(expected, actual_k, msg="Chain product seq 'k'")
+    # Sequential over "jk"
+    actual_jk = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="jk")
+    self.assertArraysAllClose(expected, actual_jk, msg="Chain product seq 'jk'")
+    # Sequential over "bj"
+    actual_bj = scan_einsum("bij,bjk,bkl->bil", A, B, C, sequential="bj")
+    self.assertArraysAllClose(expected, actual_bj, msg="Chain product seq 'bj'")
 
-    def test_output_only_formula(self):
+  def test_output_only_formula(self):
 
-        # Case: "a->a" where 'a' is sequential
-        X = jnp.arange(5, dtype=jnp.float64)
-        expected = jnp.einsum("a->a", X)
-        actual = scan_einsum("a->a", X, sequential="a")
-        self.assertArraysAllClose(expected, actual, msg="a->a sequential a")
+    # Case: "a->a" where 'a' is sequential
+    X = jnp.arange(5, dtype=jnp.float64)
+    expected = jnp.einsum("a->a", X)
+    actual = scan_einsum("a->a", X, sequential="a")
+    self.assertArraysAllClose(expected, actual, msg="a->a sequential a")
 
-        # Case: ",a->a" with one array (implicit ellipsis for first array)
-        # jnp.einsum interprets ",a->a" as "...,a->a"
-        # Our current _infer_shapes expects explicit labels for all arrays
-        # To support this, _infer_shapes or the parsing logic would need adjustment.
-        # For now, assume explicit labels.
-        # If this means "a,b->b" with arrays X, Y and seq='a'
-        # For "a->", seq 'a'
-        expected_sum = jnp.einsum("a->", X)
-        actual_sum = scan_einsum("a->", X, sequential="a")
-        self.assertArraysAllClose(
-            expected_sum, actual_sum, msg="a-> sequential a"
-        )
+    # Case: ",a->a" with one array (implicit ellipsis for first array)
+    # jnp.einsum interprets ",a->a" as "...,a->a"
+    # Our current _infer_shapes expects explicit labels for all arrays
+    # To support this, _infer_shapes or the parsing logic would need adjustment.
+    # For now, assume explicit labels.
+    # If this means "a,b->b" with arrays X, Y and seq='a'
+    # For "a->", seq 'a'
+    expected_sum = jnp.einsum("a->", X)
+    actual_sum = scan_einsum("a->", X, sequential="a")
+    self.assertArraysAllClose(expected_sum, actual_sum, msg="a-> sequential a")
 
-    def test_sequential_axis_not_in_all_arrays(self):
-        A = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)  # ij
-        B = jnp.arange(3 * 4, dtype=jnp.float64).reshape(3, 4)  # jk
-        C = jnp.arange(2 * 4, dtype=jnp.float64).reshape(
-            2, 4
-        )  # ik (output like)
+  def test_sequential_axis_not_in_all_arrays(self):
+    A = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)  # ij
+    B = jnp.arange(3 * 4, dtype=jnp.float64).reshape(3, 4)  # jk
+    C = jnp.arange(2 * 4, dtype=jnp.float64).reshape(2, 4)  # ik (output like)
 
-        # Formula: "ij,jk->ik"
-        expected = jnp.einsum("ij,jk->ik", A, B)
-        # Seq "i": A is sliced, B is passed as whole.
-        actual_i = scan_einsum("ij,jk->ik", A, B, sequential="i")
-        self.assertArraysAllClose(
-            expected, actual_i, msg="Seq 'i' for ij,jk->ik"
-        )
-        # Seq "j": A and B are sliced.
-        actual_j = scan_einsum("ij,jk->ik", A, B, sequential="j")
-        self.assertArraysAllClose(
-            expected, actual_j, msg="Seq 'j' for ij,jk->ik"
-        )
-        # Seq "k": B is sliced, A is passed as whole.
-        actual_k = scan_einsum("ij,jk->ik", A, B, sequential="k")
-        self.assertArraysAllClose(
-            expected, actual_k, msg="Seq 'k' for ij,jk->ik"
-        )
+    # Formula: "ij,jk->ik"
+    expected = jnp.einsum("ij,jk->ik", A, B)
+    # Seq "i": A is sliced, B is passed as whole.
+    actual_i = scan_einsum("ij,jk->ik", A, B, sequential="i")
+    self.assertArraysAllClose(expected, actual_i, msg="Seq 'i' for ij,jk->ik")
+    # Seq "j": A and B are sliced.
+    actual_j = scan_einsum("ij,jk->ik", A, B, sequential="j")
+    self.assertArraysAllClose(expected, actual_j, msg="Seq 'j' for ij,jk->ik")
+    # Seq "k": B is sliced, A is passed as whole.
+    actual_k = scan_einsum("ij,jk->ik", A, B, sequential="k")
+    self.assertArraysAllClose(expected, actual_k, msg="Seq 'k' for ij,jk->ik")
 
-        # More complex: "ab,bc,cd->ad"
-        X = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)  # ab
-        Y = jnp.arange(3 * 4, dtype=jnp.float64).reshape(3, 4)  # bc
-        Z = jnp.arange(4 * 5, dtype=jnp.float64).reshape(4, 5)  # cd
-        expected_xyz = jnp.einsum("ab,bc,cd->ad", X, Y, Z)
+    # More complex: "ab,bc,cd->ad"
+    X = jnp.arange(2 * 3, dtype=jnp.float64).reshape(2, 3)  # ab
+    Y = jnp.arange(3 * 4, dtype=jnp.float64).reshape(3, 4)  # bc
+    Z = jnp.arange(4 * 5, dtype=jnp.float64).reshape(4, 5)  # cd
+    expected_xyz = jnp.einsum("ab,bc,cd->ad", X, Y, Z)
 
-        # Seq "a": X sliced, Y,Z whole
-        actual_a = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="a")
-        self.assertArraysAllClose(
-            expected_xyz, actual_a, msg="Seq 'a' for ab,bc,cd->ad"
-        )
-        # Seq "b": X,Y sliced, Z whole
-        actual_b = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="b")
-        self.assertArraysAllClose(
-            expected_xyz, actual_b, msg="Seq 'b' for ab,bc,cd->ad"
-        )
-        # Seq "c": Y,Z sliced, X whole
-        actual_c = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="c")
-        self.assertArraysAllClose(
-            expected_xyz, actual_c, msg="Seq 'c' for ab,bc,cd->ad"
-        )
-        # Seq "d": Z sliced, X,Y whole
-        actual_d = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="d")
-        self.assertArraysAllClose(
-            expected_xyz, actual_d, msg="Seq 'd' for ab,bc,cd->ad"
-        )
-        # Seq "ac": a in X, c in Y,Z
-        actual_ac = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="ac")
-        self.assertArraysAllClose(
-            expected_xyz, actual_ac, msg="Seq 'ac' for ab,bc,cd->ad"
-        )
+    # Seq "a": X sliced, Y,Z whole
+    actual_a = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="a")
+    self.assertArraysAllClose(
+        expected_xyz, actual_a, msg="Seq 'a' for ab,bc,cd->ad"
+    )
+    # Seq "b": X,Y sliced, Z whole
+    actual_b = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="b")
+    self.assertArraysAllClose(
+        expected_xyz, actual_b, msg="Seq 'b' for ab,bc,cd->ad"
+    )
+    # Seq "c": Y,Z sliced, X whole
+    actual_c = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="c")
+    self.assertArraysAllClose(
+        expected_xyz, actual_c, msg="Seq 'c' for ab,bc,cd->ad"
+    )
+    # Seq "d": Z sliced, X,Y whole
+    actual_d = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="d")
+    self.assertArraysAllClose(
+        expected_xyz, actual_d, msg="Seq 'd' for ab,bc,cd->ad"
+    )
+    # Seq "ac": a in X, c in Y,Z
+    actual_ac = scan_einsum("ab,bc,cd->ad", X, Y, Z, sequential="ac")
+    self.assertArraysAllClose(
+        expected_xyz, actual_ac, msg="Seq 'ac' for ab,bc,cd->ad"
+    )
 
-    def test_custom_einsum_max(self):
-        from mbi.einsum import custom_einsum
+  def test_custom_einsum_max(self):
+    from mbi.einsum import custom_einsum
 
-        x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
-        y = jnp.array([[5.0, 6.0], [7.0, 8.0]])
-        # 'ij,jk->ik' with (+, max)
-        actual = custom_einsum(
-            "ij,jk->ik", x, y, combine_fn=jnp.add, reduce_fn=jnp.max
-        )
-        expected = jnp.array([[9.0, 10.0], [11.0, 12.0]])
-        self.assertArraysAllClose(
-            expected, actual, msg="custom_einsum with jnp.max"
-        )
+    x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    y = jnp.array([[5.0, 6.0], [7.0, 8.0]])
+    # 'ij,jk->ik' with (+, max)
+    actual = custom_einsum(
+        "ij,jk->ik", x, y, combine_fn=jnp.add, reduce_fn=jnp.max
+    )
+    expected = jnp.array([[9.0, 10.0], [11.0, 12.0]])
+    self.assertArraysAllClose(
+        expected, actual, msg="custom_einsum with jnp.max"
+    )
 
-    def test_custom_einsum_logsumexp(self):
-        from mbi.einsum import custom_einsum
-        from jax.scipy.special import logsumexp
+  def test_custom_einsum_logsumexp(self):
+    from mbi.einsum import custom_einsum
+    from jax.scipy.special import logsumexp
 
-        x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
-        y = jnp.array([[5.0, 6.0], [7.0, 8.0]])
-        actual = custom_einsum(
-            "ij,jk->ik", x, y, combine_fn=jnp.add, reduce_fn=logsumexp
-        )
-        expected = jnp.array([
-            [
-                logsumexp(jnp.array([6.0, 9.0])),
-                logsumexp(jnp.array([7.0, 10.0])),
-            ],
-            [
-                logsumexp(jnp.array([8.0, 11.0])),
-                logsumexp(jnp.array([9.0, 12.0])),
-            ],
-        ])
-        self.assertArraysAllClose(
-            expected, actual, msg="custom_einsum with logsumexp"
-        )
+    x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    y = jnp.array([[5.0, 6.0], [7.0, 8.0]])
+    actual = custom_einsum(
+        "ij,jk->ik", x, y, combine_fn=jnp.add, reduce_fn=logsumexp
+    )
+    expected = jnp.array([
+        [
+            logsumexp(jnp.array([6.0, 9.0])),
+            logsumexp(jnp.array([7.0, 10.0])),
+        ],
+        [
+            logsumexp(jnp.array([8.0, 11.0])),
+            logsumexp(jnp.array([9.0, 12.0])),
+        ],
+    ])
+    self.assertArraysAllClose(
+        expected, actual, msg="custom_einsum with logsumexp"
+    )
 
-    def test_custom_einsum_vmap_jit(self):
-        from mbi.einsum import custom_einsum
+  def test_custom_einsum_vmap_jit(self):
+    from mbi.einsum import custom_einsum
 
-        def f(x, y):
-            return custom_einsum(
-                "ij,jk->ik", x, y, combine_fn=jnp.add, reduce_fn=jnp.max
-            )
+    def f(x, y):
+      return custom_einsum(
+          "ij,jk->ik", x, y, combine_fn=jnp.add, reduce_fn=jnp.max
+      )
 
-        f = jax.jit(jax.vmap(f, in_axes=(0, 0)))
-        x = jnp.array([[[1.0, 2.0], [3.0, 4.0]]])
-        y = jnp.array([[[5.0, 6.0], [7.0, 8.0]]])
-        actual = f(x, y)
-        expected = jnp.array([[[9.0, 10.0], [11.0, 12.0]]])
-        self.assertArraysAllClose(
-            expected, actual, msg="custom_einsum vmap and jit"
-        )
+    f = jax.jit(jax.vmap(f, in_axes=(0, 0)))
+    x = jnp.array([[[1.0, 2.0], [3.0, 4.0]]])
+    y = jnp.array([[[5.0, 6.0], [7.0, 8.0]]])
+    actual = f(x, y)
+    expected = jnp.array([[[9.0, 10.0], [11.0, 12.0]]])
+    self.assertArraysAllClose(
+        expected, actual, msg="custom_einsum vmap and jit"
+    )
 
 
 if __name__ == "__main__":
-    unittest.main(argv=["first-arg-is-ignored"], exit=False)
+  unittest.main(argv=["first-arg-is-ignored"], exit=False)

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -24,270 +24,262 @@ _CLIQUE_SETS = [
 
 
 def fake_measurements(cliques):
-    P = Factor.random(_DOMAIN)
-    P = P / P.sum()
-    measurements = []
-    for cl in cliques:
-        y = P.project(cl).datavector()
-        measurements.append(marginal_loss.LinearMeasurement(y, cl))
-    return measurements
+  P = Factor.random(_DOMAIN)
+  P = P / P.sum()
+  measurements = []
+  for cl in cliques:
+    y = P.project(cl).datavector()
+    measurements.append(marginal_loss.LinearMeasurement(y, cl))
+  return measurements
 
 
 class TestEstimation(unittest.TestCase):
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_total_estimator(self, cliques):
-        measurements = fake_measurements(cliques)
-        total = estimation.minimum_variance_unbiased_total(measurements)
-        np.testing.assert_allclose(total, 1.0, rtol=1e-5)
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_total_estimator(self, cliques):
+    measurements = fake_measurements(cliques)
+    total = estimation.minimum_variance_unbiased_total(measurements)
+    np.testing.assert_allclose(total, 1.0, rtol=1e-5)
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_mirror_descent(self, cliques):
-        measurements = fake_measurements(cliques)
-        loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_mirror_descent(self, cliques):
+    measurements = fake_measurements(cliques)
+    loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
 
-        model = estimation.MirrorDescent().estimate(
-            _DOMAIN, loss_fn, known_total=1.0, iters=250
-        )
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=1e-2)
+    model = estimation.MirrorDescent().estimate(
+        _DOMAIN, loss_fn, known_total=1.0, iters=250
+    )
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=1e-2)
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_mirror_descent_l1(self, cliques):
-        measurements = fake_measurements(cliques)
-        loss_fn = marginal_loss.from_linear_measurements(
-            measurements, _DOMAIN, norm="l1"
-        )
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_mirror_descent_l1(self, cliques):
+    measurements = fake_measurements(cliques)
+    loss_fn = marginal_loss.from_linear_measurements(
+        measurements, _DOMAIN, norm="l1"
+    )
 
-        model = estimation.MirrorDescent(stepsize=0.01).estimate(
-            _DOMAIN, loss_fn, known_total=1.0, iters=250
-        )
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=1e-2)
+    model = estimation.MirrorDescent(stepsize=0.01).estimate(
+        _DOMAIN, loss_fn, known_total=1.0, iters=250
+    )
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=1e-2)
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_multiplicative_weights(self, cliques):
-        measurements = fake_measurements(cliques)
-        potentials = CliqueVector.zeros(_DOMAIN, [_DOMAIN.attributes])
-        loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
-        model = estimation.MirrorDescent().estimate(
-            _DOMAIN, loss_fn, known_total=1.0, potentials=potentials, iters=250
-        )
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_multiplicative_weights(self, cliques):
+    measurements = fake_measurements(cliques)
+    potentials = CliqueVector.zeros(_DOMAIN, [_DOMAIN.attributes])
+    loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+    model = estimation.MirrorDescent().estimate(
+        _DOMAIN, loss_fn, known_total=1.0, potentials=potentials, iters=250
+    )
 
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=1e-2)
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=1e-2)
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_dual_averaging(self, cliques):
-        measurements = fake_measurements(cliques)
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_dual_averaging(self, cliques):
+    measurements = fake_measurements(cliques)
 
-        model = estimation.DualAveraging().estimate(
-            _DOMAIN, measurements, known_total=1.0, iters=250
-        )
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=1e-2)
+    model = estimation.DualAveraging().estimate(
+        _DOMAIN, measurements, known_total=1.0, iters=250
+    )
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=1e-2)
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_interior_gradient(self, cliques):
-        measurements = fake_measurements(cliques)
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_interior_gradient(self, cliques):
+    measurements = fake_measurements(cliques)
 
-        model = estimation.InteriorGradient().estimate(
-            _DOMAIN, measurements, known_total=1.0, iters=250
-        )
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
+    model = estimation.InteriorGradient().estimate(
+        _DOMAIN, measurements, known_total=1.0, iters=250
+    )
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS))
-    def test_mle(self, cliques):
-        P = Factor.random(_DOMAIN) * 10
-        total = float(P.sum())
-        mu = CliqueVector(
-            _DOMAIN, cliques, {cl: P.project(cl) for cl in cliques}
-        )
+  @parameterized.expand(itertools.product(_CLIQUE_SETS))
+  def test_mle(self, cliques):
+    P = Factor.random(_DOMAIN) * 10
+    total = float(P.sum())
+    mu = CliqueVector(_DOMAIN, cliques, {cl: P.project(cl) for cl in cliques})
 
-        loss = marginal_loss.mle_loss_fn(mu)
-        model = estimation.LBFGS().estimate(_DOMAIN, loss, known_total=total)
-        for cl in cliques:
-            expected = mu.project(cl).datavector()
-            actual = model.project(cl).datavector()
-            np.testing.assert_allclose(actual, expected, atol=100 / total)
+    loss = marginal_loss.mle_loss_fn(mu)
+    model = estimation.LBFGS().estimate(_DOMAIN, loss, known_total=total)
+    for cl in cliques:
+      expected = mu.project(cl).datavector()
+      actual = model.project(cl).datavector()
+      np.testing.assert_allclose(actual, expected, atol=100 / total)
 
-    def test_precompile(self):
-        """precompile() should complete without error."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements = fake_measurements(cliques)
-        est = estimation.MirrorDescent()
-        future = est.precompile(_DOMAIN, measurements)
-        future.result()  # Should not raise.
+  def test_precompile(self):
+    """precompile() should complete without error."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements = fake_measurements(cliques)
+    est = estimation.MirrorDescent()
+    future = est.precompile(_DOMAIN, measurements)
+    future.result()  # Should not raise.
 
-    def test_precompile_with_extra_cliques(self):
-        """precompile() with both measurements and extra_cliques."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements = fake_measurements(cliques)
-        est = estimation.MirrorDescent()
-        future = est.precompile(
-            _DOMAIN, measurements, extra_cliques=[("c", "d")]
-        )
-        future.result()  # Should not raise.
+  def test_precompile_with_extra_cliques(self):
+    """precompile() with both measurements and extra_cliques."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements = fake_measurements(cliques)
+    est = estimation.MirrorDescent()
+    future = est.precompile(_DOMAIN, measurements, extra_cliques=[("c", "d")])
+    future.result()  # Should not raise.
 
-    def test_precompile_extra_cliques_only(self):
-        """precompile() with only extra_cliques (no concrete measurements)."""
-        est = estimation.MirrorDescent()
-        future = est.precompile(_DOMAIN, extra_cliques=[("a", "b"), ("b", "c")])
-        future.result()  # Should not raise.
+  def test_precompile_extra_cliques_only(self):
+    """precompile() with only extra_cliques (no concrete measurements)."""
+    est = estimation.MirrorDescent()
+    future = est.precompile(_DOMAIN, extra_cliques=[("a", "b"), ("b", "c")])
+    future.result()  # Should not raise.
 
-    def test_precompile_cache_hit(self):
-        """precompile() warms the cache so estimate() doesn't recompile."""
-        import jax
+  def test_precompile_cache_hit(self):
+    """precompile() warms the cache so estimate() doesn't recompile."""
+    import jax
 
-        cliques = [("a", "b"), ("b", "c")]
-        measurements = fake_measurements(cliques)
-        loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
-        est = estimation.MirrorDescent()
-        future = est.precompile(_DOMAIN, measurements)
-        future.result()
+    cliques = [("a", "b"), ("b", "c")]
+    measurements = fake_measurements(cliques)
+    loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+    est = estimation.MirrorDescent()
+    future = est.precompile(_DOMAIN, measurements)
+    future.result()
 
-        compiled_count = 0
-        original_lower = jax.stages.Lowered.compile
+    compiled_count = 0
+    original_lower = jax.stages.Lowered.compile
 
-        def counting_compile(self_lowered, *args, **kwargs):
-            nonlocal compiled_count
-            compiled_count += 1
-            return original_lower(self_lowered, *args, **kwargs)
+    def counting_compile(self_lowered, *args, **kwargs):
+      nonlocal compiled_count
+      compiled_count += 1
+      return original_lower(self_lowered, *args, **kwargs)
 
-        jax.stages.Lowered.compile = counting_compile
-        try:
-            est.estimate(_DOMAIN, loss_fn, known_total=100.0, iters=10)
-        finally:
-            jax.stages.Lowered.compile = original_lower
-        self.assertEqual(
-            compiled_count, 0, "Expected cache hit after precompile"
-        )
+    jax.stages.Lowered.compile = counting_compile
+    try:
+      est.estimate(_DOMAIN, loss_fn, known_total=100.0, iters=10)
+    finally:
+      jax.stages.Lowered.compile = original_lower
+    self.assertEqual(compiled_count, 0, "Expected cache hit after precompile")
 
-    @parameterized.expand([
-        estimation.MirrorDescent,
-        estimation.DualAveraging,
-        estimation.InteriorGradient,
-        estimation.LBFGS,
-        estimation.UniversalAcceleratedMethod,
-    ])
-    def test_estimator_with_constraints(self, estimator_cls):
-        """Estimator with constraints produces valid marginals."""
-        from mbi import Constraint
+  @parameterized.expand([
+      estimation.MirrorDescent,
+      estimation.DualAveraging,
+      estimation.InteriorGradient,
+      estimation.LBFGS,
+      estimation.UniversalAcceleratedMethod,
+  ])
+  def test_estimator_with_constraints(self, estimator_cls):
+    """Estimator with constraints produces valid marginals."""
+    from mbi import Constraint
 
-        domain = Domain(["x", "xp", "y"], [4, 2, 3])
-        mapping = np.array([0, 0, 1, 1])
-        c = Constraint(domain=domain.project(("x", "xp")), mapping=mapping)
+    domain = Domain(["x", "xp", "y"], [4, 2, 3])
+    mapping = np.array([0, 0, 1, 1])
+    c = Constraint(domain=domain.project(("x", "xp")), mapping=mapping)
 
-        cliques = [("x", "y")]
-        P = Factor.random(domain.project(("x", "y")))
-        P = P / P.sum()
-        measurements = []
-        for cl in cliques:
-            x = P.project(cl).datavector()
-            measurements.append(marginal_loss.LinearMeasurement(x, cl, 1.0))
-        loss_fn = marginal_loss.from_linear_measurements(measurements, domain)
+    cliques = [("x", "y")]
+    P = Factor.random(domain.project(("x", "y")))
+    P = P / P.sum()
+    measurements = []
+    for cl in cliques:
+      x = P.project(cl).datavector()
+      measurements.append(marginal_loss.LinearMeasurement(x, cl, 1.0))
+    loss_fn = marginal_loss.from_linear_measurements(measurements, domain)
 
-        est = estimator_cls()
-        model = est.estimate(
-            domain, loss_fn, known_total=1.0, iters=100, constraints=[c]
-        )
+    est = estimator_cls()
+    model = est.estimate(
+        domain, loss_fn, known_total=1.0, iters=100, constraints=[c]
+    )
 
-        # Marginals should only contain the input cliques.
-        self.assertEqual(set(model.cliques), set(cliques))
-        # Total should be preserved.
-        np.testing.assert_allclose(
-            model.project(("x",)).datavector().sum(), 1.0, atol=1e-4
-        )
+    # Marginals should only contain the input cliques.
+    self.assertEqual(set(model.cliques), set(cliques))
+    # Total should be preserved.
+    np.testing.assert_allclose(
+        model.project(("x",)).datavector().sum(), 1.0, atol=1e-4
+    )
 
-    @parameterized.expand([
-        estimation.MirrorDescent,
-        estimation.DualAveraging,
-        estimation.InteriorGradient,
-        estimation.LBFGS,
-        estimation.UniversalAcceleratedMethod,
-    ])
-    def test_warm_start_expanding_cliques(self, estimator_cls):
-        """Warm-starting with new cliques produces a valid model."""
-        cliques1 = [("a", "b")]
-        measurements1 = fake_measurements(cliques1)
+  @parameterized.expand([
+      estimation.MirrorDescent,
+      estimation.DualAveraging,
+      estimation.InteriorGradient,
+      estimation.LBFGS,
+      estimation.UniversalAcceleratedMethod,
+  ])
+  def test_warm_start_expanding_cliques(self, estimator_cls):
+    """Warm-starting with new cliques produces a valid model."""
+    cliques1 = [("a", "b")]
+    measurements1 = fake_measurements(cliques1)
 
-        est = estimator_cls()
-        model1 = est.estimate(_DOMAIN, measurements1, known_total=1.0, iters=50)
+    est = estimator_cls()
+    model1 = est.estimate(_DOMAIN, measurements1, known_total=1.0, iters=50)
 
-        # Round 2 adds a new clique.
-        cliques2 = [("a", "b"), ("b", "c")]
-        measurements2 = fake_measurements(cliques2)
-        model2 = est.estimate(
-            _DOMAIN,
-            measurements2,
-            known_total=1.0,
-            iters=50,
-            warm_start=model1,
-        )
+    # Round 2 adds a new clique.
+    cliques2 = [("a", "b"), ("b", "c")]
+    measurements2 = fake_measurements(cliques2)
+    model2 = est.estimate(
+        _DOMAIN,
+        measurements2,
+        known_total=1.0,
+        iters=50,
+        warm_start=model1,
+    )
 
-        np.testing.assert_allclose(
-            model2.project(("a",)).datavector().sum(), 1.0, atol=1e-4
-        )
-        # Model 2 should have the expanded clique set.
-        self.assertTrue(
-            set(cliques2).issubset(
-                {_DOMAIN.canonical(c) for c in model2.cliques}
-            )
-        )
+    np.testing.assert_allclose(
+        model2.project(("a",)).datavector().sum(), 1.0, atol=1e-4
+    )
+    # Model 2 should have the expanded clique set.
+    self.assertTrue(
+        set(cliques2).issubset({_DOMAIN.canonical(c) for c in model2.cliques})
+    )
 
-    def test_warm_start_legacy_potentials(self):
-        """Legacy potentials= kwarg still works for backwards compatibility."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements = fake_measurements(cliques)
-        loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+  def test_warm_start_legacy_potentials(self):
+    """Legacy potentials= kwarg still works for backwards compatibility."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements = fake_measurements(cliques)
+    loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
 
-        est = estimation.MirrorDescent()
-        model1 = est.estimate(_DOMAIN, loss_fn, known_total=1.0, iters=50)
+    est = estimation.MirrorDescent()
+    model1 = est.estimate(_DOMAIN, loss_fn, known_total=1.0, iters=50)
 
-        # Warm-start via legacy potentials= kwarg.
-        model2 = est.estimate(
-            _DOMAIN,
-            loss_fn,
-            known_total=1.0,
-            iters=50,
-            potentials=model1.potentials,
-        )
+    # Warm-start via legacy potentials= kwarg.
+    model2 = est.estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=50,
+        potentials=model1.potentials,
+    )
 
-        np.testing.assert_allclose(
-            model2.project(("a",)).datavector().sum(), 1.0, atol=1e-4
-        )
+    np.testing.assert_allclose(
+        model2.project(("a",)).datavector().sum(), 1.0, atol=1e-4
+    )
 
-    def test_warm_start_mixture_of_products(self):
-        """MixtureOfProducts warm-start reuses the model directly."""
-        from mbi.extensions.mixture_of_products import (
-            MixtureOfProductsEstimator,
-        )
+  def test_warm_start_mixture_of_products(self):
+    """MixtureOfProducts warm-start reuses the model directly."""
+    from mbi.extensions.mixture_of_products import (
+        MixtureOfProductsEstimator,
+    )
 
-        cliques = [("a", "b"), ("b", "c")]
-        measurements = fake_measurements(cliques)
-        loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+    cliques = [("a", "b"), ("b", "c")]
+    measurements = fake_measurements(cliques)
+    loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
 
-        est = MixtureOfProductsEstimator(num_components=5)
-        model1 = est.estimate(_DOMAIN, loss_fn, known_total=1.0, iters=50)
-        loss1 = loss_fn(model1)
+    est = MixtureOfProductsEstimator(num_components=5)
+    model1 = est.estimate(_DOMAIN, loss_fn, known_total=1.0, iters=50)
+    loss1 = loss_fn(model1)
 
-        # Warm-starting should improve on the cold-start loss.
-        model2 = est.estimate(
-            _DOMAIN,
-            loss_fn,
-            known_total=1.0,
-            iters=50,
-            warm_start=model1,
-        )
-        loss2 = loss_fn(model2)
-        self.assertLessEqual(float(loss2), float(loss1) + 1e-6)
+    # Warm-starting should improve on the cold-start loss.
+    model2 = est.estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=50,
+        warm_start=model1,
+    )
+    loss2 = loss_fn(model2)
+    self.assertLessEqual(float(loss2), float(loss1) + 1e-6)

--- a/test/test_ext_synthetic_data.py
+++ b/test/test_ext_synthetic_data.py
@@ -11,181 +11,178 @@ from mbi.extensions.synthetic_data import synthetic_data as ext_synthetic_data
 
 
 def _create_random_model(domain, cliques, N):
-    """Creates a random MRF with given cliques and total count N."""
-    potentials = {}
-    np.random.seed(0)
+  """Creates a random MRF with given cliques and total count N."""
+  potentials = {}
+  np.random.seed(0)
 
-    for cl in cliques:
-        vals = np.random.rand(*domain.project(cl).shape) + 1e-10
-        f = Factor(domain.project(cl), vals)
-        potentials[cl] = f.log()
+  for cl in cliques:
+    vals = np.random.rand(*domain.project(cl).shape) + 1e-10
+    f = Factor(domain.project(cl), vals)
+    potentials[cl] = f.log()
 
-    potential_vector = CliqueVector(domain, cliques, potentials)
-    marginals = marginal_oracles.message_passing_stable(
-        potential_vector, total=N
-    )
+  potential_vector = CliqueVector(domain, cliques, potentials)
+  marginals = marginal_oracles.message_passing_stable(potential_vector, total=N)
 
-    return MarkovRandomField(
-        potentials=potential_vector, marginals=marginals, total=N
-    )
+  return MarkovRandomField(
+      potentials=potential_vector, marginals=marginals, total=N
+  )
 
 
 class TestExtSyntheticDataAccuracy(unittest.TestCase):
-    """Tests that extensions.synthetic_data matches MRF.synthetic_data.
+  """Tests that extensions.synthetic_data matches MRF.synthetic_data.
 
-    The MRF implementation is the reference.  These tests verify that the
-    JAX-based extensions version produces equivalent marginals across
-    multiple graph structures, including the ones that triggered the
-    clique-conditioning regression (using original measurement cliques
-    instead of junction tree maximal cliques for parent determination).
+  The MRF implementation is the reference.  These tests verify that the
+  JAX-based extensions version produces equivalent marginals across
+  multiple graph structures, including the ones that triggered the
+  clique-conditioning regression (using original measurement cliques
+  instead of junction tree maximal cliques for parent determination).
+  """
+
+  def _assert_parity(self, model, cliques, N, tol=0.01):
+    """Assert extensions synth matches MRF synth within tolerance.
+
+    For each model clique we check that the normalized L1 gap between
+    extensions and MRF synthetic marginals is small.  Since both use
+    rounding (not sampling), the gap should be near zero at large N.
+
+    Args:
+        model: A fitted MarkovRandomField.
+        cliques: Cliques to evaluate.
+        N: Number of rows to generate.
+        tol: Maximum allowed normalized L1/2 gap per clique.
     """
+    np.random.seed(0)
+    synth_mrf = model.synthetic_data(rows=N, method="round")
+    synth_ext = ext_synthetic_data(model, rows=N)
 
-    def _assert_parity(self, model, cliques, N, tol=0.01):
-        """Assert extensions synth matches MRF synth within tolerance.
+    for cl in cliques:
+      mrf_marg = synth_mrf.project(cl).datavector(flatten=True)
+      ext_marg = synth_ext.project(cl).datavector(flatten=True)
 
-        For each model clique we check that the normalized L1 gap between
-        extensions and MRF synthetic marginals is small.  Since both use
-        rounding (not sampling), the gap should be near zero at large N.
+      mrf_norm = mrf_marg / max(mrf_marg.sum(), 1e-20)
+      ext_norm = ext_marg / max(ext_marg.sum(), 1e-20)
 
-        Args:
-            model: A fitted MarkovRandomField.
-            cliques: Cliques to evaluate.
-            N: Number of rows to generate.
-            tol: Maximum allowed normalized L1/2 gap per clique.
-        """
-        np.random.seed(0)
-        synth_mrf = model.synthetic_data(rows=N, method="round")
-        synth_ext = ext_synthetic_data(model, rows=N)
+      gap = 0.5 * np.sum(np.abs(mrf_norm - ext_norm))
+      self.assertLess(
+          gap,
+          tol,
+          f"Extensions gap {gap:.6f} exceeds tolerance {tol} for clique {cl}",
+      )
 
-        for cl in cliques:
-            mrf_marg = synth_mrf.project(cl).datavector(flatten=True)
-            ext_marg = synth_ext.project(cl).datavector(flatten=True)
+  def _test_model_structure(self, domain, cliques, cross_cliques=None):
+    """Test a specific model structure for MRF/extensions parity."""
+    N = 50000
+    model = _create_random_model(domain, cliques, N)
+    all_cliques = list(cliques) + (cross_cliques or [])
+    self._assert_parity(model, all_cliques, N)
 
-            mrf_norm = mrf_marg / max(mrf_marg.sum(), 1e-20)
-            ext_norm = ext_marg / max(ext_marg.sum(), 1e-20)
+  def test_single_clique(self):
+    """Single clique: no conditioning needed."""
+    domain = Domain(["A", "B"], [10, 10])
+    cliques = [("A", "B")]
+    self._test_model_structure(domain, cliques)
 
-            gap = 0.5 * np.sum(np.abs(mrf_norm - ext_norm))
-            self.assertLess(
-                gap,
-                tol,
-                f"Extensions gap {gap:.6f} exceeds tolerance {tol} "
-                f"for clique {cl}",
-            )
+  def test_independent_cliques(self):
+    """Two disjoint cliques: no shared attributes."""
+    domain = Domain(["A", "B", "C", "D"], [5, 5, 5, 5])
+    cliques = [("A", "B"), ("C", "D")]
+    self._test_model_structure(
+        domain, cliques, cross_cliques=[("A", "C"), ("B", "D")]
+    )
 
-    def _test_model_structure(self, domain, cliques, cross_cliques=None):
-        """Test a specific model structure for MRF/extensions parity."""
-        N = 50000
-        model = _create_random_model(domain, cliques, N)
-        all_cliques = list(cliques) + (cross_cliques or [])
-        self._assert_parity(model, all_cliques, N)
+  def test_chain(self):
+    """Chain A-B-C: conditioning through shared attribute B."""
+    domain = Domain(["A", "B", "C"], [5, 5, 5])
+    cliques = [("A", "B"), ("B", "C")]
+    self._test_model_structure(domain, cliques, cross_cliques=[("A", "C")])
 
-    def test_single_clique(self):
-        """Single clique: no conditioning needed."""
-        domain = Domain(["A", "B"], [10, 10])
-        cliques = [("A", "B")]
-        self._test_model_structure(domain, cliques)
+  def test_star(self):
+    """Star with hub: spokes share a hub but not each other."""
+    domain = Domain(["H", "A", "B", "C", "D"], [5, 4, 4, 4, 4])
+    cliques = [("H", "A"), ("H", "B"), ("H", "C"), ("H", "D")]
+    self._test_model_structure(
+        domain,
+        cliques,
+        cross_cliques=[("A", "B"), ("A", "C"), ("B", "D")],
+    )
 
-    def test_independent_cliques(self):
-        """Two disjoint cliques: no shared attributes."""
-        domain = Domain(["A", "B", "C", "D"], [5, 5, 5, 5])
-        cliques = [("A", "B"), ("C", "D")]
-        self._test_model_structure(
-            domain, cliques, cross_cliques=[("A", "C"), ("B", "D")]
-        )
+  def test_two_hubs_shared_separator(self):
+    """Two hubs with shared separators — the structure that triggered
+    the clique-conditioning bug.
 
-    def test_chain(self):
-        """Chain A-B-C: conditioning through shared attribute B."""
-        domain = Domain(["A", "B", "C"], [5, 5, 5])
-        cliques = [("A", "B"), ("B", "C")]
-        self._test_model_structure(domain, cliques, cross_cliques=[("A", "C")])
-
-    def test_star(self):
-        """Star with hub: spokes share a hub but not each other."""
-        domain = Domain(["H", "A", "B", "C", "D"], [5, 4, 4, 4, 4])
-        cliques = [("H", "A"), ("H", "B"), ("H", "C"), ("H", "D")]
-        self._test_model_structure(
-            domain,
-            cliques,
-            cross_cliques=[("A", "B"), ("A", "C"), ("B", "D")],
-        )
-
-    def test_two_hubs_shared_separator(self):
-        """Two hubs with shared separators — the structure that triggered
-        the clique-conditioning bug.
-
-        Hub1 (H1) connects to A, B, C.
-        Hub2 (H2) connects to A, B, C.
-        The junction tree merges {H1, A, B, C} and {H2, A, B, C} into
-        super-cliques with separator {A, B, C}.  Without the fix, A, B, C
-        are generated independently instead of from their joint.
-        """
-        domain = Domain(["H1", "H2", "A", "B", "C"], [4, 4, 3, 3, 3])
-        cliques = [
-            ("H1", "A"),
-            ("H1", "B"),
-            ("H1", "C"),
-            ("H2", "A"),
-            ("H2", "B"),
-            ("H2", "C"),
-        ]
-        self._test_model_structure(
-            domain,
-            cliques,
-            cross_cliques=[
-                ("A", "B"),
-                ("A", "C"),
-                ("B", "C"),
-                ("H1", "H2"),
-            ],
-        )
-
-    def test_overlapping_triples(self):
-        """Overlapping 3-way cliques that create 4-way super-cliques."""
-        domain = Domain(["A", "B", "C", "D", "E"], [3, 3, 3, 3, 3])
-        cliques = [
-            ("A", "B", "C"),
-            ("B", "C", "D"),
-            ("D", "E"),
-        ]
-        self._test_model_structure(
-            domain,
-            cliques,
-            cross_cliques=[("A", "D"), ("A", "E"), ("C", "E")],
-        )
-
-    def test_two_clusters_with_bridge(self):
-        """Two dense clusters connected by a single bridge edge.
-
-        Cluster 1: all pairs of {A, B, C} → super-clique (A, B, C)
-        Cluster 2: all pairs of {D, E, F} → super-clique (D, E, F)
-        Bridge: (C, D)
-        """
-        domain = Domain(["A", "B", "C", "D", "E", "F"], [3, 3, 3, 3, 3, 3])
-        cliques = [
+    Hub1 (H1) connects to A, B, C.
+    Hub2 (H2) connects to A, B, C.
+    The junction tree merges {H1, A, B, C} and {H2, A, B, C} into
+    super-cliques with separator {A, B, C}.  Without the fix, A, B, C
+    are generated independently instead of from their joint.
+    """
+    domain = Domain(["H1", "H2", "A", "B", "C"], [4, 4, 3, 3, 3])
+    cliques = [
+        ("H1", "A"),
+        ("H1", "B"),
+        ("H1", "C"),
+        ("H2", "A"),
+        ("H2", "B"),
+        ("H2", "C"),
+    ]
+    self._test_model_structure(
+        domain,
+        cliques,
+        cross_cliques=[
             ("A", "B"),
             ("A", "C"),
             ("B", "C"),
-            ("D", "E"),
-            ("D", "F"),
-            ("E", "F"),
-            ("C", "D"),
-        ]
-        self._test_model_structure(
-            domain,
-            cliques,
-            cross_cliques=[("A", "D"), ("B", "E"), ("A", "F")],
-        )
+            ("H1", "H2"),
+        ],
+    )
 
-    def test_mixed_arity_cliques(self):
-        """Mix of 1-way, 2-way, and 3-way cliques."""
-        domain = Domain(["A", "B", "C", "D", "E"], [3, 3, 3, 3, 3])
-        cliques = [("A",), ("A", "B"), ("B", "C", "D"), ("D", "E")]
-        self._test_model_structure(
-            domain,
-            cliques,
-            cross_cliques=[("A", "C"), ("A", "E"), ("C", "E")],
-        )
+  def test_overlapping_triples(self):
+    """Overlapping 3-way cliques that create 4-way super-cliques."""
+    domain = Domain(["A", "B", "C", "D", "E"], [3, 3, 3, 3, 3])
+    cliques = [
+        ("A", "B", "C"),
+        ("B", "C", "D"),
+        ("D", "E"),
+    ]
+    self._test_model_structure(
+        domain,
+        cliques,
+        cross_cliques=[("A", "D"), ("A", "E"), ("C", "E")],
+    )
+
+  def test_two_clusters_with_bridge(self):
+    """Two dense clusters connected by a single bridge edge.
+
+    Cluster 1: all pairs of {A, B, C} → super-clique (A, B, C)
+    Cluster 2: all pairs of {D, E, F} → super-clique (D, E, F)
+    Bridge: (C, D)
+    """
+    domain = Domain(["A", "B", "C", "D", "E", "F"], [3, 3, 3, 3, 3, 3])
+    cliques = [
+        ("A", "B"),
+        ("A", "C"),
+        ("B", "C"),
+        ("D", "E"),
+        ("D", "F"),
+        ("E", "F"),
+        ("C", "D"),
+    ]
+    self._test_model_structure(
+        domain,
+        cliques,
+        cross_cliques=[("A", "D"), ("B", "E"), ("A", "F")],
+    )
+
+  def test_mixed_arity_cliques(self):
+    """Mix of 1-way, 2-way, and 3-way cliques."""
+    domain = Domain(["A", "B", "C", "D", "E"], [3, 3, 3, 3, 3])
+    cliques = [("A",), ("A", "B"), ("B", "C", "D"), ("D", "E")]
+    self._test_model_structure(
+        domain,
+        cliques,
+        cross_cliques=[("A", "C"), ("A", "E"), ("C", "E")],
+    )
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/test_factor.py
+++ b/test/test_factor.py
@@ -9,125 +9,123 @@ np.random.seed(0)
 
 class TestFactor(unittest.TestCase):
 
-    def setUp(self):
-        attrs = ["a", "b", "c"]
-        shape = [2, 3, 4]
-        domain = Domain(attrs, shape)
-        values = np.random.rand(*shape)
-        self.factor = Factor(domain, jnp.asarray(values))
+  def setUp(self):
+    attrs = ["a", "b", "c"]
+    shape = [2, 3, 4]
+    domain = Domain(attrs, shape)
+    values = np.random.rand(*shape)
+    self.factor = Factor(domain, jnp.asarray(values))
 
-    def test_abstract(self):
-        domain = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
-        factor = Factor.abstract(domain)
+  def test_abstract(self):
+    domain = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
+    factor = Factor.abstract(domain)
 
-    def test_expand(self):
-        domain = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
-        res = self.factor.expand(domain)
-        self.assertEqual(res.domain, domain)
-        self.assertEqual(res.values.shape, domain.shape)
+  def test_expand(self):
+    domain = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
+    res = self.factor.expand(domain)
+    self.assertEqual(res.domain, domain)
+    self.assertEqual(res.values.shape, domain.shape)
 
-        self.assertTrue(
-            np.allclose(res.sum("d").values * 0.2, self.factor.values)
-        )
+    self.assertTrue(np.allclose(res.sum("d").values * 0.2, self.factor.values))
 
-    def test_transpose(self):
-        attrs = ["b", "c", "a"]
-        tr = self.factor.transpose(attrs)
-        ans = Domain(attrs, [3, 4, 2])
-        self.assertEqual(tr.domain, ans)
+  def test_transpose(self):
+    attrs = ["b", "c", "a"]
+    tr = self.factor.transpose(attrs)
+    ans = Domain(attrs, [3, 4, 2])
+    self.assertEqual(tr.domain, ans)
 
-    def test_project(self):
-        res = self.factor.project(["c", "a"])
-        ans = Domain(["c", "a"], [4, 2])
-        self.assertEqual(res.domain, ans)
-        self.assertEqual(res.values.shape, (4, 2))
+  def test_project(self):
+    res = self.factor.project(["c", "a"])
+    ans = Domain(["c", "a"], [4, 2])
+    self.assertEqual(res.domain, ans)
+    self.assertEqual(res.values.shape, (4, 2))
 
-        res = self.factor.project(["c", "a"], log=True)
-        self.assertEqual(res.domain, ans)
-        self.assertEqual(res.values.shape, (4, 2))
+    res = self.factor.project(["c", "a"], log=True)
+    self.assertEqual(res.domain, ans)
+    self.assertEqual(res.values.shape, (4, 2))
 
-        self.factor.project("a")
+    self.factor.project("a")
 
-    def test_sum(self):
-        res = self.factor.sum(["a", "b"])
-        self.assertEqual(res.domain, Domain(["c"], [4]))
-        self.assertTrue(
-            np.allclose(res.values, self.factor.values.sum(axis=(0, 1)))
-        )
+  def test_sum(self):
+    res = self.factor.sum(["a", "b"])
+    self.assertEqual(res.domain, Domain(["c"], [4]))
+    self.assertTrue(
+        np.allclose(res.values, self.factor.values.sum(axis=(0, 1)))
+    )
 
-    def test_logsumexp(self):
-        res = self.factor.logsumexp(["a", "c"])
-        values = self.factor.values
-        ans = np.log(np.sum(np.exp(values), axis=(0, 2)))
-        self.assertEqual(res.domain, Domain(["b"], [3]))
-        self.assertTrue(np.allclose(res.values, ans))
+  def test_logsumexp(self):
+    res = self.factor.logsumexp(["a", "c"])
+    values = self.factor.values
+    ans = np.log(np.sum(np.exp(values), axis=(0, 2)))
+    self.assertEqual(res.domain, Domain(["b"], [3]))
+    self.assertTrue(np.allclose(res.values, ans))
 
-    def test_binary(self):
-        dom = Domain(["b", "d", "e"], [3, 5, 6])
-        vals = np.random.rand(3, 5, 6)
-        factor = Factor(dom, jnp.asarray(vals))
+  def test_binary(self):
+    dom = Domain(["b", "d", "e"], [3, 5, 6])
+    vals = np.random.rand(3, 5, 6)
+    factor = Factor(dom, jnp.asarray(vals))
 
-        res = self.factor * factor
-        ans = Domain(["a", "b", "c", "d", "e"], [2, 3, 4, 5, 6])
-        self.assertEqual(res.domain, ans)
+    res = self.factor * factor
+    ans = Domain(["a", "b", "c", "d", "e"], [2, 3, 4, 5, 6])
+    self.assertEqual(res.domain, ans)
 
-        res = self.factor + factor
-        self.assertEqual(res.domain, ans)
+    res = self.factor + factor
+    self.assertEqual(res.domain, ans)
 
-        res = self.factor * 2.0
-        self.assertEqual(res.domain, self.factor.domain)
+    res = self.factor * 2.0
+    self.assertEqual(res.domain, self.factor.domain)
 
-        res = self.factor + 2.0
-        self.assertEqual(res.domain, self.factor.domain)
+    res = self.factor + 2.0
+    self.assertEqual(res.domain, self.factor.domain)
 
-        res = self.factor - 2.0
-        self.assertEqual(res.domain, self.factor.domain)
+    res = self.factor - 2.0
+    self.assertEqual(res.domain, self.factor.domain)
 
-        res = self.factor.exp().log()
-        self.assertEqual(res.domain, self.factor.domain)
-        self.assertTrue(np.allclose(res.values, self.factor.values, atol=1e-6))
+    res = self.factor.exp().log()
+    self.assertEqual(res.domain, self.factor.domain)
+    self.assertTrue(np.allclose(res.values, self.factor.values, atol=1e-6))
 
-    def test_slice(self):
-        domain = Domain.fromdict({"A": 3, "B": 2})
-        values = jnp.arange(6).reshape(3, 2)
-        factor = Factor(domain, jnp.asarray(values))
+  def test_slice(self):
+    domain = Domain.fromdict({"A": 3, "B": 2})
+    values = jnp.arange(6).reshape(3, 2)
+    factor = Factor(domain, jnp.asarray(values))
 
-        # Test slicing A=0
-        evidence = {"A": 0}
-        sliced_factor = factor.slice(evidence)
-        expected_domain = Domain.fromdict({"B": 2})
-        expected_values = values[0, :]
+    # Test slicing A=0
+    evidence = {"A": 0}
+    sliced_factor = factor.slice(evidence)
+    expected_domain = Domain.fromdict({"B": 2})
+    expected_values = values[0, :]
 
-        self.assertEqual(sliced_factor.domain, expected_domain)
-        self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
+    self.assertEqual(sliced_factor.domain, expected_domain)
+    self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
 
-        # Test slicing B=1
-        evidence = {"B": 1}
-        sliced_factor = factor.slice(evidence)
-        expected_domain = Domain.fromdict({"A": 3})
-        expected_values = values[:, 1]
+    # Test slicing B=1
+    evidence = {"B": 1}
+    sliced_factor = factor.slice(evidence)
+    expected_domain = Domain.fromdict({"A": 3})
+    expected_values = values[:, 1]
 
-        self.assertEqual(sliced_factor.domain, expected_domain)
-        self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
+    self.assertEqual(sliced_factor.domain, expected_domain)
+    self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
 
-        # Test slicing both
-        evidence = {"A": 1, "B": 1}
-        sliced_factor = factor.slice(evidence)
-        expected_domain = Domain.fromdict({})
-        expected_values = values[1, 1]
+    # Test slicing both
+    evidence = {"A": 1, "B": 1}
+    sliced_factor = factor.slice(evidence)
+    expected_domain = Domain.fromdict({})
+    expected_values = values[1, 1]
 
-        self.assertEqual(sliced_factor.domain, expected_domain)
-        self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
+    self.assertEqual(sliced_factor.domain, expected_domain)
+    self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
 
-        # Test slicing with extra attribute (should be ignored)
-        evidence = {"A": 2, "C": 5}
-        sliced_factor = factor.slice(evidence)
-        expected_domain = Domain.fromdict({"B": 2})
-        expected_values = values[2, :]
+    # Test slicing with extra attribute (should be ignored)
+    evidence = {"A": 2, "C": 5}
+    sliced_factor = factor.slice(evidence)
+    expected_domain = Domain.fromdict({"B": 2})
+    expected_values = values[2, :]
 
-        self.assertEqual(sliced_factor.domain, expected_domain)
-        self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
+    self.assertEqual(sliced_factor.domain, expected_domain)
+    self.assertTrue(jnp.array_equal(sliced_factor.values, expected_values))
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/test_inf_handling.py
+++ b/test/test_inf_handling.py
@@ -8,51 +8,51 @@ from mbi.marginal_oracles import calculate_many_marginals, message_passing_shafe
 
 class TestInfHandling(unittest.TestCase):
 
-    def test_factor_dot_nan(self):
-        """Test that Factor.dot handles 0 * -inf = 0."""
-        domain = Domain(['A'], [2])
-        f1 = Factor(domain, jnp.array([1.0, 0.0]))
-        f2 = Factor(domain, jnp.array([2.0, -jnp.inf]))
+  def test_factor_dot_nan(self):
+    """Test that Factor.dot handles 0 * -inf = 0."""
+    domain = Domain(['A'], [2])
+    f1 = Factor(domain, jnp.array([1.0, 0.0]))
+    f2 = Factor(domain, jnp.array([2.0, -jnp.inf]))
 
-        # f1.dot(f2) should be 1*2 + 0*-inf = 2 + 0 = 2
-        result = f1.dot(f2)
+    # f1.dot(f2) should be 1*2 + 0*-inf = 2 + 0 = 2
+    result = f1.dot(f2)
 
-        self.assertFalse(jnp.isnan(result), 'Result should not be NaN')
-        self.assertEqual(result, 2.0, 'Result should be 2.0')
+    self.assertFalse(jnp.isnan(result), 'Result should not be NaN')
+    self.assertEqual(result, 2.0, 'Result should be 2.0')
 
-    def test_calculate_many_marginals_zero_division(self):
-        """Test that calculate_many_marginals handles 0/0 division."""
-        domain = Domain(['A', 'B', 'C'], [2, 2, 2])
-        cliques = [('A', 'B'), ('B', 'C')]
-        potentials = CliqueVector.zeros(domain, cliques)
+  def test_calculate_many_marginals_zero_division(self):
+    """Test that calculate_many_marginals handles 0/0 division."""
+    domain = Domain(['A', 'B', 'C'], [2, 2, 2])
+    cliques = [('A', 'B'), ('B', 'C')]
+    potentials = CliqueVector.zeros(domain, cliques)
 
-        # Make P(B=0) = 0 by setting potentials to -inf where B=0
-        fAB = potentials[('A', 'B')]
-        # B is axis 1 in (A, B)
-        valsAB = fAB.values.at[:, 0].set(-jnp.inf)
-        potentials[('A', 'B')] = Factor(fAB.domain, valsAB)
+    # Make P(B=0) = 0 by setting potentials to -inf where B=0
+    fAB = potentials[('A', 'B')]
+    # B is axis 1 in (A, B)
+    valsAB = fAB.values.at[:, 0].set(-jnp.inf)
+    potentials[('A', 'B')] = Factor(fAB.domain, valsAB)
 
-        fBC = potentials[('B', 'C')]
-        # B is axis 0 in (B, C)
-        valsBC = fBC.values.at[0, :].set(-jnp.inf)
-        potentials[('B', 'C')] = Factor(fBC.domain, valsBC)
+    fBC = potentials[('B', 'C')]
+    # B is axis 0 in (B, C)
+    valsBC = fBC.values.at[0, :].set(-jnp.inf)
+    potentials[('B', 'C')] = Factor(fBC.domain, valsBC)
 
-        # This should not raise or produce NaNs.
-        # We use message_passing_shafer_shenoy to avoid NaNs from the oracle itself.
-        try:
-            res = calculate_many_marginals(
-                potentials,
-                cliques,
-                belief_propagation_oracle=message_passing_shafer_shenoy,
-            )
-        except Exception as e:
-            self.fail(f'calculate_many_marginals raised exception: {e}')
+    # This should not raise or produce NaNs.
+    # We use message_passing_shafer_shenoy to avoid NaNs from the oracle itself.
+    try:
+      res = calculate_many_marginals(
+          potentials,
+          cliques,
+          belief_propagation_oracle=message_passing_shafer_shenoy,
+      )
+    except Exception as e:
+      self.fail(f'calculate_many_marginals raised exception: {e}')
 
-        for cl in res.cliques:
-            self.assertFalse(
-                jnp.isnan(res[cl].values).any(), f'NaN found in clique {cl}'
-            )
+    for cl in res.cliques:
+      self.assertFalse(
+          jnp.isnan(res[cl].values).any(), f'NaN found in clique {cl}'
+      )
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_junction_tree.py
+++ b/test/test_junction_tree.py
@@ -5,60 +5,58 @@ from mbi.junction_tree import make_junction_tree, maximal_cliques
 
 class TestJunctionTree(unittest.TestCase):
 
-    def test_clique_support(self):
-        attrs = ['a', 'b', 'c', 'd', 'e']
-        shape = [2] * 5
-        domain = Domain(attrs, shape)
+  def test_clique_support(self):
+    attrs = ['a', 'b', 'c', 'd', 'e']
+    shape = [2] * 5
+    domain = Domain(attrs, shape)
 
-        # Case 1: Simple chain
-        cliques = [('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'e')]
-        jtree, _ = make_junction_tree(domain, cliques)
-        max_cliques = maximal_cliques(jtree)
-        # Check support
-        for cl in cliques:
-            self.assertTrue(
-                any(set(cl) <= set(mx) for mx in max_cliques),
-                f'Clique {cl} not supported by any maximal clique in chain'
-                ' case',
-            )
+    # Case 1: Simple chain
+    cliques = [('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'e')]
+    jtree, _ = make_junction_tree(domain, cliques)
+    max_cliques = maximal_cliques(jtree)
+    # Check support
+    for cl in cliques:
+      self.assertTrue(
+          any(set(cl) <= set(mx) for mx in max_cliques),
+          f'Clique {cl} not supported by any maximal clique in chain case',
+      )
 
-        # Case 2: Cycle
-        cliques = [('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'a')]
-        jtree, _ = make_junction_tree(domain, cliques)
-        max_cliques = maximal_cliques(jtree)
-        for cl in cliques:
-            self.assertTrue(
-                any(set(cl) <= set(mx) for mx in max_cliques),
-                f'Clique {cl} not supported by any maximal clique in cycle'
-                ' case',
-            )
+    # Case 2: Cycle
+    cliques = [('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'a')]
+    jtree, _ = make_junction_tree(domain, cliques)
+    max_cliques = maximal_cliques(jtree)
+    for cl in cliques:
+      self.assertTrue(
+          any(set(cl) <= set(mx) for mx in max_cliques),
+          f'Clique {cl} not supported by any maximal clique in cycle case',
+      )
 
-        # Case 3: More complex
-        # A structure where triangulation will add edges.
-        cliques = [('a', 'b', 'c'), ('c', 'd', 'e'), ('a', 'e')]
-        jtree, _ = make_junction_tree(domain, cliques)
-        max_cliques = maximal_cliques(jtree)
-        for cl in cliques:
-            self.assertTrue(
-                any(set(cl) <= set(mx) for mx in max_cliques),
-                f'Clique {cl} not supported in complex case',
-            )
+    # Case 3: More complex
+    # A structure where triangulation will add edges.
+    cliques = [('a', 'b', 'c'), ('c', 'd', 'e'), ('a', 'e')]
+    jtree, _ = make_junction_tree(domain, cliques)
+    max_cliques = maximal_cliques(jtree)
+    for cl in cliques:
+      self.assertTrue(
+          any(set(cl) <= set(mx) for mx in max_cliques),
+          f'Clique {cl} not supported in complex case',
+      )
 
-        # Case 4: Disconnected components
-        cliques = [('a', 'b'), ('d', 'e')]
-        jtree, _ = make_junction_tree(domain, cliques)
-        max_cliques = maximal_cliques(jtree)
-        for cl in cliques:
-            self.assertTrue(
-                any(set(cl) <= set(mx) for mx in max_cliques),
-                f'Clique {cl} not supported in disconnected case',
-            )
+    # Case 4: Disconnected components
+    cliques = [('a', 'b'), ('d', 'e')]
+    jtree, _ = make_junction_tree(domain, cliques)
+    max_cliques = maximal_cliques(jtree)
+    for cl in cliques:
+      self.assertTrue(
+          any(set(cl) <= set(mx) for mx in max_cliques),
+          f'Clique {cl} not supported in disconnected case',
+      )
 
-        # Null graphs
-        _ = make_junction_tree(domain, [(a,) for a in attrs])
-        _ = make_junction_tree(domain, [])
-        _ = make_junction_tree(Domain([], []), [])
+    # Null graphs
+    _ = make_junction_tree(domain, [(a,) for a in attrs])
+    _ = make_junction_tree(domain, [])
+    _ = make_junction_tree(Domain([], []), [])
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_marginal_loss.py
+++ b/test/test_marginal_loss.py
@@ -8,99 +8,99 @@ from mbi.clique_vector import CliqueVector
 
 class TestMarginalLoss(unittest.TestCase):
 
-    def test_l2_lipschitz_disjoint(self):
-        """Verify that Lipschitz constant is max(1/stddev^2) for disjoint measurements."""
-        domain = Domain.fromdict({'a': 10, 'b': 10, 'c': 10})
+  def test_l2_lipschitz_disjoint(self):
+    """Verify that Lipschitz constant is max(1/stddev^2) for disjoint measurements."""
+    domain = Domain.fromdict({'a': 10, 'b': 10, 'c': 10})
 
-        # Create disjoint measurements
-        # m1 on ('a',) with stddev 0.5 -> 1/stddev^2 = 4.0
-        # m2 on ('b',) with stddev 0.2 -> 1/stddev^2 = 25.0
-        # m3 on ('c',) with stddev 1.0 -> 1/stddev^2 = 1.0
+    # Create disjoint measurements
+    # m1 on ('a',) with stddev 0.5 -> 1/stddev^2 = 4.0
+    # m2 on ('b',) with stddev 0.2 -> 1/stddev^2 = 25.0
+    # m3 on ('c',) with stddev 1.0 -> 1/stddev^2 = 1.0
 
-        m1 = LinearMeasurement(jnp.zeros(10), ('a',), stddev=0.5)
-        m2 = LinearMeasurement(jnp.zeros(10), ('b',), stddev=0.2)
-        m3 = LinearMeasurement(jnp.zeros(10), ('c',), stddev=1.0)
+    m1 = LinearMeasurement(jnp.zeros(10), ('a',), stddev=0.5)
+    m2 = LinearMeasurement(jnp.zeros(10), ('b',), stddev=0.2)
+    m3 = LinearMeasurement(jnp.zeros(10), ('c',), stddev=1.0)
 
-        measurements = [m1, m2, m3]
+    measurements = [m1, m2, m3]
 
-        # Calculate loss function and lipschitz constant
-        loss_fn = from_linear_measurements(measurements, domain, norm='l2')
+    # Calculate loss function and lipschitz constant
+    loss_fn = from_linear_measurements(measurements, domain, norm='l2')
 
-        calculated_L = loss_fn.lipschitz
-        expected_L = max(1.0 / m.stddev**2 for m in measurements)
+    calculated_L = loss_fn.lipschitz
+    expected_L = max(1.0 / m.stddev**2 for m in measurements)
 
-        # We expect calculated_L to be very close to expected_L
-        # Using a slightly looser tolerance because power iteration is approximate
-        self.assertAlmostEqual(calculated_L, expected_L, delta=1e-3)
+    # We expect calculated_L to be very close to expected_L
+    # Using a slightly looser tolerance because power iteration is approximate
+    self.assertAlmostEqual(calculated_L, expected_L, delta=1e-3)
 
-    def test_l2_lipschitz_single(self):
-        """Verify that Lipschitz constant is 1/stddev^2 for a single measurement."""
-        domain = Domain.fromdict({'a': 10})
-        m1 = LinearMeasurement(jnp.zeros(10), ('a',), stddev=0.5)
-        measurements = [m1]
+  def test_l2_lipschitz_single(self):
+    """Verify that Lipschitz constant is 1/stddev^2 for a single measurement."""
+    domain = Domain.fromdict({'a': 10})
+    m1 = LinearMeasurement(jnp.zeros(10), ('a',), stddev=0.5)
+    measurements = [m1]
 
-        loss_fn = from_linear_measurements(measurements, domain, norm='l2')
+    loss_fn = from_linear_measurements(measurements, domain, norm='l2')
 
-        calculated_L = loss_fn.lipschitz
-        expected_L = 1.0 / m1.stddev**2
+    calculated_L = loss_fn.lipschitz
+    expected_L = 1.0 / m1.stddev**2
 
-        self.assertAlmostEqual(calculated_L, expected_L, delta=1e-3)
+    self.assertAlmostEqual(calculated_L, expected_L, delta=1e-3)
 
 
 class TestCompress(unittest.TestCase):
 
-    def test_single_column(self):
-        """Compress a one-way measurement by merging pairs."""
-        domain = Domain.fromdict({'a': 6})
-        y = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
-        m = LinearMeasurement(y, ('a',), stddev=1.0)
-        mapping = {'a': np.array([0, 0, 1, 1, 2, 2])}
-        mc = m.compress(mapping, domain)
+  def test_single_column(self):
+    """Compress a one-way measurement by merging pairs."""
+    domain = Domain.fromdict({'a': 6})
+    y = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+    m = LinearMeasurement(y, ('a',), stddev=1.0)
+    mapping = {'a': np.array([0, 0, 1, 1, 2, 2])}
+    mc = m.compress(mapping, domain)
 
-        expected = np.array([30, 70, 110]) / np.sqrt(2)
-        np.testing.assert_allclose(mc.noisy_measurement, expected)
-        self.assertEqual(mc.stddev, 1.0)
-        self.assertEqual(mc.clique, ('a',))
+    expected = np.array([30, 70, 110]) / np.sqrt(2)
+    np.testing.assert_allclose(mc.noisy_measurement, expected)
+    self.assertEqual(mc.stddev, 1.0)
+    self.assertEqual(mc.clique, ('a',))
 
-    def test_multi_column(self):
-        """Compress one attribute of a two-way measurement."""
-        domain = Domain.fromdict({'a': 4, 'b': 3})
-        y = np.arange(12, dtype=float)  # shape (4, 3) flattened
-        m = LinearMeasurement(y, ('a', 'b'), stddev=2.0)
-        mapping = {'a': np.array([0, 0, 1, 1])}
-        mc = m.compress(mapping, domain)
+  def test_multi_column(self):
+    """Compress one attribute of a two-way measurement."""
+    domain = Domain.fromdict({'a': 4, 'b': 3})
+    y = np.arange(12, dtype=float)  # shape (4, 3) flattened
+    m = LinearMeasurement(y, ('a', 'b'), stddev=2.0)
+    mapping = {'a': np.array([0, 0, 1, 1])}
+    mc = m.compress(mapping, domain)
 
-        y2d = y.reshape(4, 3)
-        # Compressed: sum pairs along axis 0, then divide by sqrt(2)
-        expected = np.vstack([y2d[0] + y2d[1], y2d[2] + y2d[3]]) / np.sqrt(2)
-        np.testing.assert_allclose(mc.noisy_measurement, expected.ravel())
-        self.assertEqual(mc.stddev, 2.0)
+    y2d = y.reshape(4, 3)
+    # Compressed: sum pairs along axis 0, then divide by sqrt(2)
+    expected = np.vstack([y2d[0] + y2d[1], y2d[2] + y2d[3]]) / np.sqrt(2)
+    np.testing.assert_allclose(mc.noisy_measurement, expected.ravel())
+    self.assertEqual(mc.stddev, 2.0)
 
-    def test_irrelevant_mapping_returns_self(self):
-        domain = Domain.fromdict({'a': 4})
-        m = LinearMeasurement(np.ones(4), ('a',))
-        mc = m.compress({'z': np.array([0, 1])}, domain)
-        self.assertIs(m, mc)
+  def test_irrelevant_mapping_returns_self(self):
+    domain = Domain.fromdict({'a': 4})
+    m = LinearMeasurement(np.ones(4), ('a',))
+    mc = m.compress({'z': np.array([0, 1])}, domain)
+    self.assertIs(m, mc)
 
-    def test_query_produces_correct_loss(self):
-        """Compressed measurement should recover true compressed marginal."""
-        domain = Domain.fromdict({'a': 6})
-        true_counts = np.array([100.0, 150.0, 200.0, 250.0, 300.0, 350.0])
-        m = LinearMeasurement(true_counts, ('a',), stddev=1.0)
-        mapping = {'a': np.array([0, 0, 1, 1, 2, 2])}
-        mc = m.compress(mapping, domain)
+  def test_query_produces_correct_loss(self):
+    """Compressed measurement should recover true compressed marginal."""
+    domain = Domain.fromdict({'a': 6})
+    true_counts = np.array([100.0, 150.0, 200.0, 250.0, 300.0, 350.0])
+    m = LinearMeasurement(true_counts, ('a',), stddev=1.0)
+    mapping = {'a': np.array([0, 0, 1, 1, 2, 2])}
+    mc = m.compress(mapping, domain)
 
-        compressed_domain = Domain.fromdict({'a': 3})
-        loss_fn = from_linear_measurements([mc], compressed_domain)
-        # The compressed true counts: [250, 450, 650]
-        from mbi import estimation
+    compressed_domain = Domain.fromdict({'a': 3})
+    loss_fn = from_linear_measurements([mc], compressed_domain)
+    # The compressed true counts: [250, 450, 650]
+    from mbi import estimation
 
-        model = estimation.MirrorDescent(stepsize=1e-3).estimate(
-            compressed_domain, loss_fn, known_total=1350.0, iters=200
-        )
-        result = np.asarray(model.project(('a',)).datavector())
-        np.testing.assert_allclose(result, [250, 450, 650], rtol=0.01)
+    model = estimation.MirrorDescent(stepsize=1e-3).estimate(
+        compressed_domain, loss_fn, known_total=1350.0, iters=200
+    )
+    result = np.asarray(model.project(('a',)).datavector())
+    np.testing.assert_allclose(result, [250, 450, 650], rtol=0.01)
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_marginal_oracles.py
+++ b/test/test_marginal_oracles.py
@@ -28,26 +28,26 @@ np.random.seed(0)
 def _variable_elimination_oracle(
     potentials: CliqueVector, total: float = 1
 ) -> CliqueVector:
-    domain, cliques = potentials.domain, potentials.cliques
-    mu = {
-        cl: marginal_oracles.variable_elimination(potentials, cl, total)
-        for cl in cliques
-    }
-    return CliqueVector(domain, cliques, mu)
+  domain, cliques = potentials.domain, potentials.cliques
+  mu = {
+      cl: marginal_oracles.variable_elimination(potentials, cl, total)
+      for cl in cliques
+  }
+  return CliqueVector(domain, cliques, mu)
 
 
 def _calculate_many_oracle(potentials: CliqueVector, total: float = 1):
-    return marginal_oracles.calculate_many_marginals(
-        potentials, potentials.cliques, total
-    )
+  return marginal_oracles.calculate_many_marginals(
+      potentials, potentials.cliques, total
+  )
 
 
 def _bulk_variable_elimination_oracle(
     potentials: CliqueVector, total: float = 1
 ):
-    return marginal_oracles.bulk_variable_elimination(
-        potentials, potentials.cliques, total
-    )
+  return marginal_oracles.bulk_variable_elimination(
+      potentials, potentials.cliques, total
+  )
 
 
 _implicit_materialized = functools.partial(
@@ -127,197 +127,191 @@ _SCHEDULES = [
 
 class TestMarginalOracles(unittest.TestCase):
 
-    @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS))
-    def test_shapes(self, oracle, cliques):
-        zeros = CliqueVector.zeros(_DOMAIN, cliques)
-        marginals = oracle(zeros)
-        self.assertEqual(marginals.domain, _DOMAIN)
-        self.assertEqual(marginals.cliques, tuple(cliques))
-        self.assertEqual(set(zeros.tables.keys()), set(marginals.tables.keys()))
-        for cl in cliques:
-            self.assertEqual(marginals[cl].domain.attributes, cl)
+  @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS))
+  def test_shapes(self, oracle, cliques):
+    zeros = CliqueVector.zeros(_DOMAIN, cliques)
+    marginals = oracle(zeros)
+    self.assertEqual(marginals.domain, _DOMAIN)
+    self.assertEqual(marginals.cliques, tuple(cliques))
+    self.assertEqual(set(zeros.tables.keys()), set(marginals.tables.keys()))
+    for cl in cliques:
+      self.assertEqual(marginals[cl].domain.attributes, cl)
 
-    @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS, [1, 100]))
-    def test_uniform(self, oracle, cliques, total=1):
-        zeros = CliqueVector.zeros(_DOMAIN, cliques)
-        marginals = oracle(zeros, total)
-        for cl in cliques:
-            expected = total / _DOMAIN.size(cl)
-            np.testing.assert_allclose(
-                marginals[cl].datavector(), expected, rtol=1e-5
-            )
+  @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS, [1, 100]))
+  def test_uniform(self, oracle, cliques, total=1):
+    zeros = CliqueVector.zeros(_DOMAIN, cliques)
+    marginals = oracle(zeros, total)
+    for cl in cliques:
+      expected = total / _DOMAIN.size(cl)
+      np.testing.assert_allclose(
+          marginals[cl].datavector(), expected, rtol=1e-5
+      )
 
-    @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS))
-    def test_matches_brute_force(self, oracle, cliques, total=10):
-        theta = CliqueVector.random(_DOMAIN, cliques)
-        mu1 = oracle(theta, total)
-        mu2 = marginal_oracles.brute_force_marginals(theta, total)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
-            )
+  @parameterized.expand(itertools.product(_ORACLES, _CLIQUE_SETS))
+  def test_matches_brute_force(self, oracle, cliques, total=10):
+    theta = CliqueVector.random(_DOMAIN, cliques)
+    mu1 = oracle(theta, total)
+    mu2 = marginal_oracles.brute_force_marginals(theta, total)
+    for cl in cliques:
+      np.testing.assert_allclose(
+          mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
+      )
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS, _ALL_CLIQUES))
-    def test_variable_elimination(self, model_cliques, query_clique):
-        theta = CliqueVector.random(_DOMAIN, model_cliques)
-        ans = marginal_oracles.variable_elimination(theta, query_clique)
-        self.assertEqual(ans.domain.attributes, query_clique)
+  @parameterized.expand(itertools.product(_CLIQUE_SETS, _ALL_CLIQUES))
+  def test_variable_elimination(self, model_cliques, query_clique):
+    theta = CliqueVector.random(_DOMAIN, model_cliques)
+    ans = marginal_oracles.variable_elimination(theta, query_clique)
+    self.assertEqual(ans.domain.attributes, query_clique)
 
-    @parameterized.expand(itertools.product(_CLIQUE_SETS, _ALL_CLIQUES))
-    def test_variable_elimination_evidence(self, model_cliques, query_clique):
-        theta = CliqueVector.random(_DOMAIN, model_cliques)
-        evidence_attr = _DOMAIN.attributes[0]
-        evidence_val = 0
-        evidence = {evidence_attr: evidence_val}
+  @parameterized.expand(itertools.product(_CLIQUE_SETS, _ALL_CLIQUES))
+  def test_variable_elimination_evidence(self, model_cliques, query_clique):
+    theta = CliqueVector.random(_DOMAIN, model_cliques)
+    evidence_attr = _DOMAIN.attributes[0]
+    evidence_val = 0
+    evidence = {evidence_attr: evidence_val}
 
-        if evidence_attr in query_clique:
-            with self.assertRaises(ValueError):
-                marginal_oracles.variable_elimination(
-                    theta, query_clique, evidence=evidence
-                )
-            return
-
-        target_clique_full = tuple(set(query_clique) | set(evidence.keys()))
-
-        ans1 = marginal_oracles.variable_elimination(
+    if evidence_attr in query_clique:
+      with self.assertRaises(ValueError):
+        marginal_oracles.variable_elimination(
             theta, query_clique, evidence=evidence
         )
+      return
 
-        ans2_full = marginal_oracles.variable_elimination(
-            theta, target_clique_full
-        )
-        ans2 = ans2_full.slice(evidence)
+    target_clique_full = tuple(set(query_clique) | set(evidence.keys()))
 
-        ans1 = ans1.normalize()
-        ans2 = ans2.normalize()
+    ans1 = marginal_oracles.variable_elimination(
+        theta, query_clique, evidence=evidence
+    )
 
-        ans2 = ans2.transpose(ans1.domain.attributes)
+    ans2_full = marginal_oracles.variable_elimination(theta, target_clique_full)
+    ans2 = ans2_full.slice(evidence)
 
-        np.testing.assert_allclose(ans1.values, ans2.values, atol=1e-5)
-        self.assertEqual(ans1.domain, ans2.domain)
+    ans1 = ans1.normalize()
+    ans2 = ans2.normalize()
 
-    @parameterized.expand(_STABLE_ORACLES)
-    def test_nan_potentials(self, oracle):
-        """Test that -inf potentials are handled correctly without NaNs."""
-        cliques = [
-            ("A", "B", "C"),
-            ("A",),
-            ("D",),
-            ("D", "A"),
-            ("D", "A", "C"),
-            ("A", "B"),
-        ]
+    ans2 = ans2.transpose(ans1.domain.attributes)
 
-        dom = Domain(["A", "B", "C", "D"], [2, 2, 2, 2])
-        potentials = CliqueVector.zeros(dom, cliques)
+    np.testing.assert_allclose(ans1.values, ans2.values, atol=1e-5)
+    self.assertEqual(ans1.domain, ans2.domain)
 
-        con = Factor(
-            dom.project(["A", "C"]), jnp.array([[0, -np.inf], [-np.inf, 0]])
-        )
-        potentials = CliqueVector(
-            potentials.domain,
-            potentials.cliques + (("A", "C"),),
-            {**potentials.tables, ("A", "C"): con},
-        )
+  @parameterized.expand(_STABLE_ORACLES)
+  def test_nan_potentials(self, oracle):
+    """Test that -inf potentials are handled correctly without NaNs."""
+    cliques = [
+        ("A", "B", "C"),
+        ("A",),
+        ("D",),
+        ("D", "A"),
+        ("D", "A", "C"),
+        ("A", "B"),
+    ]
 
-        marginals = oracle(potentials)
+    dom = Domain(["A", "B", "C", "D"], [2, 2, 2, 2])
+    potentials = CliqueVector.zeros(dom, cliques)
 
-        for cl, factor in marginals.tables.items():
-            self.assertFalse(
-                jnp.isnan(factor.values).any(), f"NaNs found in clique {cl}"
-            )
-            # With normalize(total=1), we expect sums to be 1.0 (or very close)
-            # The domain is A,C correlated perfectly (A=C). A=0,C=1 and A=1,C=0 are impossible.
-            # This is a valid graphical model configuration.
-            self.assertTrue(
-                jnp.allclose(factor.sum().values, 1.0),
-                f"Marginal for {cl} does not sum to 1",
-            )
+    con = Factor(
+        dom.project(["A", "C"]), jnp.array([[0, -np.inf], [-np.inf, 0]])
+    )
+    potentials = CliqueVector(
+        potentials.domain,
+        potentials.cliques + (("A", "C"),),
+        {**potentials.tables, ("A", "C"): con},
+    )
 
-    # --- Tests for the composable API ---
+    marginals = oracle(potentials)
 
-    @parameterized.expand(itertools.product(_SCHEDULES, _CLIQUE_SETS))
-    def test_schedule_matches_brute_force(self, oracle, cliques, total=10):
-        """Every schedule produces identical marginals to brute force."""
-        theta = CliqueVector.random(_DOMAIN, cliques)
-        mu1 = oracle(theta, total)
-        mu2 = marginal_oracles.brute_force_marginals(theta, total)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
-            )
+    for cl, factor in marginals.tables.items():
+      self.assertFalse(
+          jnp.isnan(factor.values).any(), f"NaNs found in clique {cl}"
+      )
+      # With normalize(total=1), we expect sums to be 1.0 (or very close)
+      # The domain is A,C correlated perfectly (A=C). A=0,C=1 and A=1,C=0 are impossible.
+      # This is a valid graphical model configuration.
+      self.assertTrue(
+          jnp.allclose(factor.sum().values, 1.0),
+          f"Marginal for {cl} does not sum to 1",
+      )
 
-    @parameterized.expand(itertools.product(_CONTRACTIONS, _CLIQUE_SETS))
-    def test_contraction_matches_brute_force(
-        self, contraction, cliques, total=10
-    ):
-        """Every contraction function produces identical marginals to brute force."""
-        theta = CliqueVector.random(_DOMAIN, cliques)
-        mu1 = message_passing_implicit(theta, total, contraction=contraction)
-        mu2 = marginal_oracles.brute_force_marginals(theta, total)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
-            )
+  # --- Tests for the composable API ---
+
+  @parameterized.expand(itertools.product(_SCHEDULES, _CLIQUE_SETS))
+  def test_schedule_matches_brute_force(self, oracle, cliques, total=10):
+    """Every schedule produces identical marginals to brute force."""
+    theta = CliqueVector.random(_DOMAIN, cliques)
+    mu1 = oracle(theta, total)
+    mu2 = marginal_oracles.brute_force_marginals(theta, total)
+    for cl in cliques:
+      np.testing.assert_allclose(
+          mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
+      )
+
+  @parameterized.expand(itertools.product(_CONTRACTIONS, _CLIQUE_SETS))
+  def test_contraction_matches_brute_force(
+      self, contraction, cliques, total=10
+  ):
+    """Every contraction function produces identical marginals to brute force."""
+    theta = CliqueVector.random(_DOMAIN, cliques)
+    mu1 = message_passing_implicit(theta, total, contraction=contraction)
+    mu2 = marginal_oracles.brute_force_marginals(theta, total)
+    for cl in cliques:
+      np.testing.assert_allclose(
+          mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
+      )
 
 
 class TestDefaultOracle(unittest.TestCase):
 
-    def test_cpu_returns_shafer_shenoy(self):
-        oracle = marginal_oracles.default_oracle(backend="cpu")
-        self.assertIs(oracle, message_passing_shafer_shenoy)
+  def test_cpu_returns_shafer_shenoy(self):
+    oracle = marginal_oracles.default_oracle(backend="cpu")
+    self.assertIs(oracle, message_passing_shafer_shenoy)
 
-    def test_gpu_small_returns_shafer_shenoy(self):
-        cliques = (("a", "b"), ("b", "c"), ("c", "d"))
-        oracle = marginal_oracles.default_oracle(
-            cliques, _DOMAIN, backend="gpu"
-        )
-        self.assertIs(oracle, message_passing_shafer_shenoy)
+  def test_gpu_small_returns_shafer_shenoy(self):
+    cliques = (("a", "b"), ("b", "c"), ("c", "d"))
+    oracle = marginal_oracles.default_oracle(cliques, _DOMAIN, backend="gpu")
+    self.assertIs(oracle, message_passing_shafer_shenoy)
 
-    def test_gpu_moderate_returns_shafer_shenoy(self):
-        """1M clique no longer triggers implicit (old threshold)."""
-        domain = Domain(["a", "b", "c"], [100, 100, 100])
-        cliques = (("a", "b", "c"),)
-        oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
-        self.assertIs(oracle, message_passing_shafer_shenoy)
+  def test_gpu_moderate_returns_shafer_shenoy(self):
+    """1M clique no longer triggers implicit (old threshold)."""
+    domain = Domain(["a", "b", "c"], [100, 100, 100])
+    cliques = (("a", "b", "c"),)
+    oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
+    self.assertIs(oracle, message_passing_shafer_shenoy)
 
-    def test_gpu_huge_few_nodes_returns_implicit(self):
-        """Huge SCs (>50M) with few JT nodes -> implicit (data movement)."""
-        # 3 attrs with card ~370 each -> single 3-way clique ~ 50.6M entries.
-        domain = Domain(["a", "b", "c"], [370, 370, 370])
-        cliques = (("a", "b", "c"),)
-        oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
-        self.assertIs(oracle, message_passing_implicit)
+  def test_gpu_huge_few_nodes_returns_implicit(self):
+    """Huge SCs (>50M) with few JT nodes -> implicit (data movement)."""
+    # 3 attrs with card ~370 each -> single 3-way clique ~ 50.6M entries.
+    domain = Domain(["a", "b", "c"], [370, 370, 370])
+    cliques = (("a", "b", "c"),)
+    oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
+    self.assertIs(oracle, message_passing_implicit)
 
-    def test_gpu_huge_many_nodes_returns_shafer_shenoy(self):
-        """Huge SCs but many JT nodes -> SS (kernel fusion advantage)."""
-        # 40 attrs in a chain, card=100 each, bw=2 -> max SC=1M, 39 nodes.
-        attrs = [f"x{i}" for i in range(40)]
-        domain = Domain(attrs, [100] * 40)
-        cliques = tuple(
-            (attrs[i], attrs[i + 1], attrs[i + 2]) for i in range(38)
-        )
-        oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
-        # Max SC = 100^3 = 1M < 50M, many nodes -> SS.
-        self.assertIs(oracle, message_passing_shafer_shenoy)
+  def test_gpu_huge_many_nodes_returns_shafer_shenoy(self):
+    """Huge SCs but many JT nodes -> SS (kernel fusion advantage)."""
+    # 40 attrs in a chain, card=100 each, bw=2 -> max SC=1M, 39 nodes.
+    attrs = [f"x{i}" for i in range(40)]
+    domain = Domain(attrs, [100] * 40)
+    cliques = tuple((attrs[i], attrs[i + 1], attrs[i + 2]) for i in range(38))
+    oracle = marginal_oracles.default_oracle(cliques, domain, backend="gpu")
+    # Max SC = 100^3 = 1M < 50M, many nodes -> SS.
+    self.assertIs(oracle, message_passing_shafer_shenoy)
 
-    def test_gpu_no_cliques_returns_shafer_shenoy(self):
-        oracle = marginal_oracles.default_oracle(backend="gpu")
-        self.assertIs(oracle, message_passing_shafer_shenoy)
+  def test_gpu_no_cliques_returns_shafer_shenoy(self):
+    oracle = marginal_oracles.default_oracle(backend="gpu")
+    self.assertIs(oracle, message_passing_shafer_shenoy)
 
-    @parameterized.expand([(cs,) for cs in _CLIQUE_SETS])
-    def test_correctness(self, cliques):
-        """default_oracle produces correct marginals."""
-        if not cliques:
-            return
-        oracle = marginal_oracles.default_oracle(cliques, _DOMAIN)
-        theta = CliqueVector.random(_DOMAIN, cliques)
-        mu1 = oracle(theta, 1.0)
-        mu2 = marginal_oracles.brute_force_marginals(theta, 1.0)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
-            )
+  @parameterized.expand([(cs,) for cs in _CLIQUE_SETS])
+  def test_correctness(self, cliques):
+    """default_oracle produces correct marginals."""
+    if not cliques:
+      return
+    oracle = marginal_oracles.default_oracle(cliques, _DOMAIN)
+    theta = CliqueVector.random(_DOMAIN, cliques)
+    mu1 = oracle(theta, 1.0)
+    mu2 = marginal_oracles.brute_force_marginals(theta, 1.0)
+    for cl in cliques:
+      np.testing.assert_allclose(
+          mu1[cl].datavector(), mu2[cl].datavector(), atol=1e-5
+      )
 
 
 # --- Constraint-aware oracle tests ---
@@ -362,111 +356,109 @@ _FOLDING_ORACLES = [
 
 
 def _fold_baseline(potentials, total, constraints):
-    """Brute-force baseline with constraints folded as -inf potentials."""
-    cliques = list(potentials.cliques)
-    arrays = dict(potentials.tables)
-    for c in constraints:
-        cl = potentials.domain.canonical(c.clique)
-        pot = c.potential.transpose(cl)
-        if cl in arrays:
-            arrays[cl] = arrays[cl] + pot
-        else:
-            arrays[cl] = pot
-            cliques.append(cl)
-    folded = CliqueVector(potentials.domain, cliques, arrays)
-    return marginal_oracles.brute_force_marginals(folded, total)
+  """Brute-force baseline with constraints folded as -inf potentials."""
+  cliques = list(potentials.cliques)
+  arrays = dict(potentials.tables)
+  for c in constraints:
+    cl = potentials.domain.canonical(c.clique)
+    pot = c.potential.transpose(cl)
+    if cl in arrays:
+      arrays[cl] = arrays[cl] + pot
+    else:
+      arrays[cl] = pot
+      cliques.append(cl)
+  folded = CliqueVector(potentials.domain, cliques, arrays)
+  return marginal_oracles.brute_force_marginals(folded, total)
 
 
 class TestConstrainedOracles(unittest.TestCase):
 
-    @parameterized.expand(
-        itertools.product(
-            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
-        )
-    )
-    def test_matches_brute_force(self, oracle, cliques, constraints):
-        """Constrained oracle matches brute-force with folded -inf baseline."""
-        theta = CliqueVector.random(_CDOMAIN, cliques)
-        mu = oracle(theta, 10.0, constraints=constraints)
-        baseline = _fold_baseline(theta, 10.0, constraints)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                mu[cl].datavector(),
-                baseline[cl].datavector(),
-                atol=1e-4,
-                err_msg=f"{oracle}, {cl}",
-            )
+  @parameterized.expand(
+      itertools.product(
+          _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+      )
+  )
+  def test_matches_brute_force(self, oracle, cliques, constraints):
+    """Constrained oracle matches brute-force with folded -inf baseline."""
+    theta = CliqueVector.random(_CDOMAIN, cliques)
+    mu = oracle(theta, 10.0, constraints=constraints)
+    baseline = _fold_baseline(theta, 10.0, constraints)
+    for cl in cliques:
+      np.testing.assert_allclose(
+          mu[cl].datavector(),
+          baseline[cl].datavector(),
+          atol=1e-4,
+          err_msg=f"{oracle}, {cl}",
+      )
 
-    @parameterized.expand(
-        itertools.product(
-            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
-        )
-    )
-    def test_sums_to_total(self, oracle, cliques, constraints):
-        """Constrained marginals sum to the requested total."""
-        theta = CliqueVector.random(_CDOMAIN, cliques)
-        mu = oracle(theta, 10.0, constraints=constraints)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                mu[cl].datavector().sum(), 10.0, atol=1e-4
-            )
+  @parameterized.expand(
+      itertools.product(
+          _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+      )
+  )
+  def test_sums_to_total(self, oracle, cliques, constraints):
+    """Constrained marginals sum to the requested total."""
+    theta = CliqueVector.random(_CDOMAIN, cliques)
+    mu = oracle(theta, 10.0, constraints=constraints)
+    for cl in cliques:
+      np.testing.assert_allclose(mu[cl].datavector().sum(), 10.0, atol=1e-4)
 
-    @parameterized.expand(
-        itertools.product(
-            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
-        )
-    )
-    def test_no_nans(self, oracle, cliques, constraints):
-        """Constrained marginals contain no NaNs."""
-        theta = CliqueVector.random(_CDOMAIN, cliques)
-        mu = oracle(theta, 10.0, constraints=constraints)
-        for cl in cliques:
-            self.assertFalse(jnp.isnan(mu[cl].values).any(), f"NaN in {cl}")
+  @parameterized.expand(
+      itertools.product(
+          _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+      )
+  )
+  def test_no_nans(self, oracle, cliques, constraints):
+    """Constrained marginals contain no NaNs."""
+    theta = CliqueVector.random(_CDOMAIN, cliques)
+    mu = oracle(theta, 10.0, constraints=constraints)
+    for cl in cliques:
+      self.assertFalse(jnp.isnan(mu[cl].values).any(), f"NaN in {cl}")
 
-    @parameterized.expand(
-        itertools.product(
-            _FOLDING_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
-        )
-    )
-    def test_folding_matches_brute_force(self, oracle, cliques, constraints):
-        """Core oracles with folded constraints match brute-force baseline."""
-        theta = CliqueVector.random(_CDOMAIN, cliques)
-        mu = oracle(theta, 10.0, constraints=constraints)
-        baseline = _fold_baseline(theta, 10.0, constraints)
-        for cl in cliques:
-            np.testing.assert_allclose(
-                mu[cl].datavector(),
-                baseline[cl].datavector(),
-                atol=1e-4,
-                err_msg=f"{oracle}, {cl}",
-            )
+  @parameterized.expand(
+      itertools.product(
+          _FOLDING_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+      )
+  )
+  def test_folding_matches_brute_force(self, oracle, cliques, constraints):
+    """Core oracles with folded constraints match brute-force baseline."""
+    theta = CliqueVector.random(_CDOMAIN, cliques)
+    mu = oracle(theta, 10.0, constraints=constraints)
+    baseline = _fold_baseline(theta, 10.0, constraints)
+    for cl in cliques:
+      np.testing.assert_allclose(
+          mu[cl].datavector(),
+          baseline[cl].datavector(),
+          atol=1e-4,
+          err_msg=f"{oracle}, {cl}",
+      )
 
-    @parameterized.expand(
-        itertools.product(
-            _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
-        )
-    )
-    def test_constraints_satisfied(self, oracle, cliques, constraints):
-        """Invalid entries in the constraint marginal are zero."""
-        theta = CliqueVector.random(_CDOMAIN, cliques)
-        mu = oracle(theta, 10.0, constraints=constraints)
-        for c in constraints:
-            fine, coarse = c.domain.attributes
-            # Build the expected mask from the constraint.
-            expected_zero = np.ones(c.domain.shape, dtype=bool)
-            for a in range(c.domain.shape[0]):
-                expected_zero[a, c.mapping[a]] = False
-            # Check every user clique that contains fine or coarse.
-            for cl in cliques:
-                vals = mu[cl].datavector()
-                if fine in cl and coarse in cl:
-                    # Joint over both: invalid cells must be zero.
-                    joint = mu[cl].project((fine, coarse))
-                    np.testing.assert_allclose(
-                        joint.values[expected_zero],
-                        0.0,
-                        atol=1e-5,
-                        err_msg=f"constraint violated in clique {cl}",
-                    )
-                # All marginals should be non-negative.
-                self.assertTrue((vals >= -1e-6).all(), f"negative in {cl}")
+  @parameterized.expand(
+      itertools.product(
+          _CONSTRAINED_ORACLES, _CONSTRAINED_CLIQUE_SETS, _CONSTRAINT_CONFIGS
+      )
+  )
+  def test_constraints_satisfied(self, oracle, cliques, constraints):
+    """Invalid entries in the constraint marginal are zero."""
+    theta = CliqueVector.random(_CDOMAIN, cliques)
+    mu = oracle(theta, 10.0, constraints=constraints)
+    for c in constraints:
+      fine, coarse = c.domain.attributes
+      # Build the expected mask from the constraint.
+      expected_zero = np.ones(c.domain.shape, dtype=bool)
+      for a in range(c.domain.shape[0]):
+        expected_zero[a, c.mapping[a]] = False
+      # Check every user clique that contains fine or coarse.
+      for cl in cliques:
+        vals = mu[cl].datavector()
+        if fine in cl and coarse in cl:
+          # Joint over both: invalid cells must be zero.
+          joint = mu[cl].project((fine, coarse))
+          np.testing.assert_allclose(
+              joint.values[expected_zero],
+              0.0,
+              atol=1e-5,
+              err_msg=f"constraint violated in clique {cl}",
+          )
+        # All marginals should be non-negative.
+        self.assertTrue((vals >= -1e-6).all(), f"negative in {cl}")

--- a/test/test_markov_random_field.py
+++ b/test/test_markov_random_field.py
@@ -12,256 +12,254 @@ from mbi import (
 
 class TestMarkovRandomField(unittest.TestCase):
 
-    def test_synthetic_data_accuracy(self):
-        domain = Domain(["A", "B"], [10, 10])
-        factor = Factor.random(domain).normalize(1.0)
-        marginals = CliqueVector(domain, [("A", "B")], {("A", "B"): factor})
-        N = 1000
-        model = MarkovRandomField(
-            potentials=marginals.log(), marginals=marginals, total=N
-        )
-        synthetic = model.synthetic_data(rows=N, method="round")
-        syn_factor = synthetic.project(("A", "B"))
-        syn_counts = syn_factor.datavector(flatten=True)
-        exp_factor = marginals.project(("A", "B"))
-        exp_counts = exp_factor.datavector(flatten=True) * N
-        diff = np.abs(syn_counts - exp_counts)
-        max_diff = np.max(diff)
-        self.assertTrue(
-            np.all(diff <= 2.0000001),
-            f"Counts deviated by {max_diff}, expected <= 2",
-        )
+  def test_synthetic_data_accuracy(self):
+    domain = Domain(["A", "B"], [10, 10])
+    factor = Factor.random(domain).normalize(1.0)
+    marginals = CliqueVector(domain, [("A", "B")], {("A", "B"): factor})
+    N = 1000
+    model = MarkovRandomField(
+        potentials=marginals.log(), marginals=marginals, total=N
+    )
+    synthetic = model.synthetic_data(rows=N, method="round")
+    syn_factor = synthetic.project(("A", "B"))
+    syn_counts = syn_factor.datavector(flatten=True)
+    exp_factor = marginals.project(("A", "B"))
+    exp_counts = exp_factor.datavector(flatten=True) * N
+    diff = np.abs(syn_counts - exp_counts)
+    max_diff = np.max(diff)
+    self.assertTrue(
+        np.all(diff <= 2.0000001),
+        f"Counts deviated by {max_diff}, expected <= 2",
+    )
 
-    def test_linear_indexing_strides(self):
-        """
-        Regression test for linear indexing bug where strides were calculated in Fortran order
-        instead of C order, causing mismatch with C-ordered conditional probability arrays.
-        """
-        # Domain: A(2), B(3), C(2).
-        # Generation order is C, B, A (based on previous run).
-        # So A is child of B, C.
-        # Parents of A: B(3), C(2). Sizes: [3, 2].
-        # C-strides: [2, 1]. Index = 2*B + 1*C.
-        # F-strides: [1, 3]. Index = 1*B + 3*C.
+  def test_linear_indexing_strides(self):
+    """
+    Regression test for linear indexing bug where strides were calculated in Fortran order
+    instead of C order, causing mismatch with C-ordered conditional probability arrays.
+    """
+    # Domain: A(2), B(3), C(2).
+    # Generation order is C, B, A (based on previous run).
+    # So A is child of B, C.
+    # Parents of A: B(3), C(2). Sizes: [3, 2].
+    # C-strides: [2, 1]. Index = 2*B + 1*C.
+    # F-strides: [1, 3]. Index = 1*B + 3*C.
 
-        # We want to distinguish (B=1, C=0) from (B=0, C=1).
-        # (B=1, C=0):
-        #   C-index: 1*2 + 0*1 = 2.
-        #   F-index: 1*1 + 0*3 = 1.
-        # Index 1 corresponds to (B=0, C=1) in C-order (0*2 + 1*1 = 1).
+    # We want to distinguish (B=1, C=0) from (B=0, C=1).
+    # (B=1, C=0):
+    #   C-index: 1*2 + 0*1 = 2.
+    #   F-index: 1*1 + 0*3 = 1.
+    # Index 1 corresponds to (B=0, C=1) in C-order (0*2 + 1*1 = 1).
 
-        # Setup:
-        #   P(A=1 | B=1, C=0) = 1.0  (Target case)
-        #   P(A=1 | B=0, C=1) = 0.0  (Trap case)
-        #
-        # If bug is present:
-        #   Row with (B=1, C=0) calculates index 1.
-        #   It looks up cond_probs[1], which corresponds to (B=0, C=1).
-        #   P(A=1) = 0.0.
-        #   Generates A=0.
-        #
-        # If correct:
-        #   Row with (B=1, C=0) calculates index 2.
-        #   P(A=1) = 1.0.
-        #   Generates A=1.
+    # Setup:
+    #   P(A=1 | B=1, C=0) = 1.0  (Target case)
+    #   P(A=1 | B=0, C=1) = 0.0  (Trap case)
+    #
+    # If bug is present:
+    #   Row with (B=1, C=0) calculates index 1.
+    #   It looks up cond_probs[1], which corresponds to (B=0, C=1).
+    #   P(A=1) = 0.0.
+    #   Generates A=0.
+    #
+    # If correct:
+    #   Row with (B=1, C=0) calculates index 2.
+    #   P(A=1) = 1.0.
+    #   Generates A=1.
 
-        domain = Domain(["A", "B", "C"], [2, 3, 2])
+    domain = Domain(["A", "B", "C"], [2, 3, 2])
 
-        # Initialize data
-        data = np.ones((2, 3, 2))
+    # Initialize data
+    data = np.ones((2, 3, 2))
 
-        # Target: (B=1, C=0) -> A=1
-        data[1, 1, 0] = 1000
-        data[0, 1, 0] = 0
+    # Target: (B=1, C=0) -> A=1
+    data[1, 1, 0] = 1000
+    data[0, 1, 0] = 0
 
-        # Trap: (B=0, C=1) -> A=0
-        data[1, 0, 1] = 0
-        data[0, 0, 1] = 1000
+    # Trap: (B=0, C=1) -> A=0
+    data[1, 0, 1] = 0
+    data[0, 0, 1] = 1000
 
-        # Ensure we generate B=1, C=0 frequently
-        # We can just rely on the fact that (B=1, C=0) has high weight (1000)
-        # compared to others (1).
+    # Ensure we generate B=1, C=0 frequently
+    # We can just rely on the fact that (B=1, C=0) has high weight (1000)
+    # compared to others (1).
 
-        factor = Factor(domain, data)
-        marginals = CliqueVector(
-            domain, [("A", "B", "C")], {("A", "B", "C"): factor}
-        )
+    factor = Factor(domain, data)
+    marginals = CliqueVector(
+        domain, [("A", "B", "C")], {("A", "B", "C"): factor}
+    )
 
-        N = 1000
-        model = MarkovRandomField(
-            potentials=marginals, marginals=marginals, total=N
-        )
+    N = 1000
+    model = MarkovRandomField(
+        potentials=marginals, marginals=marginals, total=N
+    )
 
-        synthetic = model.synthetic_data(rows=N, method="round")
-        data = synthetic.to_dict()
+    synthetic = model.synthetic_data(rows=N, method="round")
+    data = synthetic.to_dict()
 
-        # Filter rows where B=1, C=0
-        mask = (data["B"] == 1) & (data["C"] == 0)
-        subset_A = data["A"][mask]
+    # Filter rows where B=1, C=0
+    mask = (data["B"] == 1) & (data["C"] == 0)
+    subset_A = data["A"][mask]
 
-        self.assertGreater(
-            len(subset_A), 0, "Should have generated rows with B=1, C=0"
-        )
+    self.assertGreater(
+        len(subset_A), 0, "Should have generated rows with B=1, C=0"
+    )
 
-        # Check A values
-        # Should be all 1s
-        a_ones = subset_A.sum()
-        self.assertEqual(
-            a_ones,
-            len(subset_A),
-            f"Expected all A=1 for B=1, C=0. Found {a_ones}/{len(subset_A)}"
-            " A=1s. This indicates linear indexing stride mismatch.",
-        )
+    # Check A values
+    # Should be all 1s
+    a_ones = subset_A.sum()
+    self.assertEqual(
+        a_ones,
+        len(subset_A),
+        f"Expected all A=1 for B=1, C=0. Found {a_ones}/{len(subset_A)}"
+        " A=1s. This indicates linear indexing stride mismatch.",
+    )
 
-    def test_synthetic_data_round_accuracy_adult(self):
-        """
-        Integration test verifying that synthetic_data(method='round') preserves
-        conditional correlations (clique marginals) with high accuracy, using
-        logic derived from the Adult dataset reproduction case.
-        """
-        try:
-            data = Dataset.load("data/adult.csv", "data/adult-domain.json")
-        except FileNotFoundError:
-            # Skip if data is not present (e.g. in CI environment without data folder)
-            return
-        except Exception:
-            # Also skip on other errors like missing data files or parse issues in limited environments
-            return
+  def test_synthetic_data_round_accuracy_adult(self):
+    """
+    Integration test verifying that synthetic_data(method='round') preserves
+    conditional correlations (clique marginals) with high accuracy, using
+    logic derived from the Adult dataset reproduction case.
+    """
+    try:
+      data = Dataset.load("data/adult.csv", "data/adult-domain.json")
+    except FileNotFoundError:
+      # Skip if data is not present (e.g. in CI environment without data folder)
+      return
+    except Exception:
+      # Also skip on other errors like missing data files or parse issues in limited environments
+      return
 
-        domain = data.domain
+    domain = data.domain
 
-        # Clique from the reported issue
-        clique = (
-            "marital-status",
-            "occupation",
-            "relationship",
-            "race",
-            "sex",
-            "native-country",
-            "income>50K",
-        )
+    # Clique from the reported issue
+    clique = (
+        "marital-status",
+        "occupation",
+        "relationship",
+        "race",
+        "sex",
+        "native-country",
+        "income>50K",
+    )
 
-        joint = data.project(clique) + 0.0001
-        joint_marginals = CliqueVector(domain, [clique], {clique: joint})
+    joint = data.project(clique) + 0.0001
+    joint_marginals = CliqueVector(domain, [clique], {clique: joint})
 
-        model = MarkovRandomField(
-            potentials=joint_marginals.log(),
-            marginals=joint_marginals,
-            total=joint.values.sum(),
-        )
+    model = MarkovRandomField(
+        potentials=joint_marginals.log(),
+        marginals=joint_marginals,
+        total=joint.values.sum(),
+    )
 
-        # Generate synthetic data
-        np.random.seed(0)
-        synth = model.synthetic_data(method="round")
+    # Generate synthetic data
+    np.random.seed(0)
+    synth = model.synthetic_data(method="round")
 
-        # Verify specific problematic pair
-        cl = ("marital-status", "relationship")
-        model_ans = model.project(cl).datavector(flatten=False).astype(int)
-        synth_ans = synth.project(cl).datavector(flatten=False).astype(int)
+    # Verify specific problematic pair
+    cl = ("marital-status", "relationship")
+    model_ans = model.project(cl).datavector(flatten=False).astype(int)
+    synth_ans = synth.project(cl).datavector(flatten=False).astype(int)
 
-        # Error metric: sum of absolute differences normalized by N
-        error = np.abs(model_ans - synth_ans).sum() / data.records
+    # Error metric: sum of absolute differences normalized by N
+    error = np.abs(model_ans - synth_ans).sum() / data.records
 
-        # Threshold: achieves ~0.0009 with x64, ~0.0017 with float32.
-        self.assertLess(
-            error,
-            0.002,
-            f"Error {error} exceeded threshold 0.002 for pair {cl}",
-        )
+    # Threshold: achieves ~0.0009 with x64, ~0.0017 with float32.
+    self.assertLess(
+        error,
+        0.002,
+        f"Error {error} exceeded threshold 0.002 for pair {cl}",
+    )
 
 
 def _create_random_model(domain, cliques, N):
-    """Creates a random MRF with given cliques and total count N."""
-    potentials = {}
-    np.random.seed(0)
+  """Creates a random MRF with given cliques and total count N."""
+  potentials = {}
+  np.random.seed(0)
 
-    for cl in cliques:
-        vals = np.random.rand(*domain.project(cl).shape) + 1e-10
-        f = Factor(domain.project(cl), vals)
-        potentials[cl] = f.log()
+  for cl in cliques:
+    vals = np.random.rand(*domain.project(cl).shape) + 1e-10
+    f = Factor(domain.project(cl), vals)
+    potentials[cl] = f.log()
 
-    potential_vector = CliqueVector(domain, cliques, potentials)
-    marginals = marginal_oracles.message_passing_stable(
-        potential_vector, total=N
-    )
+  potential_vector = CliqueVector(domain, cliques, potentials)
+  marginals = marginal_oracles.message_passing_stable(potential_vector, total=N)
 
-    return MarkovRandomField(
-        potentials=potential_vector, marginals=marginals, total=N
-    )
+  return MarkovRandomField(
+      potentials=potential_vector, marginals=marginals, total=N
+  )
 
 
 class TestSyntheticDataComprehensive(unittest.TestCase):
 
-    def _test_model_structure(self, domain, cliques, N=10000):
-        """Tests synthetic data generation for a specific model structure."""
-        model = _create_random_model(domain, cliques, N)
+  def _test_model_structure(self, domain, cliques, N=10000):
+    """Tests synthetic data generation for a specific model structure."""
+    model = _create_random_model(domain, cliques, N)
 
-        # Generate synthetic data
-        syn_round = model.synthetic_data(rows=N, method="round")
-        syn_sample = model.synthetic_data(rows=N, method="sample")
+    # Generate synthetic data
+    syn_round = model.synthetic_data(rows=N, method="round")
+    syn_sample = model.synthetic_data(rows=N, method="sample")
 
-        # Check errors on supported cliques
-        errors_round = []
-        errors_sample = []
+    # Check errors on supported cliques
+    errors_round = []
+    errors_sample = []
 
-        for cl in cliques:
-            marg_model = model.project(cl).datavector(flatten=True)
-            marg_round = syn_round.project(cl).datavector(flatten=True)
-            marg_sample = syn_sample.project(cl).datavector(flatten=True)
+    for cl in cliques:
+      marg_model = model.project(cl).datavector(flatten=True)
+      marg_round = syn_round.project(cl).datavector(flatten=True)
+      marg_sample = syn_sample.project(cl).datavector(flatten=True)
 
-            # L1 Error (Total Variation Distance * 2)
-            err_round = np.sum(np.abs(marg_round - marg_model))
-            err_sample = np.sum(np.abs(marg_sample - marg_model))
+      # L1 Error (Total Variation Distance * 2)
+      err_round = np.sum(np.abs(marg_round - marg_model))
+      err_sample = np.sum(np.abs(marg_sample - marg_model))
 
-            errors_round.append(err_round)
-            errors_sample.append(err_sample)
+      errors_round.append(err_round)
+      errors_sample.append(err_sample)
 
-            # Assert round error is better than sample error if sample error is significant
-            if err_sample > 1e-5:
-                # With N=10000, sample error should be large enough to distinguish.
-                # But to avoid flakiness if they are close, we can use a loose inequality or just a print
-                # However, the requirement is "asserting that it is always less".
-                self.assertLess(
-                    err_round,
-                    err_sample,
-                    f"Round error {err_round} should be less than Sample error"
-                    f" {err_sample} for clique {cl}",
-                )
+      # Assert round error is better than sample error if sample error is significant
+      if err_sample > 1e-5:
+        # With N=10000, sample error should be large enough to distinguish.
+        # But to avoid flakiness if they are close, we can use a loose inequality or just a print
+        # However, the requirement is "asserting that it is always less".
+        self.assertLess(
+            err_round,
+            err_sample,
+            f"Round error {err_round} should be less than Sample error"
+            f" {err_sample} for clique {cl}",
+        )
 
-            # Statistical check for sample error
-            size = marg_model.size
-            bound = 10 * np.sqrt(N * size)  # Very loose bound
-            self.assertLess(
-                err_sample,
-                bound,
-                f"Sample error {err_sample} exceeds bound {bound} for clique"
-                f" {cl} (size {size})",
-            )
+      # Statistical check for sample error
+      size = marg_model.size
+      bound = 10 * np.sqrt(N * size)  # Very loose bound
+      self.assertLess(
+          err_sample,
+          bound,
+          f"Sample error {err_sample} exceeds bound {bound} for clique"
+          f" {cl} (size {size})",
+      )
 
-    def test_independent_model(self):
-        """Test with all disjoint attributes (independent factors)."""
-        domain = Domain(["A", "B", "C", "D"], [2, 3, 2, 4])
-        cliques = [("A",), ("B",), ("C",), ("D",)]
-        self._test_model_structure(domain, cliques)
+  def test_independent_model(self):
+    """Test with all disjoint attributes (independent factors)."""
+    domain = Domain(["A", "B", "C", "D"], [2, 3, 2, 4])
+    cliques = [("A",), ("B",), ("C",), ("D",)]
+    self._test_model_structure(domain, cliques)
 
-    def test_single_big_model(self):
-        """Test with a single factor over the entire domain."""
-        domain = Domain(["A", "B", "C"], [2, 2, 3])
-        cliques = [("A", "B", "C")]
-        self._test_model_structure(domain, cliques)
+  def test_single_big_model(self):
+    """Test with a single factor over the entire domain."""
+    domain = Domain(["A", "B", "C"], [2, 2, 3])
+    cliques = [("A", "B", "C")]
+    self._test_model_structure(domain, cliques)
 
-    def test_pairwise_model(self):
-        """Test with factors over pairs of attributes."""
-        domain = Domain(["A", "B", "C"], [2, 2, 2])
-        cliques = [("A", "B"), ("B", "C"), ("A", "C")]
-        self._test_model_structure(domain, cliques)
+  def test_pairwise_model(self):
+    """Test with factors over pairs of attributes."""
+    domain = Domain(["A", "B", "C"], [2, 2, 2])
+    cliques = [("A", "B"), ("B", "C"), ("A", "C")]
+    self._test_model_structure(domain, cliques)
 
-    def test_mixed_model(self):
-        """Test with factors over 2, 3, and 4 attributes."""
-        domain = Domain(["A", "B", "C", "D", "E"], [2, 2, 2, 2, 2])
-        cliques = [("A", "B"), ("B", "C", "D"), ("C", "D", "E", "A")]  # Loop
-        self._test_model_structure(domain, cliques)
+  def test_mixed_model(self):
+    """Test with factors over 2, 3, and 4 attributes."""
+    domain = Domain(["A", "B", "C", "D", "E"], [2, 2, 2, 2, 2])
+    cliques = [("A", "B"), ("B", "C", "D"), ("C", "D", "E", "A")]  # Loop
+    self._test_model_structure(domain, cliques)
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/test_mixture_of_products.py
+++ b/test/test_mixture_of_products.py
@@ -29,291 +29,289 @@ _CLIQUE_SETS = [
 
 
 def _fake_measurements(domain, cliques):
-    """Create noise-free measurements from a random distribution."""
-    P = Factor.random(domain)
-    P = P / P.sum()
-    measurements = []
-    for cl in cliques:
-        y = P.project(cl).datavector()
-        measurements.append(marginal_loss.LinearMeasurement(y, cl))
-    return measurements, P
+  """Create noise-free measurements from a random distribution."""
+  P = Factor.random(domain)
+  P = P / P.sum()
+  measurements = []
+  for cl in cliques:
+    y = P.project(cl).datavector()
+    measurements.append(marginal_loss.LinearMeasurement(y, cl))
+  return measurements, P
 
 
 class TestMixtureOfProductsClass(unittest.TestCase):
-    """Tests for the MixtureOfProducts data structure."""
+  """Tests for the MixtureOfProducts data structure."""
 
-    def setUp(self):
-        domain = Domain(["x", "y"], [3, 4])
-        products = {
-            "x": jnp.array([[0.2, 0.3, 0.5], [0.4, 0.4, 0.2]]),
-            "y": jnp.array([[0.1, 0.2, 0.3, 0.4], [0.25, 0.25, 0.25, 0.25]]),
-        }
-        self.model = MixtureOfProducts(products, domain, total=100.0)
+  def setUp(self):
+    domain = Domain(["x", "y"], [3, 4])
+    products = {
+        "x": jnp.array([[0.2, 0.3, 0.5], [0.4, 0.4, 0.2]]),
+        "y": jnp.array([[0.1, 0.2, 0.3, 0.4], [0.25, 0.25, 0.25, 0.25]]),
+    }
+    self.model = MixtureOfProducts(products, domain, total=100.0)
 
-    def test_num_components(self):
-        self.assertEqual(self.model.num_components, 2)
+  def test_num_components(self):
+    self.assertEqual(self.model.num_components, 2)
 
-    def test_project_single_attr(self):
-        marg = self.model.project("x")
-        self.assertEqual(marg.domain, self.model.domain.project(("x",)))
-        # Marginal should sum to total
-        np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
+  def test_project_single_attr(self):
+    marg = self.model.project("x")
+    self.assertEqual(marg.domain, self.model.domain.project(("x",)))
+    # Marginal should sum to total
+    np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
 
-    def test_project_multiple_attrs(self):
-        marg = self.model.project(("x", "y"))
-        self.assertEqual(marg.domain.shape, (3, 4))
-        np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
+  def test_project_multiple_attrs(self):
+    marg = self.model.project(("x", "y"))
+    self.assertEqual(marg.domain.shape, (3, 4))
+    np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
 
-    def test_project_consistency(self):
-        """Marginal of the joint should equal the direct marginal."""
-        joint = self.model.project(("x", "y"))
-        marg_x_from_joint = joint.project("x")
-        marg_x_direct = self.model.project("x")
-        np.testing.assert_allclose(
-            marg_x_from_joint.datavector(),
-            marg_x_direct.datavector(),
-            atol=1e-6,
-        )
+  def test_project_consistency(self):
+    """Marginal of the joint should equal the direct marginal."""
+    joint = self.model.project(("x", "y"))
+    marg_x_from_joint = joint.project("x")
+    marg_x_direct = self.model.project("x")
+    np.testing.assert_allclose(
+        marg_x_from_joint.datavector(),
+        marg_x_direct.datavector(),
+        atol=1e-6,
+    )
 
-    def test_supports(self):
-        self.assertTrue(self.model.supports("x"))
-        self.assertTrue(self.model.supports(("x", "y")))
-        self.assertFalse(self.model.supports("z"))
+  def test_supports(self):
+    self.assertTrue(self.model.supports("x"))
+    self.assertTrue(self.model.supports(("x", "y")))
+    self.assertFalse(self.model.supports("z"))
 
-    def test_synthetic_data(self):
-        data = self.model.synthetic_data(rows=500)
-        self.assertEqual(data.records, 500)
-        self.assertEqual(data.domain, self.model.domain)
+  def test_synthetic_data(self):
+    data = self.model.synthetic_data(rows=500)
+    self.assertEqual(data.records, 500)
+    self.assertEqual(data.domain, self.model.domain)
 
-    def test_synthetic_data_default_rows(self):
-        data = self.model.synthetic_data()
-        self.assertEqual(data.records, 100)
+  def test_synthetic_data_default_rows(self):
+    data = self.model.synthetic_data()
+    self.assertEqual(data.records, 100)
 
-    def test_synthetic_data_values_in_range(self):
-        data = self.model.synthetic_data(rows=200)
-        data_dict = data.to_dict()
-        for col in self.model.domain.attributes:
-            col_data = data_dict[col]
-            self.assertTrue(np.all(col_data >= 0))
-            self.assertTrue(np.all(col_data < self.model.domain[col]))
+  def test_synthetic_data_values_in_range(self):
+    data = self.model.synthetic_data(rows=200)
+    data_dict = data.to_dict()
+    for col in self.model.domain.attributes:
+      col_data = data_dict[col]
+      self.assertTrue(np.all(col_data >= 0))
+      self.assertTrue(np.all(col_data < self.model.domain[col]))
 
 
 class TestMixtureOfProductsEstimation(unittest.TestCase):
-    """Tests for the mixture_of_products estimation function."""
+  """Tests for the mixture_of_products estimation function."""
 
-    @parameterized.expand([(cliques,) for cliques in _CLIQUE_SETS])
-    def test_noiseless_recovery(self, cliques):
-        """With noise-free measurements, the model should fit them closely."""
-        measurements, P = _fake_measurements(_DOMAIN, cliques)
-        model = MixtureOfProductsEstimator(
-            num_components=50,
-            learning_rate=0.1,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=500,
-        )
+  @parameterized.expand([(cliques,) for cliques in _CLIQUE_SETS])
+  def test_noiseless_recovery(self, cliques):
+    """With noise-free measurements, the model should fit them closely."""
+    measurements, P = _fake_measurements(_DOMAIN, cliques)
+    model = MixtureOfProductsEstimator(
+        num_components=50,
+        learning_rate=0.1,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=500,
+    )
 
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=5e-2)
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=5e-2)
 
-    def test_l1_loss(self):
-        """Test that L1 loss works without crashing and converges."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, P = _fake_measurements(_DOMAIN, cliques)
-        loss_fn = marginal_loss.from_linear_measurements(
-            measurements, _DOMAIN, norm="l1"
-        )
+  def test_l1_loss(self):
+    """Test that L1 loss works without crashing and converges."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, P = _fake_measurements(_DOMAIN, cliques)
+    loss_fn = marginal_loss.from_linear_measurements(
+        measurements, _DOMAIN, norm="l1"
+    )
 
-        model = MixtureOfProductsEstimator(
-            num_components=50,
-            learning_rate=0.01,
-        ).estimate(
-            _DOMAIN,
-            loss_fn,
-            known_total=1.0,
-            iters=500,
-        )
+    model = MixtureOfProductsEstimator(
+        num_components=50,
+        learning_rate=0.01,
+    ).estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=500,
+    )
 
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=0.1)
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=0.1)
 
-    def test_l2_loss(self):
-        """Test explicit L2 loss construction."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, P = _fake_measurements(_DOMAIN, cliques)
-        loss_fn = marginal_loss.from_linear_measurements(
-            measurements, _DOMAIN, norm="l2"
-        )
+  def test_l2_loss(self):
+    """Test explicit L2 loss construction."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, P = _fake_measurements(_DOMAIN, cliques)
+    loss_fn = marginal_loss.from_linear_measurements(
+        measurements, _DOMAIN, norm="l2"
+    )
 
-        model = MixtureOfProductsEstimator(
-            num_components=50,
-        ).estimate(
-            _DOMAIN,
-            loss_fn,
-            known_total=1.0,
-            iters=500,
-        )
+    model = MixtureOfProductsEstimator(
+        num_components=50,
+    ).estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=500,
+    )
 
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=5e-2)
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=5e-2)
 
-    def test_projectable_protocol(self):
-        """MixtureOfProducts should satisfy the Projectable protocol."""
-        cliques = [("a", "b"), ("c", "d")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        model = MixtureOfProductsEstimator(
-            num_components=10,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=50,
-        )
+  def test_projectable_protocol(self):
+    """MixtureOfProducts should satisfy the Projectable protocol."""
+    cliques = [("a", "b"), ("c", "d")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    model = MixtureOfProductsEstimator(
+        num_components=10,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=50,
+    )
 
-        # Check it has the required attributes/methods
-        self.assertTrue(hasattr(model, "domain"))
-        self.assertTrue(hasattr(model, "project"))
-        self.assertTrue(hasattr(model, "supports"))
-        self.assertEqual(model.domain, _DOMAIN)
+    # Check it has the required attributes/methods
+    self.assertTrue(hasattr(model, "domain"))
+    self.assertTrue(hasattr(model, "project"))
+    self.assertTrue(hasattr(model, "supports"))
+    self.assertEqual(model.domain, _DOMAIN)
 
-    def test_synthetic_data_from_estimation(self):
-        """Synthetic data should be generatable from an estimated model."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        model = MixtureOfProductsEstimator(
-            num_components=20,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
+  def test_synthetic_data_from_estimation(self):
+    """Synthetic data should be generatable from an estimated model."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    model = MixtureOfProductsEstimator(
+        num_components=20,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
 
-        data = model.synthetic_data(rows=1000)
-        self.assertEqual(data.records, 1000)
-        self.assertEqual(data.domain, _DOMAIN)
+    data = model.synthetic_data(rows=1000)
+    self.assertEqual(data.records, 1000)
+    self.assertEqual(data.domain, _DOMAIN)
 
-    def test_automatic_total_estimation(self):
-        """When given measurements, known_total should be estimated automatically."""
-        cliques = [("a", "b")]
-        P = Factor.random(_DOMAIN) * 1000
-        total = float(P.sum())
-        measurements = [
-            marginal_loss.LinearMeasurement(P.project(cl).datavector(), cl)
-            for cl in cliques
-        ]
+  def test_automatic_total_estimation(self):
+    """When given measurements, known_total should be estimated automatically."""
+    cliques = [("a", "b")]
+    P = Factor.random(_DOMAIN) * 1000
+    total = float(P.sum())
+    measurements = [
+        marginal_loss.LinearMeasurement(P.project(cl).datavector(), cl)
+        for cl in cliques
+    ]
 
-        model = MixtureOfProductsEstimator(
-            num_components=10,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=50,
-        )
-        # Total should be automatically estimated close to the true value
-        np.testing.assert_allclose(model.total, total, rtol=0.1)
+    model = MixtureOfProductsEstimator(
+        num_components=10,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=50,
+    )
+    # Total should be automatically estimated close to the true value
+    np.testing.assert_allclose(model.total, total, rtol=0.1)
 
-    def test_callback(self):
-        """Callback should be invoked during estimation."""
-        cliques = [("a", "b")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
+  def test_callback(self):
+    """Callback should be invoked during estimation."""
+    cliques = [("a", "b")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
 
-        callback_count = [0]
+    callback_count = [0]
 
-        def callback(model):
-            callback_count[0] += 1
+    def callback(model):
+      callback_count[0] += 1
 
-        MixtureOfProductsEstimator(
-            num_components=5,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-            callback_fn=callback,
-        )
-        self.assertGreater(callback_count[0], 0)
+    MixtureOfProductsEstimator(
+        num_components=5,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+        callback_fn=callback,
+    )
+    self.assertGreater(callback_count[0], 0)
 
-    def test_custom_optimizer(self):
-        """Should accept a custom optax optimizer."""
-        import optax
+  def test_custom_optimizer(self):
+    """Should accept a custom optax optimizer."""
+    import optax
 
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        model = MixtureOfProductsEstimator(
-            num_components=20,
-            optimizer=optax.sgd(0.01),
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
-        # Just check it runs without error
-        self.assertIsInstance(model, MixtureOfProducts)
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    model = MixtureOfProductsEstimator(
+        num_components=20,
+        optimizer=optax.sgd(0.01),
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
+    # Just check it runs without error
+    self.assertIsInstance(model, MixtureOfProducts)
 
-    def test_single_component(self):
-        """A single-component mixture is just a product distribution."""
-        cliques = [("a",), ("b",)]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        model = MixtureOfProductsEstimator(
-            num_components=1,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=500,
-        )
-        self.assertEqual(model.num_components, 1)
-        # Each singleton marginal should still be close
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=5e-2)
+  def test_single_component(self):
+    """A single-component mixture is just a product distribution."""
+    cliques = [("a",), ("b",)]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    model = MixtureOfProductsEstimator(
+        num_components=1,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=500,
+    )
+    self.assertEqual(model.num_components, 1)
+    # Each singleton marginal should still be close
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=5e-2)
 
 
 class TestMixtureOfProductsNonNegativity(unittest.TestCase):
-    """Test that the softmax parameterization guarantees non-negativity."""
+  """Test that the softmax parameterization guarantees non-negativity."""
 
-    def test_marginals_nonnegative(self):
-        """All marginals should be non-negative."""
-        cliques = [("a", "b"), ("b", "c"), ("c", "d")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        model = MixtureOfProductsEstimator(
-            num_components=20,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
+  def test_marginals_nonnegative(self):
+    """All marginals should be non-negative."""
+    cliques = [("a", "b"), ("b", "c"), ("c", "d")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    model = MixtureOfProductsEstimator(
+        num_components=20,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
 
-        for cl in cliques:
-            marg = model.project(cl)
-            self.assertTrue(
-                jnp.all(marg.values >= 0),
-                f"Negative values in marginal for clique {cl}",
-            )
+    for cl in cliques:
+      marg = model.project(cl)
+      self.assertTrue(
+          jnp.all(marg.values >= 0),
+          f"Negative values in marginal for clique {cl}",
+      )
 
-    def test_marginals_sum_to_total(self):
-        """Each marginal should sum to total."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        model = MixtureOfProductsEstimator(
-            num_components=20,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
+  def test_marginals_sum_to_total(self):
+    """Each marginal should sum to total."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    model = MixtureOfProductsEstimator(
+        num_components=20,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
 
-        for cl in cliques:
-            marg = model.project(cl)
-            np.testing.assert_allclose(
-                float(marg.sum()), model.total, atol=1e-5
-            )
+    for cl in cliques:
+      marg = model.project(cl)
+      np.testing.assert_allclose(float(marg.sum()), model.total, atol=1e-5)
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/test_precompute_marginals.py
+++ b/test/test_precompute_marginals.py
@@ -12,163 +12,161 @@ from mbi.extensions.precompute_marginals import precompute_marginals
 
 
 def _make_domain(sizes):
-    """Create a domain with attributes a0, a1, ... with given sizes."""
-    attrs = [f'a{i}' for i in range(len(sizes))]
-    return Domain(attrs, sizes)
+  """Create a domain with attributes a0, a1, ... with given sizes."""
+  attrs = [f'a{i}' for i in range(len(sizes))]
+  return Domain(attrs, sizes)
 
 
 def _make_dataset(domain, n, seed=0, weights=None):
-    """Create a random dataset with n records."""
-    rng = np.random.default_rng(seed)
-    data = {
-        a: (
-            rng.integers(0, domain[a], size=n).astype(
-                np.min_scalar_type(domain[a] - 1)
-            )
-        )
-        for a in domain.attributes
-    }
-    return Dataset(data, domain, weights=weights)
+  """Create a random dataset with n records."""
+  rng = np.random.default_rng(seed)
+  data = {
+      a: (
+          rng.integers(0, domain[a], size=n).astype(
+              np.min_scalar_type(domain[a] - 1)
+          )
+      )
+      for a in domain.attributes
+  }
+  return Dataset(data, domain, weights=weights)
 
 
 def _reference_marginal(dataset, cl):
-    """Compute a marginal using Dataset.project (numpy reference)."""
-    return dataset.project(cl)
+  """Compute a marginal using Dataset.project (numpy reference)."""
+  return dataset.project(cl)
 
 
 class TestPrecomputeMarginals(unittest.TestCase):
-    """Tests correctness of precompute_marginals against Dataset.project."""
+  """Tests correctness of precompute_marginals against Dataset.project."""
 
-    def _assert_marginals_match(self, dataset, cliques):
-        """Assert precomputed marginals match the reference for all cliques."""
-        result = precompute_marginals(dataset, cliques)
-        for cl in cliques:
-            expected = _reference_marginal(dataset, cl)
-            actual = result[cl]
-            np.testing.assert_array_almost_equal(
-                np.asarray(actual.datavector(flatten=True)),
-                np.asarray(expected.datavector(flatten=True)),
-                decimal=4,
-                err_msg=f'Marginal mismatch for clique {cl}',
-            )
+  def _assert_marginals_match(self, dataset, cliques):
+    """Assert precomputed marginals match the reference for all cliques."""
+    result = precompute_marginals(dataset, cliques)
+    for cl in cliques:
+      expected = _reference_marginal(dataset, cl)
+      actual = result[cl]
+      np.testing.assert_array_almost_equal(
+          np.asarray(actual.datavector(flatten=True)),
+          np.asarray(expected.datavector(flatten=True)),
+          decimal=4,
+          err_msg=f'Marginal mismatch for clique {cl}',
+      )
 
-    def test_pairwise_homogeneous(self):
-        """All attributes have the same domain size."""
-        domain = _make_domain([8, 8, 8, 8])
-        dataset = _make_dataset(domain, 1000)
-        cliques = list(itertools.combinations(domain.attributes, 2))
-        self._assert_marginals_match(dataset, cliques)
+  def test_pairwise_homogeneous(self):
+    """All attributes have the same domain size."""
+    domain = _make_domain([8, 8, 8, 8])
+    dataset = _make_dataset(domain, 1000)
+    cliques = list(itertools.combinations(domain.attributes, 2))
+    self._assert_marginals_match(dataset, cliques)
 
-    def test_pairwise_heterogeneous(self):
-        """Attributes have different domain sizes triggering bucketing."""
-        domain = _make_domain([2, 5, 16, 64])
-        dataset = _make_dataset(domain, 5000)
-        cliques = list(itertools.combinations(domain.attributes, 2))
-        self._assert_marginals_match(dataset, cliques)
+  def test_pairwise_heterogeneous(self):
+    """Attributes have different domain sizes triggering bucketing."""
+    domain = _make_domain([2, 5, 16, 64])
+    dataset = _make_dataset(domain, 5000)
+    cliques = list(itertools.combinations(domain.attributes, 2))
+    self._assert_marginals_match(dataset, cliques)
 
-    def test_three_way_marginals(self):
-        """Cliques of size 3."""
-        domain = _make_domain([4, 8, 3, 6])
-        dataset = _make_dataset(domain, 2000)
-        cliques = list(itertools.combinations(domain.attributes, 3))
-        self._assert_marginals_match(dataset, cliques)
+  def test_three_way_marginals(self):
+    """Cliques of size 3."""
+    domain = _make_domain([4, 8, 3, 6])
+    dataset = _make_dataset(domain, 2000)
+    cliques = list(itertools.combinations(domain.attributes, 3))
+    self._assert_marginals_match(dataset, cliques)
 
-    def test_mixed_clique_sizes(self):
-        """Mix of 1-way, 2-way, and 3-way cliques."""
-        domain = _make_domain([3, 7, 5])
-        dataset = _make_dataset(domain, 3000)
-        cliques = [
-            ('a0',),
-            ('a1',),
-            ('a2',),
-            ('a0', 'a1'),
-            ('a1', 'a2'),
-            ('a0', 'a1', 'a2'),
-        ]
-        self._assert_marginals_match(dataset, cliques)
+  def test_mixed_clique_sizes(self):
+    """Mix of 1-way, 2-way, and 3-way cliques."""
+    domain = _make_domain([3, 7, 5])
+    dataset = _make_dataset(domain, 3000)
+    cliques = [
+        ('a0',),
+        ('a1',),
+        ('a2',),
+        ('a0', 'a1'),
+        ('a1', 'a2'),
+        ('a0', 'a1', 'a2'),
+    ]
+    self._assert_marginals_match(dataset, cliques)
 
-    def test_single_attribute_cliques(self):
-        """Univariate marginals."""
-        domain = _make_domain([2, 100, 32])
-        dataset = _make_dataset(domain, 1000)
-        cliques = [('a0',), ('a1',), ('a2',)]
-        self._assert_marginals_match(dataset, cliques)
+  def test_single_attribute_cliques(self):
+    """Univariate marginals."""
+    domain = _make_domain([2, 100, 32])
+    dataset = _make_dataset(domain, 1000)
+    cliques = [('a0',), ('a1',), ('a2',)]
+    self._assert_marginals_match(dataset, cliques)
 
-    def test_jax_dataset_input(self):
-        """Accepts JaxDataset directly."""
-        domain = _make_domain([4, 8, 16])
-        np_dataset = _make_dataset(domain, 2000)
-        jax_data = {
-            a: jnp.asarray(np_dataset.to_dict()[a]) for a in domain.attributes
-        }
-        jax_dataset = JaxDataset(jax_data, domain)
-        cliques = list(itertools.combinations(domain.attributes, 2))
-        result = precompute_marginals(jax_dataset, cliques)
-        for cl in cliques:
-            expected = _reference_marginal(np_dataset, cl)
-            actual = result[cl]
-            np.testing.assert_array_almost_equal(
-                np.asarray(actual.datavector(flatten=True)),
-                np.asarray(expected.datavector(flatten=True)),
-                decimal=4,
-            )
+  def test_jax_dataset_input(self):
+    """Accepts JaxDataset directly."""
+    domain = _make_domain([4, 8, 16])
+    np_dataset = _make_dataset(domain, 2000)
+    jax_data = {
+        a: jnp.asarray(np_dataset.to_dict()[a]) for a in domain.attributes
+    }
+    jax_dataset = JaxDataset(jax_data, domain)
+    cliques = list(itertools.combinations(domain.attributes, 2))
+    result = precompute_marginals(jax_dataset, cliques)
+    for cl in cliques:
+      expected = _reference_marginal(np_dataset, cl)
+      actual = result[cl]
+      np.testing.assert_array_almost_equal(
+          np.asarray(actual.datavector(flatten=True)),
+          np.asarray(expected.datavector(flatten=True)),
+          decimal=4,
+      )
 
-    def test_attribute_order_preserved(self):
-        """Clique attribute order is respected in the output Factor."""
-        domain = _make_domain([3, 5, 7])
-        dataset = _make_dataset(domain, 1000)
-        cl = ('a2', 'a0')
-        result = precompute_marginals(dataset, [cl])
-        self.assertEqual(result[cl].domain.attributes, ('a2', 'a0'))
-        expected = _reference_marginal(dataset, cl)
-        np.testing.assert_array_almost_equal(
-            np.asarray(result[cl].datavector(flatten=True)),
-            np.asarray(expected.datavector(flatten=True)),
-            decimal=4,
-        )
+  def test_attribute_order_preserved(self):
+    """Clique attribute order is respected in the output Factor."""
+    domain = _make_domain([3, 5, 7])
+    dataset = _make_dataset(domain, 1000)
+    cl = ('a2', 'a0')
+    result = precompute_marginals(dataset, [cl])
+    self.assertEqual(result[cl].domain.attributes, ('a2', 'a0'))
+    expected = _reference_marginal(dataset, cl)
+    np.testing.assert_array_almost_equal(
+        np.asarray(result[cl].datavector(flatten=True)),
+        np.asarray(expected.datavector(flatten=True)),
+        decimal=4,
+    )
 
-    def test_large_domain_sizes(self):
-        """Domain sizes exceeding uint8 range."""
-        domain = _make_domain([256, 512])
-        dataset = _make_dataset(domain, 5000)
-        cliques = [('a0', 'a1')]
-        self._assert_marginals_match(dataset, cliques)
+  def test_large_domain_sizes(self):
+    """Domain sizes exceeding uint8 range."""
+    domain = _make_domain([256, 512])
+    dataset = _make_dataset(domain, 5000)
+    cliques = [('a0', 'a1')]
+    self._assert_marginals_match(dataset, cliques)
 
-    def test_random_heterogeneous_sweep(self):
-        """Randomized sweep over various domain configurations."""
-        rng = np.random.default_rng(42)
-        for trial in range(10):
-            d = rng.integers(3, 8)
-            sizes = [
-                int(rng.choice([2, 3, 4, 8, 16, 32, 64])) for _ in range(d)
-            ]
-            domain = _make_domain(sizes)
-            dataset = _make_dataset(domain, 500, seed=trial)
-            cliques = list(itertools.combinations(domain.attributes, 2))
-            self._assert_marginals_match(dataset, cliques)
+  def test_random_heterogeneous_sweep(self):
+    """Randomized sweep over various domain configurations."""
+    rng = np.random.default_rng(42)
+    for trial in range(10):
+      d = rng.integers(3, 8)
+      sizes = [int(rng.choice([2, 3, 4, 8, 16, 32, 64])) for _ in range(d)]
+      domain = _make_domain(sizes)
+      dataset = _make_dataset(domain, 500, seed=trial)
+      cliques = list(itertools.combinations(domain.attributes, 2))
+      self._assert_marginals_match(dataset, cliques)
 
-    def test_weighted_dataset(self):
-        """Weighted datasets produce correct marginals."""
-        domain = _make_domain([4, 8])
-        rng = np.random.default_rng(99)
-        weights = rng.exponential(size=2000)
-        dataset = _make_dataset(domain, 2000, seed=99, weights=weights)
-        cliques = [('a0',), ('a1',), ('a0', 'a1')]
-        self._assert_marginals_match(dataset, cliques)
+  def test_weighted_dataset(self):
+    """Weighted datasets produce correct marginals."""
+    domain = _make_domain([4, 8])
+    rng = np.random.default_rng(99)
+    weights = rng.exponential(size=2000)
+    dataset = _make_dataset(domain, 2000, seed=99, weights=weights)
+    cliques = [('a0',), ('a1',), ('a0', 'a1')]
+    self._assert_marginals_match(dataset, cliques)
 
-    def test_accepts_tuple_of_cliques(self):
-        """Accepts a tuple (Sequence) of cliques, not just a list."""
-        domain = _make_domain([4, 8])
-        dataset = _make_dataset(domain, 1000)
-        cliques = (('a0', 'a1'),)
-        result = precompute_marginals(dataset, cliques)
-        expected = _reference_marginal(dataset, ('a0', 'a1'))
-        np.testing.assert_array_almost_equal(
-            np.asarray(result[('a0', 'a1')].datavector(flatten=True)),
-            np.asarray(expected.datavector(flatten=True)),
-            decimal=4,
-        )
+  def test_accepts_tuple_of_cliques(self):
+    """Accepts a tuple (Sequence) of cliques, not just a list."""
+    domain = _make_domain([4, 8])
+    dataset = _make_dataset(domain, 1000)
+    cliques = (('a0', 'a1'),)
+    result = precompute_marginals(dataset, cliques)
+    expected = _reference_marginal(dataset, ('a0', 'a1'))
+    np.testing.assert_array_almost_equal(
+        np.asarray(result[('a0', 'a1')].datavector(flatten=True)),
+        np.asarray(expected.datavector(flatten=True)),
+        decimal=4,
+    )
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_reweighted_dataset.py
+++ b/test/test_reweighted_dataset.py
@@ -28,306 +28,306 @@ _CLIQUE_SETS = [
 
 
 def _make_seed_data(domain, n=5000):
-    """Create a random Dataset over the domain."""
-    data = {
-        col: np.random.randint(0, domain[col], n) for col in domain.attributes
-    }
-    return Dataset(data, domain)
+  """Create a random Dataset over the domain."""
+  data = {
+      col: np.random.randint(0, domain[col], n) for col in domain.attributes
+  }
+  return Dataset(data, domain)
 
 
 def _fake_measurements(domain, cliques):
-    """Create noise-free measurements from a random distribution."""
-    P = Factor.random(domain)
-    P = P / P.sum()
-    measurements = []
-    for cl in cliques:
-        y = P.project(cl).datavector()
-        measurements.append(marginal_loss.LinearMeasurement(y, cl))
-    return measurements, P
+  """Create noise-free measurements from a random distribution."""
+  P = Factor.random(domain)
+  P = P / P.sum()
+  measurements = []
+  for cl in cliques:
+    y = P.project(cl).datavector()
+    measurements.append(marginal_loss.LinearMeasurement(y, cl))
+  return measurements, P
 
 
 class TestJaxDatasetBasics(unittest.TestCase):
-    """Tests for JaxDataset used as the reweighted model."""
+  """Tests for JaxDataset used as the reweighted model."""
 
-    def setUp(self):
-        self.domain = Domain(["x", "y"], [3, 4])
-        data = {"x": np.array([0, 1, 2, 0, 1]), "y": np.array([0, 1, 2, 3, 0])}
-        self.dataset = Dataset(data, self.domain)
-        weights = jax.nn.softmax(jnp.zeros(5)) * 100.0
-        self.model = JaxDataset(
-            {col: jnp.array(data[col]) for col in self.domain.attributes},
-            self.domain,
-            weights,
-        )
+  def setUp(self):
+    self.domain = Domain(["x", "y"], [3, 4])
+    data = {"x": np.array([0, 1, 2, 0, 1]), "y": np.array([0, 1, 2, 3, 0])}
+    self.dataset = Dataset(data, self.domain)
+    weights = jax.nn.softmax(jnp.zeros(5)) * 100.0
+    self.model = JaxDataset(
+        {col: jnp.array(data[col]) for col in self.domain.attributes},
+        self.domain,
+        weights,
+    )
 
-    def test_num_records(self):
-        self.assertEqual(self.model.records, 5)
+  def test_num_records(self):
+    self.assertEqual(self.model.records, 5)
 
-    def test_weights_sum_to_total(self):
-        np.testing.assert_allclose(
-            float(self.model.weights.sum()), 100.0, atol=1e-5
-        )
+  def test_weights_sum_to_total(self):
+    np.testing.assert_allclose(
+        float(self.model.weights.sum()), 100.0, atol=1e-5
+    )
 
-    def test_uniform_weights(self):
-        """Initial weights should be uniform."""
-        weights = np.asarray(self.model.weights)
-        np.testing.assert_allclose(weights, 20.0, atol=1e-5)
+  def test_uniform_weights(self):
+    """Initial weights should be uniform."""
+    weights = np.asarray(self.model.weights)
+    np.testing.assert_allclose(weights, 20.0, atol=1e-5)
 
-    def test_project_single_attr(self):
-        marg = self.model.project("x")
-        self.assertEqual(marg.domain, self.model.domain.project(("x",)))
-        np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
+  def test_project_single_attr(self):
+    marg = self.model.project("x")
+    self.assertEqual(marg.domain, self.model.domain.project(("x",)))
+    np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
 
-    def test_project_multiple_attrs(self):
-        marg = self.model.project(("x", "y"))
-        self.assertEqual(marg.domain.shape, (3, 4))
-        np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
+  def test_project_multiple_attrs(self):
+    marg = self.model.project(("x", "y"))
+    self.assertEqual(marg.domain.shape, (3, 4))
+    np.testing.assert_allclose(float(marg.sum()), 100.0, atol=1e-5)
 
-    def test_project_consistency(self):
-        """Marginal of the joint should equal the direct marginal."""
-        joint = self.model.project(("x", "y"))
-        marg_x_from_joint = joint.project("x")
-        marg_x_direct = self.model.project("x")
-        np.testing.assert_allclose(
-            marg_x_from_joint.datavector(),
-            marg_x_direct.datavector(),
-            atol=1e-6,
-        )
+  def test_project_consistency(self):
+    """Marginal of the joint should equal the direct marginal."""
+    joint = self.model.project(("x", "y"))
+    marg_x_from_joint = joint.project("x")
+    marg_x_direct = self.model.project("x")
+    np.testing.assert_allclose(
+        marg_x_from_joint.datavector(),
+        marg_x_direct.datavector(),
+        atol=1e-6,
+    )
 
-    def test_supports(self):
-        self.assertTrue(self.model.supports("x"))
-        self.assertTrue(self.model.supports(("x", "y")))
-        self.assertFalse(self.model.supports("z"))
+  def test_supports(self):
+    self.assertTrue(self.model.supports("x"))
+    self.assertTrue(self.model.supports(("x", "y")))
+    self.assertFalse(self.model.supports("z"))
 
-    def test_synthetic_data(self):
-        data = self.model.synthetic_data(rows=500)
-        self.assertEqual(data.records, 500)
-        self.assertEqual(data.domain, self.model.domain)
+  def test_synthetic_data(self):
+    data = self.model.synthetic_data(rows=500)
+    self.assertEqual(data.records, 500)
+    self.assertEqual(data.domain, self.model.domain)
 
-    def test_synthetic_data_default_rows(self):
-        data = self.model.synthetic_data()
-        self.assertEqual(data.records, 100)
+  def test_synthetic_data_default_rows(self):
+    data = self.model.synthetic_data()
+    self.assertEqual(data.records, 100)
 
-    def test_synthetic_data_values_in_range(self):
-        data = self.model.synthetic_data(rows=200)
-        data_dict = data.to_dict()
-        for col in self.model.domain.attributes:
-            col_data = data_dict[col]
-            self.assertTrue(np.all(col_data >= 0))
-            self.assertTrue(np.all(col_data < self.model.domain[col]))
+  def test_synthetic_data_values_in_range(self):
+    data = self.model.synthetic_data(rows=200)
+    data_dict = data.to_dict()
+    for col in self.model.domain.attributes:
+      col_data = data_dict[col]
+      self.assertTrue(np.all(col_data >= 0))
+      self.assertTrue(np.all(col_data < self.model.domain[col]))
 
-    def test_pytree_roundtrip(self):
-        """Model should survive JAX pytree flatten/unflatten."""
-        leaves, treedef = jax.tree_util.tree_flatten(self.model)
-        reconstructed = jax.tree_util.tree_unflatten(treedef, leaves)
-        np.testing.assert_allclose(
-            np.asarray(reconstructed.weights), np.asarray(self.model.weights)
-        )
+  def test_pytree_roundtrip(self):
+    """Model should survive JAX pytree flatten/unflatten."""
+    leaves, treedef = jax.tree_util.tree_flatten(self.model)
+    reconstructed = jax.tree_util.tree_unflatten(treedef, leaves)
+    np.testing.assert_allclose(
+        np.asarray(reconstructed.weights), np.asarray(self.model.weights)
+    )
 
 
 class TestEstimation(unittest.TestCase):
-    """Tests for the reweighted_dataset.estimate function."""
+  """Tests for the reweighted_dataset.estimate function."""
 
-    @parameterized.expand([(cliques,) for cliques in _CLIQUE_SETS])
-    def test_noiseless_recovery(self, cliques):
-        """With noise-free measurements, the model should fit them closely."""
-        measurements, P = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN, n=5000)
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-            learning_rate=0.1,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=500,
-        )
+  @parameterized.expand([(cliques,) for cliques in _CLIQUE_SETS])
+  def test_noiseless_recovery(self, cliques):
+    """With noise-free measurements, the model should fit them closely."""
+    measurements, P = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN, n=5000)
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+        learning_rate=0.1,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=500,
+    )
 
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=5e-2)
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=5e-2)
 
-    def test_l1_loss(self):
-        """Test that L1 loss works without crashing and converges."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, P = _fake_measurements(_DOMAIN, cliques)
-        loss_fn = marginal_loss.from_linear_measurements(
-            measurements, _DOMAIN, norm="l1"
-        )
-        seed_data = _make_seed_data(_DOMAIN)
+  def test_l1_loss(self):
+    """Test that L1 loss works without crashing and converges."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, P = _fake_measurements(_DOMAIN, cliques)
+    loss_fn = marginal_loss.from_linear_measurements(
+        measurements, _DOMAIN, norm="l1"
+    )
+    seed_data = _make_seed_data(_DOMAIN)
 
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-            learning_rate=0.01,
-        ).estimate(
-            _DOMAIN,
-            loss_fn,
-            known_total=1.0,
-            iters=500,
-        )
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+        learning_rate=0.01,
+    ).estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=500,
+    )
 
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=0.1)
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=0.1)
 
-    def test_l2_loss(self):
-        """Test explicit L2 loss construction."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, P = _fake_measurements(_DOMAIN, cliques)
-        loss_fn = marginal_loss.from_linear_measurements(
-            measurements, _DOMAIN, norm="l2"
-        )
-        seed_data = _make_seed_data(_DOMAIN)
+  def test_l2_loss(self):
+    """Test explicit L2 loss construction."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, P = _fake_measurements(_DOMAIN, cliques)
+    loss_fn = marginal_loss.from_linear_measurements(
+        measurements, _DOMAIN, norm="l2"
+    )
+    seed_data = _make_seed_data(_DOMAIN)
 
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-        ).estimate(
-            _DOMAIN,
-            loss_fn,
-            known_total=1.0,
-            iters=500,
-        )
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+    ).estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=500,
+    )
 
-        for M in measurements:
-            expected = M.noisy_measurement
-            actual = model.project(M.clique).datavector()
-            np.testing.assert_allclose(actual, expected, atol=5e-2)
+    for M in measurements:
+      expected = M.noisy_measurement
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, expected, atol=5e-2)
 
-    def test_returns_jax_dataset(self):
-        """estimate() should return a JaxDataset."""
-        cliques = [("a", "b"), ("c", "d")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN)
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=50,
-        )
+  def test_returns_jax_dataset(self):
+    """estimate() should return a JaxDataset."""
+    cliques = [("a", "b"), ("c", "d")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN)
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=50,
+    )
 
-        self.assertIsInstance(model, JaxDataset)
-        self.assertEqual(model.domain, _DOMAIN)
-        self.assertTrue(model.supports(("a", "b")))
+    self.assertIsInstance(model, JaxDataset)
+    self.assertEqual(model.domain, _DOMAIN)
+    self.assertTrue(model.supports(("a", "b")))
 
-    def test_conforms_to_model_protocol(self):
-        """JaxDataset should satisfy the Model protocol."""
-        cliques = [("a", "b"), ("c", "d")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN)
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=50,
-        )
+  def test_conforms_to_model_protocol(self):
+    """JaxDataset should satisfy the Model protocol."""
+    cliques = [("a", "b"), ("c", "d")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN)
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=50,
+    )
 
-        # Model extends Projectable with synthetic_data
-        self.assertTrue(hasattr(model, "domain"))
-        self.assertTrue(hasattr(model, "project"))
-        self.assertTrue(hasattr(model, "supports"))
-        self.assertTrue(hasattr(model, "synthetic_data"))
+    # Model extends Projectable with synthetic_data
+    self.assertTrue(hasattr(model, "domain"))
+    self.assertTrue(hasattr(model, "project"))
+    self.assertTrue(hasattr(model, "supports"))
+    self.assertTrue(hasattr(model, "synthetic_data"))
 
-    def test_synthetic_data_from_estimation(self):
-        """Synthetic data should be generatable from an estimated model."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN)
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
+  def test_synthetic_data_from_estimation(self):
+    """Synthetic data should be generatable from an estimated model."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN)
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
 
-        data = model.synthetic_data(rows=1000)
-        self.assertEqual(data.records, 1000)
-        self.assertEqual(data.domain, _DOMAIN)
+    data = model.synthetic_data(rows=1000)
+    self.assertEqual(data.records, 1000)
+    self.assertEqual(data.domain, _DOMAIN)
 
-    def test_callback(self):
-        """Callback should be invoked during estimation."""
-        cliques = [("a", "b")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN)
+  def test_callback(self):
+    """Callback should be invoked during estimation."""
+    cliques = [("a", "b")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN)
 
-        callback_count = [0]
+    callback_count = [0]
 
-        def callback(model):
-            callback_count[0] += 1
+    def callback(model):
+      callback_count[0] += 1
 
-        ReweightedDatasetEstimator(
-            seed_data=seed_data,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-            callback_fn=callback,
-        )
-        self.assertGreater(callback_count[0], 0)
+    ReweightedDatasetEstimator(
+        seed_data=seed_data,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+        callback_fn=callback,
+    )
+    self.assertGreater(callback_count[0], 0)
 
-    def test_custom_optimizer(self):
-        """Should accept a custom optax optimizer."""
-        import optax
+  def test_custom_optimizer(self):
+    """Should accept a custom optax optimizer."""
+    import optax
 
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN)
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-            optimizer=optax.sgd(0.01),
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
-        self.assertIsInstance(model, JaxDataset)
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN)
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+        optimizer=optax.sgd(0.01),
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
+    self.assertIsInstance(model, JaxDataset)
 
 
 class TestNonNegativity(unittest.TestCase):
-    """Test that the softmax parameterization guarantees non-negativity."""
+  """Test that the softmax parameterization guarantees non-negativity."""
 
-    def test_marginals_nonnegative(self):
-        """All marginals should be non-negative."""
-        cliques = [("a", "b"), ("b", "c"), ("c", "d")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN)
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
+  def test_marginals_nonnegative(self):
+    """All marginals should be non-negative."""
+    cliques = [("a", "b"), ("b", "c"), ("c", "d")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN)
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
 
-        for cl in cliques:
-            marg = model.project(cl)
-            self.assertTrue(
-                jnp.all(marg.values >= 0),
-                f"Negative values in marginal for clique {cl}",
-            )
+    for cl in cliques:
+      marg = model.project(cl)
+      self.assertTrue(
+          jnp.all(marg.values >= 0),
+          f"Negative values in marginal for clique {cl}",
+      )
 
-    def test_marginals_sum_to_total(self):
-        """Each marginal should sum to total."""
-        cliques = [("a", "b"), ("b", "c")]
-        measurements, _ = _fake_measurements(_DOMAIN, cliques)
-        seed_data = _make_seed_data(_DOMAIN)
-        model = ReweightedDatasetEstimator(
-            seed_data=seed_data,
-        ).estimate(
-            _DOMAIN,
-            measurements,
-            iters=100,
-        )
+  def test_marginals_sum_to_total(self):
+    """Each marginal should sum to total."""
+    cliques = [("a", "b"), ("b", "c")]
+    measurements, _ = _fake_measurements(_DOMAIN, cliques)
+    seed_data = _make_seed_data(_DOMAIN)
+    model = ReweightedDatasetEstimator(
+        seed_data=seed_data,
+    ).estimate(
+        _DOMAIN,
+        measurements,
+        iters=100,
+    )
 
-        for cl in cliques:
-            marg = model.project(cl)
-            np.testing.assert_allclose(
-                float(marg.sum()), float(model.weights.sum()), atol=1e-5
-            )
+    for cl in cliques:
+      marg = model.project(cl)
+      np.testing.assert_allclose(
+          float(marg.sum()), float(model.weights.sum()), atol=1e-5
+      )
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -23,124 +23,118 @@ from mbi import (
 
 
 def _roundtrip(obj):
-    """Save and load a pytree through an in-memory buffer."""
-    buf = io.BytesIO()
-    save(obj, buf)
-    buf.seek(0)
-    return load(buf)
+  """Save and load a pytree through an in-memory buffer."""
+  buf = io.BytesIO()
+  save(obj, buf)
+  buf.seek(0)
+  return load(buf)
 
 
 @pytest.fixture
 def domain():
-    return Domain(["A", "B", "C"], [3, 4, 5])
+  return Domain(["A", "B", "C"], [3, 4, 5])
 
 
 @pytest.fixture
 def cliques():
-    return [("A", "B"), ("B", "C")]
+  return [("A", "B"), ("B", "C")]
 
 
 class TestCliqueVector:
 
-    def test_roundtrip(self, domain, cliques):
-        cv = CliqueVector.random(domain, cliques)
-        loaded = _roundtrip(cv)
+  def test_roundtrip(self, domain, cliques):
+    cv = CliqueVector.random(domain, cliques)
+    loaded = _roundtrip(cv)
 
-        assert loaded.domain == cv.domain
-        assert loaded.cliques == cv.cliques
-        for cl in cv.cliques:
-            np.testing.assert_allclose(
-                np.asarray(loaded[cl].values),
-                np.asarray(cv[cl].values),
-                atol=1e-6,
-            )
+    assert loaded.domain == cv.domain
+    assert loaded.cliques == cv.cliques
+    for cl in cv.cliques:
+      np.testing.assert_allclose(
+          np.asarray(loaded[cl].values),
+          np.asarray(cv[cl].values),
+          atol=1e-6,
+      )
 
 
 class TestMarkovRandomField:
 
-    def test_roundtrip(self, domain, cliques):
-        potentials = CliqueVector.random(domain, cliques).log()
-        marginals = marginal_oracles.message_passing_hugin(
-            potentials, total=100.0
-        )
-        mrf = MarkovRandomField(
-            potentials=potentials, marginals=marginals, total=100.0
-        )
-        loaded = _roundtrip(mrf)
+  def test_roundtrip(self, domain, cliques):
+    potentials = CliqueVector.random(domain, cliques).log()
+    marginals = marginal_oracles.message_passing_hugin(potentials, total=100.0)
+    mrf = MarkovRandomField(
+        potentials=potentials, marginals=marginals, total=100.0
+    )
+    loaded = _roundtrip(mrf)
 
-        assert loaded.domain == mrf.domain
-        np.testing.assert_allclose(float(loaded.total), float(mrf.total))
-        for cl in mrf.potentials.cliques:
-            np.testing.assert_allclose(
-                np.asarray(loaded.potentials[cl].values),
-                np.asarray(mrf.potentials[cl].values),
-                atol=1e-6,
-            )
+    assert loaded.domain == mrf.domain
+    np.testing.assert_allclose(float(loaded.total), float(mrf.total))
+    for cl in mrf.potentials.cliques:
+      np.testing.assert_allclose(
+          np.asarray(loaded.potentials[cl].values),
+          np.asarray(mrf.potentials[cl].values),
+          atol=1e-6,
+      )
 
-    def test_project_after_load(self, domain, cliques):
-        """Loaded model should support the same queries as the original."""
-        potentials = CliqueVector.random(domain, cliques).log()
-        marginals = marginal_oracles.message_passing_hugin(
-            potentials, total=100.0
-        )
-        mrf = MarkovRandomField(
-            potentials=potentials, marginals=marginals, total=100.0
-        )
-        loaded = _roundtrip(mrf)
+  def test_project_after_load(self, domain, cliques):
+    """Loaded model should support the same queries as the original."""
+    potentials = CliqueVector.random(domain, cliques).log()
+    marginals = marginal_oracles.message_passing_hugin(potentials, total=100.0)
+    mrf = MarkovRandomField(
+        potentials=potentials, marginals=marginals, total=100.0
+    )
+    loaded = _roundtrip(mrf)
 
-        for attr in mrf.domain.attributes:
-            np.testing.assert_allclose(
-                np.asarray(loaded.project((attr,)).values),
-                np.asarray(mrf.project((attr,)).values),
-                atol=1e-5,
-            )
+    for attr in mrf.domain.attributes:
+      np.testing.assert_allclose(
+          np.asarray(loaded.project((attr,)).values),
+          np.asarray(mrf.project((attr,)).values),
+          atol=1e-5,
+      )
 
 
 class TestLinearMeasurements:
 
-    def test_roundtrip(self, domain, cliques):
-        ms = [
-            LinearMeasurement(jnp.asarray(np.random.randn(domain.size(cl))), cl)
-            for cl in cliques
-        ]
-        loaded = _roundtrip(ms)
+  def test_roundtrip(self, domain, cliques):
+    ms = [
+        LinearMeasurement(jnp.asarray(np.random.randn(domain.size(cl))), cl)
+        for cl in cliques
+    ]
+    loaded = _roundtrip(ms)
 
-        assert len(loaded) == len(ms)
-        for orig, ld in zip(ms, loaded):
-            assert ld.clique == orig.clique
-            np.testing.assert_allclose(ld.stddev, orig.stddev)
-            np.testing.assert_allclose(
-                np.asarray(ld.noisy_measurement),
-                np.asarray(orig.noisy_measurement),
-                atol=1e-6,
-            )
+    assert len(loaded) == len(ms)
+    for orig, ld in zip(ms, loaded):
+      assert ld.clique == orig.clique
+      np.testing.assert_allclose(ld.stddev, orig.stddev)
+      np.testing.assert_allclose(
+          np.asarray(ld.noisy_measurement),
+          np.asarray(orig.noisy_measurement),
+          atol=1e-6,
+      )
 
-    def test_mixed_query_types(self, domain, cliques):
-        """All query types roundtrip correctly in a single list."""
-        cl = cliques[0]
-        size = domain.size(cl)
-        weights = np.random.rand(size)
-        ms = [
-            LinearMeasurement(jnp.ones(size), cl),
-            LinearMeasurement(jnp.ones(size), cl, query=WeightedQuery(weights)),
-            LinearMeasurement(jnp.ones(size), cl, query=NormalizedQuery()),
-            LinearMeasurement(
-                jnp.ones(size - 1), cl, query=SlicedQuery(start=1)
-            ),
-        ]
-        loaded = _roundtrip(ms)
+  def test_mixed_query_types(self, domain, cliques):
+    """All query types roundtrip correctly in a single list."""
+    cl = cliques[0]
+    size = domain.size(cl)
+    weights = np.random.rand(size)
+    ms = [
+        LinearMeasurement(jnp.ones(size), cl),
+        LinearMeasurement(jnp.ones(size), cl, query=WeightedQuery(weights)),
+        LinearMeasurement(jnp.ones(size), cl, query=NormalizedQuery()),
+        LinearMeasurement(jnp.ones(size - 1), cl, query=SlicedQuery(start=1)),
+    ]
+    loaded = _roundtrip(ms)
 
-        assert isinstance(loaded[0].query, DatavectorQuery)
-        assert isinstance(loaded[1].query, WeightedQuery)
-        np.testing.assert_allclose(loaded[1].query.weights, weights, atol=1e-7)
-        assert isinstance(loaded[2].query, NormalizedQuery)
-        assert isinstance(loaded[3].query, SlicedQuery)
-        assert loaded[3].query.start == 1
+    assert isinstance(loaded[0].query, DatavectorQuery)
+    assert isinstance(loaded[1].query, WeightedQuery)
+    np.testing.assert_allclose(loaded[1].query.weights, weights, atol=1e-7)
+    assert isinstance(loaded[2].query, NormalizedQuery)
+    assert isinstance(loaded[3].query, SlicedQuery)
+    assert loaded[3].query.start == 1
 
-        # Functional equivalence for the weighted query.
-        f = Factor(domain.project(cl), jnp.ones(size))
-        np.testing.assert_allclose(
-            np.asarray(loaded[1].query(f)),
-            np.asarray(ms[1].query(f)),
-            atol=1e-7,
-        )
+    # Functional equivalence for the weighted query.
+    f = Factor(domain.project(cl), jnp.ones(size))
+    np.testing.assert_allclose(
+        np.asarray(loaded[1].query(f)),
+        np.asarray(ms[1].query(f)),
+        atol=1e-7,
+    )


### PR DESCRIPTION
## Reformat to 2-space indentation

Sets `pyink-indentation = 2` in `pyproject.toml` and reformats the entire codebase (`src`, `test`, `mechanisms`, `examples`) to match the [Google Python style guide](https://google.github.io/styleguide/pyguide.html#34-indentation).

### Pure formatting change

Aside from the indentation width, the only differences are the line reflows that naturally follow from a shallower indent — some lines that previously wrapped to stay within the 80-column limit now fit on a single line. No code logic is altered; `git diff -w` shows only whitespace/reflow differences.

### Checks

- `pyink --check src test mechanisms examples` ✅
- `flake8 src test mechanisms examples` ✅
- `pydocstyle src/mbi/` ✅
- `pylint src/mbi/` → **9.84/10** (identical to master; no new findings) ✅
- Full test suite: **1319 passed** ✅

### Note on review

This is a large but mechanical diff. Reviewing with whitespace hidden (`?w=1` on the GitHub diff URL, or `git diff -w`) makes it easy to confirm nothing but indentation changed.