### PR TITLE
Fix minimum_variance_unbiased_total to recognize legacy identity queries

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -238,7 +238,9 @@ def minimum_variance_unbiased_total(
     y = M.noisy_measurement
     try:
       # TODO: generalize to support any linear measurement that supports total query
-      if isinstance(M.query, DatavectorQuery):  # query = Identity
+      # Accept both the DatavectorQuery dataclass and the legacy
+      # Factor.datavector callable as identity queries.
+      if isinstance(M.query, DatavectorQuery) or M.query == Factor.datavector:
         estimates.append(y.sum())
         variances.append(M.stddev**2 * y.size)
     except Exception:  # pylint: disable=broad-exception-caught

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -41,6 +41,29 @@ class TestEstimation(unittest.TestCase):
     total = estimation.minimum_variance_unbiased_total(measurements)
     np.testing.assert_allclose(total, 1.0, rtol=1e-5)
 
+  def test_total_estimator_legacy_factor_datavector_query(self):
+    # Regression test: measurements whose query is the legacy
+    # ``Factor.datavector`` callable (rather than a ``DatavectorQuery``
+    # instance) must still contribute to the total estimate.
+    P = Factor.random(_DOMAIN)
+    P = 10.0 * P / P.sum()  # total = 10
+    y = P.project(("a",)).datavector()
+    m = marginal_loss.LinearMeasurement(y, ("a",), query=Factor.datavector)
+    total = estimation.minimum_variance_unbiased_total([m])
+    np.testing.assert_allclose(total, 10.0, rtol=1e-5)
+
+  def test_total_estimator_ignores_non_identity_query(self):
+    # A non-identity query (e.g. a normalized datavector) carries no
+    # information about the total and must be excluded, so the fallback
+    # default (1.0) is returned.
+    P = Factor.random(_DOMAIN)
+    y = P.project(("a",)).datavector()
+    m = marginal_loss.LinearMeasurement(
+        y, ("a",), query=marginal_loss.NormalizedQuery()
+    )
+    total = estimation.minimum_variance_unbiased_total([m])
+    np.testing.assert_allclose(total, 1.0, rtol=1e-5)
+
   @parameterized.expand(itertools.product(_CLIQUE_SETS))
   def test_mirror_descent(self, cliques):
     measurements = fake_measurements(cliques)


### PR DESCRIPTION
## Summary

`minimum_variance_unbiased_total` estimates the total count by summing identity-query measurements. A prior refactor that introduced the `DatavectorQuery` dataclass changed the identity check from a value comparison against `Factor.datavector` to a strict `isinstance(M.query, DatavectorQuery)`.

This regressed callers that still construct `LinearMeasurement`s with `query=Factor.datavector`: their identity measurements were silently dropped from the total, collapsing it to the fallback default of `1.0`.

## Fix

Accept **both** representations of the identity query:

```python
if isinstance(M.query, DatavectorQuery) or M.query == Factor.datavector:
```

## Tests

- `test_total_estimator_legacy_factor_datavector_query`: a measurement with `query=Factor.datavector` contributes to the total.
- `test_total_estimator_ignores_non_identity_query`: a non-identity query (e.g. `NormalizedQuery`) is excluded.

Full `test_estimation.py` suite passes (67/67).