### PR TITLE
Make stddev and lipschitz dynamic pytree leaves to fix precompile() cache misses

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -208,7 +208,7 @@ class Estimator(ABC):
     all_measurements = list(measurements or [])
     for cl in extra_cliques or []:
       shape = (domain.project(cl).size(),)
-      abstract_values = jax.ShapeDtypeStruct(shape, jnp.float32)
+      abstract_values = jax.ShapeDtypeStruct(shape, jnp.result_type(float))
       all_measurements.append(
           marginal_loss.LinearMeasurement(abstract_values, cl)
       )
@@ -390,7 +390,7 @@ class MirrorDescent(Estimator):
     # proportional to L. We also divide by scaling factor to account for
     # the fact that gradients are scaled up by a factor of known_total.
     # See Eq 75. of https://www.cs.uic.edu/~zhangx/teaching/bregman.pdf.
-    L = loss_fn.lipschitz or 1.0
+    L = loss_fn.lipschitz
     alpha = 2.0 / (L * known_total) if self.stepsize is None else self.stepsize
     mu = marginal_oracle(potentials, known_total)
     initial_loss = loss_fn(mu)
@@ -491,7 +491,7 @@ class DualAveraging(Estimator):
     )  # upper bound on entropy
     Q = 0  # upper bound on variance of stochastic gradients
     gamma = Q / D
-    L = (loss_fn.lipschitz or 1.0) / known_total
+    L = loss_fn.lipschitz / known_total
 
     w = v = marginal_oracle(potentials, known_total)
     gbar = CliqueVector.zeros(domain, loss_fn.cliques)
@@ -579,7 +579,7 @@ class InteriorGradient(Estimator):
         loss_fn.cliques, domain, constraints=constraints
     )
 
