### PR TITLE
Disable XLA constant folding in _generate_column to speed up compilation

### DIFF
--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -297,7 +297,19 @@ def _gather_inputs(cp, domain, pot_map, msg_map):
   return inputs
 
 
-@jax.jit(static_argnames=['query', 'parent_sizes', 'total'])
+@jax.jit(
+    static_argnames=['query', 'parent_sizes', 'total'],
+    # `total` (the row count) is a static argument, so arrays built from it are
+    # compile-time constants. In the root-column branch below, `parent_idx =
+    # jnp.zeros(total)` and the downstream bincount/argsort/repeat over it become
+    # `total`-sized constant subgraphs. XLA's constant_folding pass then evaluates
+    # them on the host, which is extremely slow (tens of seconds/column) and
+    # memory-hungry for large datasets. Disabling the pass for this function
+    # defers that work to the device at runtime with negligible cost (the folded
+    # values are tiny), and applies to both the direct-call and AOT (precompile)
+    # paths, keeping the JIT cache key consistent.
+    compiler_options={'xla_disable_hlo_passes': 'constant_folding'},
+)
 def _generate_column(
     prng, inputs, parent_arrays, *, query, parent_sizes, total
 ):


### PR DESCRIPTION
## Summary

`total` (the row count) is a **static** argument to `_generate_column`, so arrays derived from it are compile-time constants. In the root-column branch:

```python
parent_idx = jnp.zeros(total, dtype=jnp.int32)
```

and the downstream `bincount`/`argsort`/`repeat` over `parent_idx` become `total`-sized constant subgraphs. XLA's `constant_folding` pass then evaluates them **on the host**, which is extremely slow and memory-hungry for large datasets.

This only affects **root columns** (no parents). For non-root columns `parent_idx` comes from `parent_arrays` (a traced input), so those ops are data-dependent and never folded.

## Fix

Set `compiler_options={'xla_disable_hlo_passes': 'constant_folding'}` on the `_generate_column` `@jax.jit` decorator. This defers the (tiny) constant computation to device runtime. It applies to **both** the direct-call path in `synthetic_data()` and the AOT `.lower().compile()` path in `precompile()`, because jax carries jit-level `compiler_options` through `.lower().compile()` (see `MeshComputation.compile`: `self._compiler_options_kvs + t_compiler_options`) — so the JIT cache key stays consistent across both paths.

## Measured impact

574-column BRFSS stress test, ~2.1M rows, per root column:

| | compile time | host constant-folds | device temp |
|---|---|---|---|
| before (folding on) | ~14.0 s | 7.3 s + 4.4 s | 0.064 GiB |
| after (folding off) | ~1.7 s | none | 0.072 GiB |

~8x faster root-column compilation, no change to device memory or generated output.

## Testing

`test/test_ext_synthetic_data.py` and `test/test_factor.py` pass (jax 0.10.2). No behavior change — this is a compile-time-only option.