### PR TITLE
Fix precompile() JIT cache misses under jax_enable_x64

### DIFF
--- a/pyrefly-baseline.json
+++ b/pyrefly-baseline.json
@@ -1009,9 +1009,9 @@
       "severity": "error"
     },
     {
-      "line": 191,
+      "line": 204,
       "column": 18,
-      "stop_line": 191,
+      "stop_line": 204,
       "stop_column": 22,
       "path": "src/mbi/extensions/synthetic_data.py",
       "code": -2,
@@ -1021,9 +1021,9 @@
       "severity": "error"
     },
     {
-      "line": 220,
+      "line": 233,
       "column": 7,
-      "stop_line": 220,
+      "stop_line": 233,
       "stop_column": 18,
       "path": "src/mbi/extensions/synthetic_data.py",
       "code": -2,
@@ -1033,9 +1033,9 @@
       "severity": "error"
     },
     {
-      "line": 255,
+      "line": 268,
       "column": 23,
-      "stop_line": 255,
+      "stop_line": 268,
       "stop_column": 38,
       "path": "src/mbi/extensions/synthetic_data.py",
       "code": -2,
@@ -1045,10 +1045,10 @@
       "severity": "error"
     },
     {
-      "line": 66,
-      "column": 24,
-      "stop_line": 66,
-      "stop_column": 71,
+      "line": 75,
+      "column": 17,
+      "stop_line": 75,
+      "stop_column": 75,
       "path": "src/mbi/factor.py",
       "code": -2,
       "name": "bad-argument-type",
@@ -1057,9 +1057,9 @@
       "severity": "error"
     },
     {
-      "line": 141,
+      "line": 151,
       "column": 7,
-      "stop_line": 141,
+      "stop_line": 151,
       "stop_column": 43,
       "path": "src/mbi/factor.py",
       "code": -2,
@@ -1069,9 +1069,9 @@
       "severity": "error"
     },
     {
-      "line": 178,
+      "line": 188,
       "column": 32,
-      "stop_line": 178,
+      "stop_line": 188,
       "stop_column": 44,
       "path": "src/mbi/factor.py",
       "code": -2,
@@ -1081,9 +1081,9 @@
       "severity": "error"
     },
     {
-      "line": 180,
+      "line": 190,
       "column": 15,
-      "stop_line": 180,
+      "stop_line": 190,
       "stop_column": 27,
       "path": "src/mbi/factor.py",
       "code": -2,
@@ -1093,9 +1093,9 @@
       "severity": "error"
     },
     {
-      "line": 273,
+      "line": 283,
       "column": 9,
-      "stop_line": 273,
+      "stop_line": 283,
       "stop_column": 17,
       "path": "src/mbi/factor.py",
       "code": -2,

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -92,6 +92,9 @@ def precompile(
         if not any(attr in inp.domain.attributes for inp in inputs):
           inputs.append(Factor.abstract(domain.project([attr])))
 
+      # int32 matches _generate_column's ravel dtype; see the parent_arrays
+      # comment in synthetic_data() for why the boundary is int32 rather than
+      # the compact storage dtype.
       abstract_parents = tuple(
           jax.ShapeDtypeStruct((rows,), jnp.int32) for _ in cp.parents
       )
@@ -157,7 +160,17 @@ def synthetic_data(
     cp = plan.columns[col]
 
     inputs = _gather_inputs(cp, domain, pot_map, msg_map)
-    parent_arrays = tuple(data[p] for p in cp.parents)
+    # Parents feed only _ravel_multi_index, which casts them to int32 anyway, so
+    # int32 is the real compute dtype. Passing int32 here (and lowering int32 in
+    # precompile) keeps the JIT signature a fixed contract, independent of the
+    # compact storage dtype (np.min_scalar_type(domain[p]), applied at the end of
+    # the loop). A dtype mismatch would miss the JIT cache and recompile every
+    # column. The only cost is a slightly larger host->device copy of this
+    # O(rows) array; peak HBM is unchanged, since the int32 index is materialized
+    # on-device regardless.
+    parent_arrays = tuple(
+        jnp.asarray(data[p], dtype=jnp.int32) for p in cp.parents
+    )
     t0 = time.monotonic()
     data[col] = _generate_column(
         col_rng,

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -63,7 +63,17 @@ class Factor:
 
   @classmethod
   def abstract(cls, domain: Domain) -> Factor:
-    return cls(domain, jax.ShapeDtypeStruct(domain.shape, jnp.float32))
+    """Creates a shape/dtype-only Factor for ahead-of-time compilation.
+
+    Uses the same default float dtype as ``zeros``/``ones`` (float64 when
+    ``jax_enable_x64`` is set, float32 otherwise) so that programs traced
+    with abstract factors share the JIT cache with programs run on real
+    factors.  Hardcoding a dtype here silently defeats precompilation and
+    forces a recompile on every call whenever the environment dtype differs.
+    """
+    return cls(
+        domain, jax.ShapeDtypeStruct(domain.shape, jnp.result_type(float))
+    )
 
   # Reshaping operations
   def transpose(self, attrs: Sequence[Attribute]) -> Factor:

--- a/test/test_ext_synthetic_data.py
+++ b/test/test_ext_synthetic_data.py
@@ -1,4 +1,5 @@
 import unittest
+import jax
 import numpy as np
 from mbi import (
     Domain,
@@ -182,6 +183,100 @@ class TestExtSyntheticDataAccuracy(unittest.TestCase):
         cliques,
         cross_cliques=[("A", "C"), ("A", "E"), ("C", "E")],
     )
+
+
+class TestExtSyntheticDataPrecompile(unittest.TestCase):
+  """Tests that precompile() lowers against the signatures generation uses.
+
+  precompile() ahead-of-time lowers ``_generate_column`` for each column; for
+  the resulting compiled executables to be reused, the argument avals (shape +
+  dtype) it lowers against must exactly match those ``synthetic_data`` passes
+  at generation.  Two dtype mismatches previously defeated this whenever
+  ``jax_enable_x64`` was set, forcing a recompile on every one of the columns:
+
+    * ``Factor.abstract`` emitted float32 while real factors were float64, and
+    * parent arrays were passed as ``np.min_scalar_type`` (uint8/uint16/...)
+      instead of the int32 signature precompile lowered against.
+
+  This test records the per-column avals from both paths and asserts they are
+  identical, which is the precise cache-hit precondition.
+  """
+
+  def setUp(self):
+    super().setUp()
+    # precompile() compiles in a background thread that does not inherit a
+    # thread-local ``jax.enable_x64()`` context, so enable x64 globally here.
+    self._prev_x64 = jax.config.read("jax_enable_x64")
+    jax.config.update("jax_enable_x64", True)
+
+  def tearDown(self):
+    jax.config.update("jax_enable_x64", self._prev_x64)
+    super().tearDown()
+
+  def _leaf_avals(self, *args):
+    return tuple(
+        (tuple(leaf.shape), str(leaf.dtype))
+        for leaf in jax.tree_util.tree_leaves(args)
+        if hasattr(leaf, "shape") and hasattr(leaf, "dtype")
+    )
+
+  def test_precompile_signature_matches_generation(self):
+    import importlib
+
+    # The __init__ re-exports the ``synthetic_data`` function, shadowing the
+    # submodule of the same name, so import it explicitly from sys.modules.
+    sd = importlib.import_module("mbi.extensions.synthetic_data")
+    real = sd._generate_column
+
+    # Use a chain so at least one column is generated with parents, exercising
+    # the parent-array dtype path.  The bugs only manifest under x64, where the
+    # default float dtype is float64 (enabled globally in setUp).
+    domain = Domain(["A", "B", "C"], [5, 5, 5])
+    cliques = [("A", "B"), ("B", "C")]
+    model = _create_random_model(domain, cliques, N=1000)
+    rows = 1000
+
+    precompile_sigs = {}
+    generation_sigs = {}
+
+    class _PrecompileRecorder:
+
+      def lower(inner, prng, inputs, parents, *, query, **kwargs):  # pylint: disable=no-self-argument
+        precompile_sigs[query] = self._leaf_avals(prng, inputs, parents)
+        return real.lower(prng, inputs, parents, query=query, **kwargs)
+
+    class _GenerationRecorder:
+
+      def __call__(inner, prng, inputs, parents, *, query, **kwargs):  # pylint: disable=no-self-argument
+        generation_sigs[query] = self._leaf_avals(prng, inputs, parents)
+        return real(prng, inputs, parents, query=query, **kwargs)
+
+    try:
+      sd._generate_column = _PrecompileRecorder()
+      sd.precompile(domain, list(model.cliques), rows).result()
+      sd._generate_column = _GenerationRecorder()
+      sd.synthetic_data(model, rows)
+    finally:
+      sd._generate_column = real
+
+    self.assertTrue(precompile_sigs, "precompile lowered no columns")
+    self.assertEqual(
+        set(precompile_sigs), set(generation_sigs), "column sets differ"
+    )
+    # At least one column must be generated with a parent (the chain
+    # guarantees it): a parent appears as an int32 array of shape (rows,).
+    self.assertTrue(
+        any(((rows,), "int32") in sig for sig in generation_sigs.values()),
+        "expected at least one column generated with an int32 parent array",
+    )
+    for query, gen_sig in generation_sigs.items():
+      self.assertEqual(
+          precompile_sigs[query],
+          gen_sig,
+          f"aval mismatch for column {query}: precompile lowered "
+          f"{precompile_sigs[query]} but generation passed {gen_sig}; "
+          "the JIT cache would miss and recompile.",
+      )
 
 
 if __name__ == "__main__":

--- a/test/test_factor.py
+++ b/test/test_factor.py
@@ -1,6 +1,7 @@
 import unittest
 from mbi.factor import Factor
 from mbi.domain import Domain
+import jax
 import numpy as np
 import jax.numpy as jnp
 
@@ -19,6 +20,19 @@ class TestFactor(unittest.TestCase):
   def test_abstract(self):
     domain = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
     factor = Factor.abstract(domain)
+
+  def test_abstract_dtype_matches_zeros(self):
+    # Abstract factors must share the default float dtype with real factors
+    # so AOT-precompiled programs hit the JIT cache instead of recompiling.
+    domain = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])
+    self.assertEqual(
+        Factor.abstract(domain).values.dtype, Factor.zeros(domain).values.dtype
+    )
+
+  def test_abstract_dtype_respects_x64(self):
+    domain = Domain(["a", "b"], [2, 3])
+    with jax.enable_x64():
+      self.assertEqual(Factor.abstract(domain).values.dtype, jnp.float64)
 
   def test_expand(self):
     domain = Domain(["a", "b", "c", "d"], [2, 3, 4, 5])


### PR DESCRIPTION
## Problem

When `jax_enable_x64` is set, `precompile()` fails to warm the JIT cache for `synthetic_data`, so **every generated column recompiles** `_generate_column` from scratch. This makes AOT precompilation a no-op (and a net slowdown) on exactly the large, high-dimensional runs where x64 is required for numerical stability.

Two independent dtype mismatches cause it:

1. **`Factor.abstract` hardcodes `float32`.** Under x64, real factors are `float64`, so the abstract inputs `precompile()` lowers against differ from the real inputs at generation.
2. **Parent arrays are passed as `np.min_scalar_type`** (`uint8`/`uint16`/...) at generation, while `precompile()` lowers against `int32`.

Either mismatch alone is enough to miss the cache for every column.

## Fix

- `Factor.abstract` now uses `jnp.result_type(float)` — the same default float dtype as `zeros`/`ones` (float64 under x64, float32 otherwise).
- `synthetic_data` casts parent arrays to `int32` to match the abstract parents `precompile()` lowers against. Output storage stays compact (only the JIT-input dtype changes).

## Tests

- `test_factor`: `Factor.abstract` dtype now matches `zeros`, and respects x64.
- `test_ext_synthetic_data`: a per-column **aval-signature match** test that records the shapes/dtypes `precompile()` lowers against vs. those `synthetic_data` passes and asserts they are identical — the precise cache-hit precondition. It fails on either mismatch above and passes with the fix.

All 19 tests in the two files pass.

> Note: `precompile()` compiles in a background thread that does **not** inherit a thread-local `with jax.enable_x64()` context. Enabling x64 globally via `jax.config.update` (as intended for large runs) works correctly; the test enables it globally for this reason.