### PR TITLE
Shorten over-explained docstrings and comments

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -238,13 +238,11 @@ def minimum_variance_unbiased_total(
     y = M.noisy_measurement
     try:
       # TODO: generalize to support any linear measurement that supports total query
-      # Accept both the DatavectorQuery dataclass and the legacy
-      # Factor.datavector callable as identity queries.
+      # Identity queries (DatavectorQuery or the legacy Factor.datavector) that
+      # haven't opted out via use_for_total_estimation contribute to the total.
       is_identity = (
           isinstance(M.query, DatavectorQuery) or M.query == Factor.datavector
       )
-      # Honor an opt-out flag when the query carries one; the legacy
-      # Factor.datavector callable has no flag and defaults to contributing.
       use_for_total = getattr(M.query, "use_for_total_estimation", True)
       if is_identity and use_for_total:
         estimates.append(y.sum())

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -92,9 +92,7 @@ def precompile(
         if not any(attr in inp.domain.attributes for inp in inputs):
           inputs.append(Factor.abstract(domain.project([attr])))
 
-      # int32 matches _generate_column's ravel dtype; see the parent_arrays
-      # comment in synthetic_data() for why the boundary is int32 rather than
-      # the compact storage dtype.
+      # int32 matches _generate_column's ravel dtype (see parent_arrays below).
       abstract_parents = tuple(
           jax.ShapeDtypeStruct((rows,), jnp.int32) for _ in cp.parents
       )
@@ -160,14 +158,8 @@ def synthetic_data(
     cp = plan.columns[col]
 
     inputs = _gather_inputs(cp, domain, pot_map, msg_map)
-    # Parents feed only _ravel_multi_index, which casts them to int32 anyway, so
-    # int32 is the real compute dtype. Passing int32 here (and lowering int32 in
-    # precompile) keeps the JIT signature a fixed contract, independent of the
-    # compact storage dtype (np.min_scalar_type(domain[p]), applied at the end of
-    # the loop). A dtype mismatch would miss the JIT cache and recompile every
-    # column. The only cost is a slightly larger host->device copy of this
-    # O(rows) array; peak HBM is unchanged, since the int32 index is materialized
-    # on-device regardless.
+    # Parents are only fed to _ravel_multi_index (int32); pinning int32 here
+    # keeps the JIT signature stable and avoids per-column recompiles.
     parent_arrays = tuple(
         jnp.asarray(data[p], dtype=jnp.int32) for p in cp.parents
     )
@@ -299,15 +291,8 @@ def _gather_inputs(cp, domain, pot_map, msg_map):
 
 @jax.jit(
     static_argnames=['query', 'parent_sizes', 'total'],
-    # `total` (the row count) is a static argument, so arrays built from it are
-    # compile-time constants. In the root-column branch below, `parent_idx =
-    # jnp.zeros(total)` and the downstream bincount/argsort/repeat over it become
-    # `total`-sized constant subgraphs. XLA's constant_folding pass then evaluates
-    # them on the host, which is extremely slow (tens of seconds/column) and
-    # memory-hungry for large datasets. Disabling the pass for this function
-    # defers that work to the device at runtime with negligible cost (the folded
-    # values are tiny), and applies to both the direct-call and AOT (precompile)
-    # paths, keeping the JIT cache key consistent.
+    # `total` is static, so root-column arrays built from it become large
+    # constant subgraphs XLA would fold on the host (slow); defer to device.
     compiler_options={'xla_disable_hlo_passes': 'constant_folding'},
 )
 def _generate_column(
@@ -331,13 +316,8 @@ def _generate_column(
   return _gumbel_round(prng, marg_2d, parent_idx, total)
 
 
-# Row-chunk the (parent_product, domain_size) stochastic rounding when a single
-# column's marginal is large. The dense computation materializes ~10 arrays of
-# that shape plus argsort workspace (~26 GiB when parent_product*domain_size
-# approaches 2^28 under jax_enable_x64), which OOMs device memory. Per-parent
-# rounding is independent, so processing parents in chunks caps the working set
-# at a few hundred MiB with identical statistical behavior. Marginals at or below
-# the threshold use the original dense path unchanged.
+# Chunk the per-parent rounding for large marginals: the dense path allocates
+# many (parent_product, domain_size) arrays (~26 GiB near 2^28 x64) and OOMs.
 _ROUND_CHUNK_CELLS = 1 << 24  # ~16M cells/chunk (~1 GiB working set under x64)
 
 

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -63,14 +63,9 @@ class Factor:
 
   @classmethod
   def abstract(cls, domain: Domain) -> Factor:
-    """Creates a shape/dtype-only Factor for ahead-of-time compilation.
-
-    Uses the same default float dtype as ``zeros``/``ones`` (float64 when
-    ``jax_enable_x64`` is set, float32 otherwise) so that programs traced
-    with abstract factors share the JIT cache with programs run on real
-    factors.  Hardcoding a dtype here silently defeats precompilation and
-    forces a recompile on every call whenever the environment dtype differs.
-    """
+    """Creates a shape/dtype-only Factor for ahead-of-time compilation."""
+    # Match zeros/ones' default float dtype so abstract-traced programs share
+    # the JIT cache with real runs (a fixed dtype would force recompiles).
     return cls(
         domain, jax.ShapeDtypeStruct(domain.shape, jnp.result_type(float))
     )

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -48,11 +48,8 @@ class DatavectorQuery:
   """Identity query: ``f.datavector()``.
 
   Attributes:
-      use_for_total_estimation: Whether measurements using this query should
-          contribute to :func:`mbi.minimum_variance_unbiased_total`.  Defaults
-          to ``True``.  Set to ``False`` to exclude the measurement from
-          total-count estimation, e.g. when its marginal is a biased or
-          partial view of the population and would skew the estimate.
+      use_for_total_estimation: If ``False``, exclude measurements using this
+          query from ``minimum_variance_unbiased_total``. Defaults to ``True``.
   """
 
   use_for_total_estimation: bool = True


### PR DESCRIPTION
## Summary

Trims docstrings and inline comments that were more verbose than the rationale they convey, following the comment/docstring brevity conventions (inline comments ≤ 2 lines; docstrings describe *what*, comments explain *how*).

## Changes

- **`extensions/synthetic_data.py`** — four inline comments compressed to ≤ 2 lines (the largest were 8 and 11 lines): int32 parent-dtype boundary, the `constant_folding` decorator rationale, and the row-chunking module comment. The "why" is preserved, just no longer belabored.
- **`factor.py`** — `Factor.abstract` docstring reduced to one line; the dtype/JIT-cache rationale moves to a 2-line inline comment.
- **`marginal_loss.py`** — `DatavectorQuery.use_for_total_estimation` attribute doc condensed to two lines.
- **`estimation.py`** — merged two back-to-back comments in `minimum_variance_unbiased_total` into one.

## Nature of change

Comment/docstring-only — **no behavior change**.

## Validation

- `pyink --check`, `pyrefly check` (0 errors), `pydocstyle` → all clean
- All edited comment lines are under 80 chars
- Affected test suites pass: `test_estimation`, `test_marginal_loss`, `test_factor`, `test_ext_synthetic_data`, `test_synthetic_data_chunking`