### PR TITLE
Row-chunk stochastic rounding in _gumbel_round to bound device memory

### DIFF
--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -319,24 +319,25 @@ def _generate_column(
   return _gumbel_round(prng, marg_2d, parent_idx, total)
 
 
-def _gumbel_round(prng, marg_2d, flat_parent_idx, total):
-  """Assign each record a value matching expected marginals."""
-  rng1, rng2 = jax.random.split(prng)
+# Row-chunk the (parent_product, domain_size) stochastic rounding when a single
+# column's marginal is large. The dense computation materializes ~10 arrays of
+# that shape plus argsort workspace (~26 GiB when parent_product*domain_size
+# approaches 2^28 under jax_enable_x64), which OOMs device memory. Per-parent
+# rounding is independent, so processing parents in chunks caps the working set
+# at a few hundred MiB with identical statistical behavior. Marginals at or below
+# the threshold use the original dense path unchanged.
+_ROUND_CHUNK_CELLS = 1 << 24  # ~16M cells/chunk (~1 GiB working set under x64)
 
-  domain_size = marg_2d.shape[-1]
-  parent_product = marg_2d.shape[0]
 
-  marg_parents = marg_2d.sum(axis=-1, keepdims=True)
-  cond_probs = jnp.where(marg_parents != 0, marg_2d / marg_parents, 0.0)
-
-  counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
-
+def _stochastic_round_dense(rng, cond_probs, counts_per_parent):
+  """Expected-count rounding: floor + Gumbel-top-k of the remainder."""
+  parent_product, domain_size = cond_probs.shape
   expected = counts_per_parent[:, None] * cond_probs
   integ = jnp.floor(expected).astype(jnp.int32)
   frac = expected - jnp.floor(expected)
   extra = counts_per_parent - integ.sum(axis=1)
 
-  u = jax.random.uniform(rng1, (parent_product, domain_size))
+  u = jax.random.uniform(rng, (parent_product, domain_size))
   scores = jnp.log(frac + 1e-30) - jnp.log(-jnp.log(u + 1e-30))
   scores = jnp.where(frac == 0, -jnp.inf, scores)
 
@@ -352,7 +353,50 @@ def _gumbel_round(prng, marg_2d, flat_parent_idx, total):
   )
   roundup = jnp.zeros((parent_product, domain_size), dtype=jnp.int32)
   roundup = roundup.at[row_indices, ranked].set(roundup_mask)
