### PR TITLE
Route marginal projections through the smallest-domain containing clique

### DIFF
--- a/src/mbi/clique_vector.py
+++ b/src/mbi/clique_vector.py
@@ -102,10 +102,12 @@ class CliqueVector:
 
   # @functools.lru_cache(maxsize=None)
   def parent(self, clique: Clique) -> Clique | None:
-    """Finds a clique in this vector that is a superset of the given clique."""
-    for result in self.cliques:
-      if set(clique) <= set(result):
-        return result
+    """Returns the smallest-domain clique in this vector containing ``clique``."""
+    scope = set(clique)
+    candidates = [c for c in self.cliques if scope <= set(c)]
+    if not candidates:
+      return None
+    return min(candidates, key=self.domain.size)
 
   def supports(self, clique: Clique) -> bool:
     """Checks if the given clique is supported (is a subset of any clique in the vector)."""

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -20,7 +20,7 @@ from jax.typing import ArrayLike
 import numpy as np
 import optax
 
-from .clique_utils import Clique, maximal_subset
+from .clique_utils import Clique, clique_mapping, maximal_subset
 from .clique_vector import CliqueVector
 from .domain import Domain
 from .factor import Factor
@@ -316,21 +316,16 @@ def calculate_l2_lipschitz_from_metadata(
   user-supplied callable query), signalling the caller to fall back to the
   power-iteration estimate.
   """
-  maximal = maximal_subset([m.clique for m in measurements])
-
-  def parent(clique: Clique) -> Clique:
-    scope = set(clique)
-    for c in maximal:  # Same order CliqueVector.parent scans.
-      if scope <= set(c):
-        return c
-    raise ValueError(f"No maximal clique contains {clique}.")
+  cliques = [m.clique for m in measurements]
+  maximal = maximal_subset(cliques)
+  routing = clique_mapping(maximal, cliques, domain)
 
   blocks: dict[Clique, float] = {}
   for m in measurements:
     q_norm_sq = _query_op_norm_sq(m.query)
     if q_norm_sq is None:
       return None
-    containing = parent(m.clique)
+    containing = routing[m.clique]
     proj_norm_sq = domain.size(containing) / domain.size(m.clique)
     stddev = max(float(m.stddev), 1e-12)
     contribution = q_norm_sq / stddev**2 * proj_norm_sq

--- a/test/test_clique_vector.py
+++ b/test/test_clique_vector.py
@@ -1,0 +1,32 @@
+import unittest
+
+import mbi
+
+
+class TestCliqueVectorParent(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.domain = mbi.Domain.fromdict({'a': 2, 'b': 3, 'c': 4})
+
+  def test_prefers_smallest_domain_superset(self):
+    # (a,) fits in both (a,b) [size 6] and (a,c) [size 8]; pick the smaller.
+    cv = mbi.CliqueVector.zeros(self.domain, [('a', 'c'), ('a', 'b')])
+    self.assertEqual(cv.parent(('a',)), ('a', 'b'))
+
+  def test_order_independent(self):
+    cv1 = mbi.CliqueVector.zeros(self.domain, [('a', 'c'), ('a', 'b')])
+    cv2 = mbi.CliqueVector.zeros(self.domain, [('a', 'b'), ('a', 'c')])
+    self.assertEqual(cv1.parent(('a',)), cv2.parent(('a',)))
+
+  def test_returns_self_when_present(self):
+    cv = mbi.CliqueVector.zeros(self.domain, [('a', 'b'), ('a', 'c')])
+    self.assertEqual(cv.parent(('a', 'b')), ('a', 'b'))
+
+  def test_none_when_no_superset(self):
+    cv = mbi.CliqueVector.zeros(self.domain, [('a', 'b')])
+    self.assertIsNone(cv.parent(('c',)))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/test_marginal_loss.py
+++ b/test/test_marginal_loss.py
@@ -208,6 +208,17 @@ class TestAnalyticLipschitz(unittest.TestCase):
       # And it agrees with the power-iteration ground truth.
       self.assertAlmostEqual(analytic, self._power(ms), delta=1e-2)
 
+  def test_routes_subclique_to_smallest_domain_parent(self):
+    # (a,) fits in (a,b) [size 6] and (a,c) [size 8]; routing via the smaller
+    # gives block (a,b) = 1 + |ab|/|a| = 4, order-independently.
+    for order in [
+        [self._m(('a', 'b')), self._m(('a', 'c')), self._m(('a',))],
+        [self._m(('a', 'c')), self._m(('a', 'b')), self._m(('a',))],
+    ]:
+      analytic = calculate_l2_lipschitz_from_metadata(self.domain, order)
+      self.assertAlmostEqual(analytic, 4.0, places=9)
+      self.assertAlmostEqual(analytic, self._power(order), delta=1e-2)
+
   def test_upper_bounds_power_for_weighted_overlap(self):
     # Non-uniform weights on overlapping sub-cliques: analytic may be a strict
     # but safe overestimate (never below the true constant).


### PR DESCRIPTION
## Summary

`CliqueVector.parent` (used by `project`, and therefore by the L2 loss) previously
returned the *first* clique in iteration order that contained the target
sub-clique. The analytic Lipschitz constant added in #202 was computed against
that same first-superset routing.

For a sub-clique measurement that fits inside several maximal cliques, the
marginalization operator norm is `|C| / |c|` — so routing through the
**smallest-domain** container minimizes each Hessian block and hence the loss's
Lipschitz constant. This is exactly the criterion `clique_mapping` /
`reverse_clique_mapping` already use, so `parent` was the odd one out.

This PR makes `parent` pick the smallest-domain superset and routes the analytic
Lipschitz through `clique_mapping` to stay consistent with the loss's actual
projection.

## Effect (two-parent micro-benchmark)

Domain `a=2, b=3, c=50`; measure identity on `(a,c)` and `(a,b)`, plus a
sub-clique measurement on `(a,)`:

| Property | Result |
| --- | --- |
| Lipschitz constant | **5100 → 400 (12.75× lower)**, now independent of measurement order |
| Final solution | **identical** across old/new routing (marginals agree to `<1e-4`) |
| Convergence | modest, estimator-dependent speedup (InteriorGradient 29 → 16 iters to 1% gap; ~1.5–2× for the accelerated / line-search estimators) |

The change is **correctness-neutral**: for consistent marginals every containing
clique gives the same projection, and all estimators converge to the same
solution. The win is a strictly lower-or-equal `L` (a tighter default step size)
plus removal of a latent inconsistency between `parent` and `clique_mapping`.

## Tests

- New `test/test_clique_vector.py` for the `parent` selection rule
  (smallest-domain, order-independent, self-when-present, `None` otherwise).
- New routing test in `test/test_marginal_loss.py` asserting order-independent
  smallest-domain routing that matches the power-iteration ground truth.

Full suite: 1346 passed; `pyrefly check` clean; `pyink --check` clean.
