### PR TITLE
Add use_for_total_estimation opt-out flag to DatavectorQuery

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -240,7 +240,13 @@ def minimum_variance_unbiased_total(
       # TODO: generalize to support any linear measurement that supports total query
       # Accept both the DatavectorQuery dataclass and the legacy
       # Factor.datavector callable as identity queries.
-      if isinstance(M.query, DatavectorQuery) or M.query == Factor.datavector:
+      is_identity = (
+          isinstance(M.query, DatavectorQuery) or M.query == Factor.datavector
+      )
+      # Honor an opt-out flag when the query carries one; the legacy
+      # Factor.datavector callable has no flag and defaults to contributing.
+      use_for_total = getattr(M.query, "use_for_total_estimation", True)
+      if is_identity and use_for_total:
         estimates.append(y.sum())
         variances.append(M.stddev**2 * y.size)
     except Exception:  # pylint: disable=broad-exception-caught

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -45,7 +45,17 @@ def _weighted_datavector(weights: np.ndarray, x: Factor) -> jax.Array:
 
 @dataclasses.dataclass(frozen=True)
 class DatavectorQuery:
-  """Identity query: ``f.datavector()``."""
+  """Identity query: ``f.datavector()``.
+
+  Attributes:
+      use_for_total_estimation: Whether measurements using this query should
+          contribute to :func:`mbi.minimum_variance_unbiased_total`.  Defaults
+          to ``True``.  Set to ``False`` to exclude the measurement from
+          total-count estimation, e.g. when its marginal is a biased or
+          partial view of the population and would skew the estimate.
+  """
+
+  use_for_total_estimation: bool = True
 
   def __call__(self, f: Factor) -> jax.Array:
     return f.datavector()

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -64,6 +64,38 @@ class TestEstimation(unittest.TestCase):
     total = estimation.minimum_variance_unbiased_total([m])
     np.testing.assert_allclose(total, 1.0, rtol=1e-5)
 
+  def test_total_estimator_respects_use_for_total_estimation_flag(self):
+    # An identity query that opts out of total estimation must be excluded,
+    # so the fallback default (1.0) is returned.
+    P = Factor.random(_DOMAIN)
+    P = 10.0 * P / P.sum()  # total = 10
+    y = P.project(("a",)).datavector()
+    m = marginal_loss.LinearMeasurement(
+        y,
+        ("a",),
+        query=marginal_loss.DatavectorQuery(use_for_total_estimation=False),
+    )
+    total = estimation.minimum_variance_unbiased_total([m])
+    np.testing.assert_allclose(total, 1.0, rtol=1e-5)
+
+  def test_total_estimator_mixes_opted_in_measurements_only(self):
+    # Only measurements that opt in should drive the estimate; an opted-out
+    # measurement with a wildly different scale must not skew it.
+    P = Factor.random(_DOMAIN)
+    P = 10.0 * P / P.sum()  # total = 10
+    y_in = P.project(("a",)).datavector()
+    y_out = 1000.0 * P.project(("b",)).datavector()  # scale 1000, opted out
+    m_in = marginal_loss.LinearMeasurement(
+        y_in, ("a",), query=marginal_loss.DatavectorQuery()
+    )
+    m_out = marginal_loss.LinearMeasurement(
+        y_out,
+        ("b",),
+        query=marginal_loss.DatavectorQuery(use_for_total_estimation=False),
+    )
+    total = estimation.minimum_variance_unbiased_total([m_in, m_out])
+    np.testing.assert_allclose(total, 10.0, rtol=1e-5)
+
   @parameterized.expand(itertools.product(_CLIQUE_SETS))
   def test_mirror_descent(self, cliques):
     measurements = fake_measurements(cliques)


### PR DESCRIPTION
## Summary

Adds a boolean field `use_for_total_estimation` to `DatavectorQuery` (the identity query `f.datavector()`), defaulting to `True`. `minimum_variance_unbiased_total` now consults this flag, letting callers exclude a specific identity measurement from total-count estimation.

This is useful when a measured marginal is a biased or partial view of the population (e.g. a subpopulation or truncated slice) that would otherwise skew the inferred total.

## Changes

- **`marginal_loss.DatavectorQuery`**: new `use_for_total_estimation: bool = True` field (documented in the class docstring).
- **`estimation.minimum_variance_unbiased_total`**: reads the flag via `getattr(query, "use_for_total_estimation", True)`, so:
  - a `DatavectorQuery(use_for_total_estimation=False)` measurement is excluded;
  - the legacy `Factor.datavector` callable (no flag) keeps contributing, unchanged.
- **Tests**: added coverage for the opt-out case and a mixed opted-in/opted-out case.

## Compatibility

Fully backward compatible — the field defaults to `True`, and the `getattr` fallback preserves behavior for legacy identity queries.

## Validation

- `pytest test/test_estimation.py test/test_serialization.py test/test_marginal_loss.py` → 82 passed
- `pyrefly check` → 0 errors
- `pyink --check` / `pydocstyle` → clean