### PR TITLE
Compute L2 Lipschitz constant analytically from measurement metadata

### DIFF
--- a/src/mbi/__init__.py
+++ b/src/mbi/__init__.py
@@ -42,7 +42,7 @@ from .dataset import Dataset
 from .domain import Domain
 from .factor import Factor
 from .marginal_loss import DatavectorQuery, LinearMeasurement, MarginalLossFn
-from .marginal_loss import NormalizedQuery, SlicedQuery, WeightedQuery
+from .marginal_loss import SlicedQuery, WeightedQuery
 from .marginal_oracles import MarginalOracle
 from .markov_random_field import MarkovRandomField
 from ._serialization import save, load
@@ -64,7 +64,6 @@ __all__ = [
     "ModelSummary",
     "summarize",
     "set_log_fn",
-    "NormalizedQuery",
     "SlicedQuery",
     "WeightedQuery",
     "save",

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -11,7 +11,7 @@ included.
 
 import dataclasses
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, SupportsFloat, cast
 
 import chex
 import jax
@@ -57,6 +57,9 @@ class DatavectorQuery:
   def __call__(self, f: Factor) -> jax.Array:
     return f.datavector()
 
+  def op_norm_sq(self) -> float:
+    return 1.0
+
 
 @dataclasses.dataclass(frozen=True, eq=False)
 class WeightedQuery:
@@ -67,20 +70,15 @@ class WeightedQuery:
   def __call__(self, f: Factor) -> jax.Array:
     return f.datavector() * self.weights
 
+  def op_norm_sq(self) -> float:
+    return float(np.max(np.asarray(self.weights) ** 2))
+
   # Identity-based hash/eq so JAX static tracing works (ndarray isn't hashable).
   def __hash__(self) -> int:
     return id(self)
 
   def __eq__(self, other: object) -> bool:
     return self is other
-
-
-@dataclasses.dataclass(frozen=True)
-class NormalizedQuery:
-  """L1-normalized datavector: ``f.normalize(1).datavector()``."""
-
-  def __call__(self, f: Factor) -> jax.Array:
-    return f.normalize(1.0).datavector()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -91,6 +89,9 @@ class SlicedQuery:
 
   def __call__(self, f: Factor) -> jax.Array:
     return f.datavector()[self.start :]
+
+  def op_norm_sq(self) -> float:
+    return 1.0
 
 
 @jax.tree_util.register_dataclass
@@ -284,6 +285,59 @@ def calculate_l2_lipschitz(
   return float(estimate)
 
 
+def _query_op_norm_sq(query: Callable[[Factor], ArrayLike]) -> float | None:
+  """Squared operator norm ||Q||_2^2 of a linear query, or None if unknown."""
+  fn = getattr(query, "op_norm_sq", None)
+  return float(cast(SupportsFloat, fn())) if callable(fn) else None
+
+
+def calculate_l2_lipschitz_from_metadata(
+    domain: Domain,
+    measurements: Sequence[LinearMeasurement],
+) -> float | None:
+  """Lipschitz constant of the (unnormalized) l2 loss gradient from metadata.
+
+  The loss is quadratic, so its gradient's Lipschitz constant is lambda_max of a
+  Hessian that is block-diagonal by maximal clique::
+
+      H = sum_M (1 / sigma_M^2) (Q_M P_{c_M})^T (Q_M P_{c_M})
+
+  where P_{c_M} marginalizes a maximal-clique table down to clique c_M, with
+  ||P_c||^2 = |C| / |c| (the product of the summed-out domain sizes). Bounding
+  each block by the sum of its terms' norms gives::
+
+      L <= max_C sum_{M->C} ||Q_M||^2 / sigma_M^2 * |C| / |c_M|.
+
+  The uniform vector is the top eigenvector of every marginalization operator,
+  so this is *exact* when all queries are identity marginals (the common case)
+  and a safe overestimate otherwise (a larger L only shrinks the step size).
+
+  Returns None if any query's operator norm is unknown (e.g. a nonlinear or
+  user-supplied callable query), signalling the caller to fall back to the
+  power-iteration estimate.
+  """
+  maximal = maximal_subset([m.clique for m in measurements])
+
+  def parent(clique: Clique) -> Clique:
+    scope = set(clique)
+    for c in maximal:  # Same order CliqueVector.parent scans.
+      if scope <= set(c):
+        return c
+    raise ValueError(f"No maximal clique contains {clique}.")
+
+  blocks: dict[Clique, float] = {}
+  for m in measurements:
+    q_norm_sq = _query_op_norm_sq(m.query)
+    if q_norm_sq is None:
+      return None
+    containing = parent(m.clique)
+    proj_norm_sq = domain.size(containing) / domain.size(m.clique)
+    stddev = max(float(m.stddev), 1e-12)
+    contribution = q_norm_sq / stddev**2 * proj_norm_sq
+    blocks[containing] = blocks.get(containing, 0.0) + contribution
+  return max(blocks.values()) if blocks else 1.0
+
+
 def from_linear_measurements(
     measurements: list[LinearMeasurement],
     domain: Domain,
@@ -321,7 +375,9 @@ def from_linear_measurements(
       for m in measurements
   )
   if norm == "l2" and not normalize and not has_abstract:
-    lipschitz = calculate_l2_lipschitz(domain, maximal_cliques, loss)
+    lipschitz = calculate_l2_lipschitz_from_metadata(domain, measurements)
+    if lipschitz is None:
+      lipschitz = calculate_l2_lipschitz(domain, maximal_cliques, loss)
     return MarginalLossFn(maximal_cliques, loss_fn, data, lipschitz)
 
   return loss

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -59,7 +59,7 @@ class TestEstimation(unittest.TestCase):
     P = Factor.random(_DOMAIN)
     y = P.project(("a",)).datavector()
     m = marginal_loss.LinearMeasurement(
-        y, ("a",), query=marginal_loss.NormalizedQuery()
+        y, ("a",), query=lambda f: f.normalize(1.0).datavector()
     )
     total = estimation.minimum_variance_unbiased_total([m])
     np.testing.assert_allclose(total, 1.0, rtol=1e-5)

--- a/test/test_marginal_loss.py
+++ b/test/test_marginal_loss.py
@@ -1,11 +1,16 @@
 import dataclasses
 import unittest
+from unittest import mock
 import jax
 import numpy as np
 import jax.numpy as jnp
 from mbi.domain import Domain
+from mbi.factor import Factor
 from mbi.marginal_loss import LinearMeasurement, from_linear_measurements, calculate_l2_lipschitz
+from mbi.marginal_loss import calculate_l2_lipschitz_from_metadata
+from mbi.marginal_loss import DatavectorQuery, WeightedQuery, SlicedQuery
 from mbi.clique_vector import CliqueVector
+import mbi.marginal_loss as marginal_loss
 
 
 class TestMarginalLoss(unittest.TestCase):
@@ -161,6 +166,105 @@ class TestJitCacheReuse(unittest.TestCase):
     )
     n_after_first, n_after_second = self._traces_for(loss1, loss2)
     self.assertEqual(n_after_first, n_after_second)
+
+
+class TestAnalyticLipschitz(unittest.TestCase):
+  """Metadata-based Lipschitz matches (or safely upper-bounds) power iteration."""
+
+  def setUp(self):
+    super().setUp()
+    self.domain = Domain.fromdict({'a': 2, 'b': 3, 'c': 4})
+
+  def _m(self, clique, stddev=1.0, query=None):
+    q = query if query is not None else DatavectorQuery()
+    out = np.asarray(q(Factor.zeros(self.domain.project(clique))))
+    return LinearMeasurement(np.zeros_like(out), clique, stddev, query=q)
+
+  def _power(self, ms):
+    lf = from_linear_measurements(list(ms), self.domain)
+    return calculate_l2_lipschitz(self.domain, list(lf.cliques), lf)
+
+  def test_exact_for_identity_marginals(self):
+    # (expected closed-form, measurements) for all-identity structures.
+    cases = {
+        # max(1/0.5^2, 1/0.2^2, 1/1^2) = 25.
+        25.0: [
+            self._m(('a',), 0.5),
+            self._m(('b',), 0.2),
+            self._m(('c',), 1.0),
+        ],
+        # block (a,b,c): 1 + |abc|/|a| = 1 + 24/2 = 13.
+        13.0: [self._m(('a', 'b', 'c')), self._m(('a',))],
+        # block (a,b,c): 1 + 24/6 + 24/12 = 1 + 4 + 2 = 7.
+        7.0: [
+            self._m(('a', 'b', 'c')),
+            self._m(('a', 'b')),
+            self._m(('b', 'c')),
+        ],
+    }
+    for expected, ms in cases.items():
+      analytic = calculate_l2_lipschitz_from_metadata(self.domain, ms)
+      self.assertAlmostEqual(analytic, expected, places=9)
+      # And it agrees with the power-iteration ground truth.
+      self.assertAlmostEqual(analytic, self._power(ms), delta=1e-2)
+
+  def test_upper_bounds_power_for_weighted_overlap(self):
+    # Non-uniform weights on overlapping sub-cliques: analytic may be a strict
+    # but safe overestimate (never below the true constant).
+    ms = [
+        self._m(('a', 'b', 'c')),
+        self._m(('a', 'b'), query=WeightedQuery(np.arange(1, 7).astype(float))),
+        self._m(
+            ('b', 'c'), query=WeightedQuery(np.arange(1, 13).astype(float))
+        ),
+    ]
+    analytic = calculate_l2_lipschitz_from_metadata(self.domain, ms)
+    self.assertGreaterEqual(analytic, self._power(ms) - 1e-6)
+
+  def test_single_weighted_is_exact(self):
+    w = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    ms = [self._m(('a', 'b'), stddev=2.0, query=WeightedQuery(w))]
+    analytic = calculate_l2_lipschitz_from_metadata(self.domain, ms)
+    self.assertAlmostEqual(analytic, np.max(w**2) / 4.0, places=9)  # 36/4 = 9.
+    self.assertAlmostEqual(analytic, self._power(ms), delta=1e-2)
+
+  def test_sliced_query_op_norm(self):
+    ms = [self._m(('a', 'b'), query=SlicedQuery(1))]
+    analytic = calculate_l2_lipschitz_from_metadata(self.domain, ms)
+    self.assertAlmostEqual(analytic, 1.0, places=9)
+
+  def test_returns_none_for_unknown_callable(self):
+    ms = [
+        LinearMeasurement(
+            np.zeros(6), ('a', 'b'), 1.0, query=lambda f: f.datavector()
+        )
+    ]
+    self.assertIsNone(calculate_l2_lipschitz_from_metadata(self.domain, ms))
+
+  def test_from_linear_measurements_uses_analytic_not_power(self):
+    # For all-identity measurements the analytic path must be taken, so power
+    # iteration is never invoked.
+    ms = [self._m(('a', 'b')), self._m(('b', 'c'))]
+    with mock.patch.object(
+        marginal_loss,
+        'calculate_l2_lipschitz',
+        side_effect=AssertionError('power iteration should not run'),
+    ):
+      lf = from_linear_measurements(ms, self.domain)
+    self.assertAlmostEqual(lf.lipschitz, 1.0, places=9)
+
+  def test_from_linear_measurements_falls_back_for_unknown_query(self):
+    # An unknown callable query has no declared operator norm, so from_metadata
+    # returns None and the loss falls back to the power-iteration estimate.
+    ms = [
+        LinearMeasurement(
+            np.zeros(6), ('a', 'b'), 1.0, query=lambda f: f.datavector()
+        )
+    ]
+    self.assertIsNone(calculate_l2_lipschitz_from_metadata(self.domain, ms))
+    lf = from_linear_measurements(ms, self.domain)
+    expected = calculate_l2_lipschitz(self.domain, list(lf.cliques), lf)
+    np.testing.assert_allclose(lf.lipschitz, expected)
 
 
 if __name__ == '__main__':

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -13,7 +13,6 @@ from mbi import (
     Factor,
     LinearMeasurement,
     MarkovRandomField,
-    NormalizedQuery,
     SlicedQuery,
     WeightedQuery,
     load,
@@ -119,7 +118,6 @@ class TestLinearMeasurements:
     ms = [
         LinearMeasurement(jnp.ones(size), cl),
         LinearMeasurement(jnp.ones(size), cl, query=WeightedQuery(weights)),
-        LinearMeasurement(jnp.ones(size), cl, query=NormalizedQuery()),
         LinearMeasurement(jnp.ones(size - 1), cl, query=SlicedQuery(start=1)),
     ]
     loaded = _roundtrip(ms)
@@ -127,9 +125,8 @@ class TestLinearMeasurements:
     assert isinstance(loaded[0].query, DatavectorQuery)
     assert isinstance(loaded[1].query, WeightedQuery)
     np.testing.assert_allclose(loaded[1].query.weights, weights, atol=1e-7)
-    assert isinstance(loaded[2].query, NormalizedQuery)
-    assert isinstance(loaded[3].query, SlicedQuery)
-    assert loaded[3].query.start == 1
+    assert isinstance(loaded[2].query, SlicedQuery)
+    assert loaded[2].query.start == 1
 
     # Functional equivalence for the weighted query.
     f = Factor(domain.project(cl), jnp.ones(size))


### PR DESCRIPTION
Compute L2 Lipschitz constant analytically from measurement metadata

The L2 (unnormalized) marginal loss is quadratic, so the Lipschitz
constant of its gradient is lambda_max of a Hessian that is
block-diagonal by maximal clique:

    H = sum_M (1 / sigma_M^2) (Q_M P_{c_M})^T (Q_M P_{c_M})

where P_{c_M} marginalizes a maximal-clique table down to clique c_M
(||P_c||^2 = |C| / |c|). Bounding each block by the sum of its terms'
operator norms gives

    L <= max_C sum_{M->C} ||Q_M||^2 / sigma_M^2 * |C| / |c_M|,

which is exact when all queries are identity marginals (the common
case) and a safe overestimate otherwise.

Previously this constant was estimated with 50 steps of power iteration
(jvp over grad), a cold-start JAX compilation that dominated setup time
for large models and was not covered by precompile(). The analytic path
needs no device computation.

`from_linear_measurements` now uses the metadata formula when every
query exposes a known operator norm, and falls back to the existing
power-iteration estimate for opaque/user-supplied callables, so behavior
is unchanged in those cases. Each built-in linear query gains an
`op_norm_sq` method (DatavectorQuery and SlicedQuery -> 1, WeightedQuery
-> max weight^2).

Also removes NormalizedQuery, which was unused internally (only ever
referenced from tests and the public export list).

---

Testing: full `pytest test/` suite passes (1341 passed). New `TestAnalyticLipschitz` covers exactness vs. power iteration for identity marginals, safe upper-bounding for weighted overlaps, sliced/weighted operator norms, `None` for opaque callables, and the power-iteration fallback path.