-  integ = jnp.maximum(integ + roundup, 0)
+  return jnp.maximum(integ + roundup, 0)
+
+
+def _stochastic_round_chunked(rng, cond_probs, counts_per_parent):
+  """Row-chunked equivalent of ``_stochastic_round_dense`` for large marginals."""
+  parent_product, domain_size = cond_probs.shape
+  chunk_rows = max(1, _ROUND_CHUNK_CELLS // domain_size)
+  n_chunks = -(-parent_product // chunk_rows)  # ceil division
+  pad = n_chunks * chunk_rows - parent_product
+
+  cp = jnp.pad(cond_probs, ((0, pad), (0, 0)))
+  cp = cp.reshape(n_chunks, chunk_rows, domain_size)
+  ct = jnp.pad(counts_per_parent, (0, pad)).reshape(n_chunks, chunk_rows)
+
+  def body(_, xs):
+    idx, cp_k, ct_k = xs
+    integ_k = _stochastic_round_dense(jax.random.fold_in(rng, idx), cp_k, ct_k)
+    return None, integ_k
+
+  _, integ = jax.lax.scan(body, None, (jnp.arange(n_chunks), cp, ct))
+  return integ.reshape(n_chunks * chunk_rows, domain_size)[:parent_product]
+
+
+def _stochastic_round(rng, cond_probs, counts_per_parent):
+  """Assign integer counts per (parent, value) matching expected marginals."""
+  parent_product, domain_size = cond_probs.shape
+  if parent_product * domain_size <= _ROUND_CHUNK_CELLS:
+    return _stochastic_round_dense(rng, cond_probs, counts_per_parent)
+  return _stochastic_round_chunked(rng, cond_probs, counts_per_parent)
+
+
+def _gumbel_round(prng, marg_2d, flat_parent_idx, total):
+  """Assign each record a value matching expected marginals."""
+  rng1, rng2 = jax.random.split(prng)
+
+  domain_size = marg_2d.shape[-1]
+  parent_product = marg_2d.shape[0]
+
+  marg_parents = marg_2d.sum(axis=-1, keepdims=True)
+  cond_probs = jnp.where(marg_parents != 0, marg_2d / marg_parents, 0.0)
+
+  counts_per_parent = jnp.bincount(flat_parent_idx, length=parent_product)
+
+  integ = _stochastic_round(rng1, cond_probs, counts_per_parent)
 
   value_options = jnp.arange(domain_size, dtype=jnp.int32)
   value_options_tiled = jnp.tile(value_options, parent_product)

--- a/test/test_synthetic_data_chunking.py
+++ b/test/test_synthetic_data_chunking.py
@@ -1,0 +1,106 @@
+"""Tests for memory-bounded row-chunking in synthetic data generation.
+
+Verifies that ``_stochastic_round`` produces identical rounding *contracts*
+whether it runs the dense path or the row-chunked ``lax.scan`` path, and that
+end-to-end generation still matches the dense reference when chunking is forced.
+"""
+
+import unittest
+from unittest import mock
+
+import importlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from mbi import Domain, Factor, CliqueVector, MarkovRandomField, marginal_oracles
+
+# ``mbi.extensions`` re-exports the ``synthetic_data`` *function*, which shadows
+# the submodule of the same name; import the module object explicitly.
+sd = importlib.import_module('mbi.extensions.synthetic_data')
+
+
+def _random_cond_probs(parent_product, domain_size, seed=0):
+  rng = np.random.default_rng(seed)
+  m = rng.random((parent_product, domain_size)) + 1e-6
+  return jnp.asarray(m / m.sum(axis=1, keepdims=True))
+
+
+class TestStochasticRoundChunking(unittest.TestCase):
+
+  def _assert_round_contract(self, integ, cond_probs, counts):
+    """The rounding contract that BOTH dense and chunked paths must satisfy."""
+    integ = np.asarray(integ)
+    counts = np.asarray(counts)
+    expected = counts[:, None] * np.asarray(cond_probs)
+    floor = np.floor(expected).astype(np.int32)
+    # 1. Per-parent totals are preserved exactly.
+    np.testing.assert_array_equal(integ.sum(axis=1), counts)
+    # 2. Each cell is floor(expected) or floor(expected)+1.
+    self.assertTrue(np.all(integ >= floor))
+    self.assertTrue(np.all(integ <= floor + 1))
+    # 3. Non-negative int32.
+    self.assertEqual(integ.dtype, np.int32)
+    self.assertTrue(np.all(integ >= 0))
+
+  def test_chunked_matches_contract_and_exercises_scan(self):
+    parent_product, domain_size = 5000, 8  # 40k cells
+    cond_probs = _random_cond_probs(parent_product, domain_size)
+    counts = jnp.asarray(
+        np.random.default_rng(1).integers(0, 50, size=parent_product)
+    )
+    rng = jax.random.PRNGKey(0)
+
+    dense = sd._stochastic_round_dense(rng, cond_probs, counts)
+    self._assert_round_contract(dense, cond_probs, counts)
+
+    # Force chunking with a tiny threshold so n_chunks > 1.
+    with mock.patch.object(sd, '_ROUND_CHUNK_CELLS', 8 * 64):  # 64 rows/chunk
+      chunked = sd._stochastic_round(rng, cond_probs, counts)
+    self._assert_round_contract(chunked, cond_probs, counts)
+
+    # Global total identical across both paths.
+    self.assertEqual(int(np.asarray(dense).sum()), int(np.asarray(chunked).sum()))
+
+  def test_dense_path_used_below_threshold(self):
+    parent_product, domain_size = 100, 4
+    cond_probs = _random_cond_probs(parent_product, domain_size)
+    counts = jnp.asarray(np.full(parent_product, 10))
+    rng = jax.random.PRNGKey(0)
+    # Below threshold -> dense path -> bit-identical to _stochastic_round_dense.
+    out = sd._stochastic_round(rng, cond_probs, counts)
+    ref = sd._stochastic_round_dense(rng, cond_probs, counts)
+    np.testing.assert_array_equal(np.asarray(out), np.asarray(ref))
+
+  def test_end_to_end_generation_with_forced_chunking(self):
+    domain = Domain(['a', 'b', 'c'], [12, 10, 8])
+    cliques = [('a', 'b'), ('b', 'c')]
+    potentials = {}
+    rng = np.random.default_rng(0)
+    for cl in cliques:
+      vals = rng.random(domain.project(cl).shape) + 1e-10
+      potentials[cl] = Factor(domain.project(cl), vals).log()
+    pv = CliqueVector(domain, cliques, potentials)
+    n = 20000
+    marginals = marginal_oracles.message_passing_stable(pv, total=n)
+    model = MarkovRandomField(potentials=pv, marginals=marginals, total=n)
+
+    dense_df = sd.synthetic_data(model, rows=n, seed=3)
+    with mock.patch.object(sd, '_ROUND_CHUNK_CELLS', 16):  # force chunking
+      chunk_df = sd.synthetic_data(model, rows=n, seed=3)
+
+    # Both must yield exactly `n` rows over the correct columns.
+    self.assertEqual(dense_df.records, n)
+    self.assertEqual(chunk_df.records, n)
+    # 1-way marginals should agree closely (same rounding contract, diff RNG).
+    for col in domain.attributes:
+      d = np.asarray(dense_df.project(col).datavector())
+      c = np.asarray(chunk_df.project(col).datavector())
+      # Total mass identical; distribution close.
+      self.assertEqual(d.sum(), c.sum())
+      np.testing.assert_allclose(d / d.sum(), c / c.sum(), atol=0.03)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/test_synthetic_data_chunking.py
+++ b/test/test_synthetic_data_chunking.py
@@ -61,7 +61,9 @@ class TestStochasticRoundChunking(unittest.TestCase):
     self._assert_round_contract(chunked, cond_probs, counts)
 
     # Global total identical across both paths.
-    self.assertEqual(int(np.asarray(dense).sum()), int(np.asarray(chunked).sum()))
+    self.assertEqual(
+        int(np.asarray(dense).sum()), int(np.asarray(chunked).sum())
+    )
 
   def test_dense_path_used_below_threshold(self):
     parent_product, domain_size = 100, 4


### PR DESCRIPTION
## Problem

The dense stochastic rounding in `_gumbel_round` materializes ~10 arrays of shape `(parent_product, domain_size)` plus argsort workspace simultaneously. For a single high-cardinality clique this reaches **~26 GiB of device memory** when `parent_product * domain_size` approaches `2^28` under `jax_enable_x64`, causing `RESOURCE_EXHAUSTED` during generation on GPU/TPU.

Analytical footprint (per-cell): ~5 float64 + ~6 int32 co-resident arrays + argsort ≈ 64 B/cell + sort overhead:

| clique cells | current peak | chunked peak |
|---|---|---|
| 2^23 (8.4M) | ~0.7 GiB | ~0.1 GiB |
| 2^25 (34M) | ~2.8 GiB | ~0.2 GiB |
| 2^28 (268M) | ~26 GiB (OOM) | ~1 GiB |

## Fix

Per-parent rounding is independent, so process parents in **row chunks via `lax.scan`**, capping the working set at a few hundred MiB regardless of clique size.

- The rounding contract is preserved **exactly**: per-parent totals equal the sampled counts, and each cell is `floor(expected)` or `floor(expected)+1`.
- Marginals at or below `_ROUND_CHUNK_CELLS` (16M cells) use the original dense path **unchanged** — common small/medium cliques are bit-identical to before.
- Chunk RNG uses `jax.random.fold_in` per chunk (statistically equivalent to the dense draw; not bit-identical, as expected for a memory refactor).

## Tests

Adds `test/test_synthetic_data_chunking.py`:
- rounding-contract invariants on both dense and chunked paths,
- dense path bit-identical below threshold,
- end-to-end generation under forced chunking matches the dense reference within tolerance.

All 3 pass. (Note: the pre-existing `test_ext_synthetic_data.py` failures are unrelated — a numpy read-only issue in the reference `MRF.synthetic_data`, present on `master` without this change.)