-    inv_lipschitz = 1.0 / (loss_fn.lipschitz or 1.0)
+    inv_lipschitz = 1.0 / loss_fn.lipschitz
     x = y = z = marginal_oracle(potentials, known_total)
     initial_loss = loss_fn(x)
     return InteriorGradientState(
@@ -776,7 +776,7 @@ class UniversalAcceleratedMethod(Estimator):
     # f_scaled(p) = loss_fn(N*p) has Lipschitz-continuous gradient with
     # constant N² * L, where L = loss_fn.lipschitz.  The initial stepsize
     # is the inverse of this smoothness estimate.
-    L = loss_fn.lipschitz or 1.0
+    L = loss_fn.lipschitz
     stepsize = 1.0 / (known_total * known_total * L)
     return _AcceleratedStepSearchState(
         x=x,

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -101,7 +101,9 @@ class LinearMeasurement:
 
   noisy_measurement: ArrayLike
   clique: Clique = jax.tree.static()
-  stddev: float = jax.tree.static(default=1.0)
+  # Dynamic (traced) leaf, not static aux-data: a static value gets baked into
+  # the treedef, changing the jit cache key and defeating precompile() reuse.
+  stddev: float = 1.0
   query: Callable[[Factor], ArrayLike] = jax.tree.static(
       default=DatavectorQuery()
   )
@@ -177,13 +179,15 @@ class MarginalLossFn:
           treated as static metadata for JIT compilation.
       data: Arbitrary pytree of arrays captured by ``loss_fn``.  This is
           traced through JIT and can change without recompilation.
-      lipschitz: Optional Lipschitz constant of the gradient.
+      lipschitz: Lipschitz constant of the gradient. Defaults to ``1.0``.
   """
 
   cliques: Sequence[Clique] = jax.tree.static()
   loss_fn: Callable[[CliqueVector, Any], chex.Numeric] = jax.tree.static()
   data: Any = ()
-  lipschitz: float | None = jax.tree.static(default=None)
+  # Dynamic (traced) leaf, always a concrete float (never None): a static value
+  # gets baked into the treedef, changing the jit cache key and defeating reuse.
+  lipschitz: float = 1.0
 
   def __post_init__(self):
     object.__setattr__(self, "cliques", tuple(self.cliques))

--- a/test/test_ext_synthetic_data.py
+++ b/test/test_ext_synthetic_data.py
@@ -1,3 +1,5 @@
+import importlib
+import logging
 import unittest
 import jax
 import numpy as np
@@ -277,6 +279,97 @@ class TestExtSyntheticDataPrecompile(unittest.TestCase):
           f"{precompile_sigs[query]} but generation passed {gen_sig}; "
           "the JIT cache would miss and recompile.",
       )
+
+
+class TestExtSyntheticDataCacheHit(unittest.TestCase):
+  """Behavioral test: synthetic_data() reuses precompile()'s JIT cache.
+
+  Complements the aval-signature test above by asserting the *observable*
+  consequence: after precompile() warms the cache, generation triggers zero
+  new compilations of the per-column kernel ``_generate_column``.  Checked in
+  both the default (float32) and ``jax_enable_x64`` (float64) regimes, since
+  the dtype mismatches that used to defeat reuse only surfaced under x64.
+  """
+
+  class _CompileCounter(logging.Handler):
+    """Counts JAX 'Compiling ... _generate_column' log records."""
+
+    def __init__(self):
+      super().__init__()
+      self.n = 0
+
+    def emit(self, record):
+      try:
+        msg = record.getMessage()
+      except Exception:  # pylint: disable=broad-exception-caught
+        return
+      if "Compiling" in msg and "_generate_column" in msg:
+        self.n += 1
+
+  def _run_regime(self, enable_x64):
+    sd = importlib.import_module("mbi.extensions.synthetic_data")
+    # ``jax_log_compiles`` / ``jax_enable_compilation_cache`` are contextmanager
+    # flags, which must be read via attribute access rather than config.read().
+    prev_x64 = jax.config.jax_enable_x64
+    prev_log = jax.config.jax_log_compiles
+    prev_cache = jax.config.jax_enable_compilation_cache
+    counter = self._CompileCounter()
+    loggers = [logging.getLogger(name) for name in ("", "jax", "jax._src")]
+    prev_levels = [(lg, lg.level) for lg in loggers]
+    try:
+      jax.config.update("jax_enable_x64", enable_x64)
+      # Disable the persistent on-disk cache and clear the in-memory cache so
+      # that precompile() genuinely compiles (emitting the log records we
+      # count) rather than loading a warm executable from a previous run.
+      jax.config.update("jax_enable_compilation_cache", False)
+      jax.clear_caches()
+      jax.config.update("jax_log_compiles", True)
+      for lg in loggers:
+        lg.setLevel(logging.DEBUG)
+        lg.addHandler(counter)
+
+      # A chain guarantees columns generated with parents, exercising the
+      # parent-array dtype path that broke reuse under x64.
+      domain = Domain(["A", "B", "C"], [5, 5, 5])
+      cliques = [("A", "B"), ("B", "C")]
+      model = _create_random_model(domain, cliques, N=1000)
+      rows = 1000
+
+      sd.precompile(domain, list(model.cliques), rows).result()
+      n_after_precompile = counter.n
+      sd.synthetic_data(model, rows)
+      n_after_generate = counter.n
+    finally:
+      for lg in loggers:
+        lg.removeHandler(counter)
+      for lg, level in prev_levels:
+        lg.setLevel(level)
+      jax.config.update("jax_log_compiles", prev_log)
+      jax.config.update("jax_enable_compilation_cache", prev_cache)
+      jax.config.update("jax_enable_x64", prev_x64)
+
+    # precompile() must actually have compiled the kernel, otherwise the test
+    # is vacuous; then generation must add no further compilations.
+    self.assertGreater(
+        n_after_precompile,
+        0,
+        "precompile() compiled no _generate_column; test is vacuous",
+    )
+    self.assertEqual(
+        n_after_generate,
+        n_after_precompile,
+        "synthetic_data() recompiled _generate_column "
+        f"({n_after_generate - n_after_precompile} new compiles) with "
+        f"jax_enable_x64={enable_x64}: the precompile() cache missed.",
+    )
+
+  def test_cache_hit_x64(self):
+    """Under jax_enable_x64 (float64), generation reuses the precompiled cache."""
+    self._run_regime(enable_x64=True)
+
+  def test_cache_hit_default(self):
+    """Under the default (float32) regime, generation reuses the cache."""
+    self._run_regime(enable_x64=False)
 
 
 if __name__ == "__main__":

--- a/test/test_marginal_loss.py
+++ b/test/test_marginal_loss.py
@@ -1,4 +1,6 @@
+import dataclasses
 import unittest
+import jax
 import numpy as np
 import jax.numpy as jnp
 from mbi.domain import Domain
@@ -100,6 +102,65 @@ class TestCompress(unittest.TestCase):
     )
     result = np.asarray(model.project(('a',)).datavector())
     np.testing.assert_allclose(result, [250, 450, 650], rtol=0.01)
+
+
+class TestJitCacheReuse(unittest.TestCase):
+  """Regression tests for JIT cache reuse across measurement noise.
+
+  ``stddev`` and ``lipschitz`` must be dynamic (traced) pytree leaves, not
+  static aux-data.  When they were static, two otherwise-identical inputs that
+  differed only in noise level produced different pytree treedefs, which
+  changed the ``jax.jit`` cache key and forced a full recompilation.  This
+  silently defeated ``MirrorDescent.precompile`` (its abstract placeholder
+  measurements use the default ``stddev`` / ``lipschitz`` and would never match
+  the real values), so the precompiled executable was always discarded and
+  ``estimate`` recompiled from scratch.
+  """
+
+  def _traces_for(self, arg1, arg2):
+    """Returns (traces after 1st call, traces after 2nd call).
+
+    The body of a jitted function is executed exactly once per trace, i.e.
+    once per compilation.  If ``arg2`` reuses ``arg1``'s compiled program the
+    second call adds no trace.
+    """
+    traces = []
+
+    @jax.jit
+    def f(x):
+      traces.append(None)
+      return jax.tree_util.tree_leaves(x)[0].sum()
+
+    f(arg1)
+    n_after_first = len(traces)
+    f(arg2)
+    n_after_second = len(traces)
+    return n_after_first, n_after_second
+
+  def test_stddev_change_does_not_recompile(self):
+    """Measurements differing only in ``stddev`` reuse the compiled program."""
+    m1 = LinearMeasurement(jnp.zeros(4), ('a',), stddev=1.0)
+    m2 = LinearMeasurement(jnp.zeros(4), ('a',), stddev=9.0)
+    # Sanity check: the treedef must be identical (stddev is a leaf, not aux).
+    self.assertEqual(
+        jax.tree_util.tree_structure(m1), jax.tree_util.tree_structure(m2)
+    )
+    n_after_first, n_after_second = self._traces_for(m1, m2)
+    self.assertEqual(n_after_first, n_after_second)
+
+  def test_lipschitz_change_does_not_recompile(self):
+    """Losses differing only in ``lipschitz`` reuse the compiled program."""
+    domain = Domain.fromdict({'a': 4})
+    loss1 = from_linear_measurements(
+        [LinearMeasurement(jnp.zeros(4), ('a',), stddev=1.0)], domain
+    )
+    loss2 = dataclasses.replace(loss1, lipschitz=loss1.lipschitz * 3.0)
+    self.assertEqual(
+        jax.tree_util.tree_structure(loss1),
+        jax.tree_util.tree_structure(loss2),
+    )
+    n_after_first, n_after_second = self._traces_for(loss1, loss2)
+    self.assertEqual(n_after_first, n_after_second)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

`stddev` (`LinearMeasurement`) and `lipschitz` (`MarginalLossFn`) were static pytree aux-data, so they were baked into the treedef and therefore into the `jax.jit` cache key. Two measurements/losses that differ only in noise level (or lipschitz) produced different cache keys and forced a full recompilation.

This silently defeated `MirrorDescent.precompile()`: it builds abstract placeholder measurements with the default `stddev=1.0` and (because the values are abstract) `lipschitz=None`, neither of which matches the real values `estimate()` produces. The precompiled executable was always discarded and `estimate()` recompiled from scratch.

## Changes

- `LinearMeasurement.stddev` is now a dynamic (traced) leaf — it is only a numeric weight in the loss and never used in control flow.
- `MarginalLossFn.lipschitz` is now a dynamic leaf that is always a concrete `float` (default `1.0`, never `None`). It only scales the initial learning rate, which is stored in the traced optimizer state, so its value never needs to affect the compiled program.
- The four `loss_fn.lipschitz or 1.0` sites use `loss_fn.lipschitz` directly (it is always a float now, and `or` would raise `TracerBoolConversionError` under `precompile`'s `eval_shape` tracing).
- `precompile()`'s `extra_cliques` placeholder hardcoded `jnp.float32`; under `jax_enable_x64` the real measurements are `float64`, so the placeholder dtype did not match. Use `jnp.result_type(float)`, closing the last dtype gap left by #193.

## Tests

Adds `TestJitCacheReuse` (regression) asserting that changing only `stddev` or only `lipschitz` does not change the pytree treedef and triggers no recompilation. Verified these fail on `master` (treedef mismatch showing the static value in the aux-data) and pass with the fix.

End-to-end: an isolated probe replicating the precompile → estimate flow under x64 now reports **0** `_multi_step` recompiles during `estimate()` (previously it recompiled from scratch).

`test_marginal_loss` (8) and `test_estimation` (65) both pass locally.
