### PR TITLE
Avoid OverflowError in summarize for astronomically large domains

### DIFF
--- a/src/mbi/_model_summary.py
+++ b/src/mbi/_model_summary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import math
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, cast
 
@@ -18,8 +19,22 @@ if TYPE_CHECKING:
   from .marginal_oracles import MarginalOracle
 
 
+def _sci(n: float) -> str:
+  """Scientific notation via logs, safe for ints too large to cast to float."""
+  log10 = math.log10(n)
+  exp = math.floor(log10)
+  mantissa = 10 ** (log10 - exp)
+  if mantissa >= 9.995:  # would round to "10.00e{exp}"
+    mantissa, exp = 1.0, exp + 1
+  return f"{mantissa:.2f}e{exp}"
+
+
 def _fmt_size(n: int | float) -> str:
   """Format a number of cells as a human-readable string."""
+  # Beyond a trillion, use scientific notation: the domain size can be an int
+  # too large to cast to float (which would raise OverflowError).
+  if n >= 1e12:
+    return _sci(n)
   if n >= 1e9:
     return f"{n / 1e9:.2f}B"
   if n >= 1e6:
@@ -29,8 +44,10 @@ def _fmt_size(n: int | float) -> str:
   return str(n)
 
 
-def _fmt_bytes(nbytes: int) -> str:
+def _fmt_bytes(nbytes: int | float) -> str:
   """Format a byte count as a human-readable string."""
+  if nbytes >= 2**50:
+    return f"{_sci(nbytes)} B"
   if nbytes >= 2**30:
     return f"{nbytes / 2**30:.2f} GiB"
   if nbytes >= 2**20:

--- a/test/test_model_summary.py
+++ b/test/test_model_summary.py
@@ -1,0 +1,42 @@
+"""Tests for model summary formatting, especially huge-domain safety."""
+
+import unittest
+
+from mbi import Domain
+from mbi._model_summary import _fmt_bytes, _fmt_size, summarize
+
+
+class TestFormatHelpers(unittest.TestCase):
+
+  def test_fmt_size_regular(self):
+    self.assertEqual(_fmt_size(500), "500")
+    self.assertEqual(_fmt_size(2500), "2.50K")
+    self.assertEqual(_fmt_size(3.4e6), "3.40M")
+    self.assertEqual(_fmt_size(7e9), "7.00B")
+
+  def test_fmt_size_huge_int_does_not_overflow(self):
+    # 2**1100 (~1e331) exceeds float range; float(n) would raise OverflowError.
+    self.assertEqual(_fmt_size(10**331), "1.00e331")
+    self.assertEqual(_fmt_size(2**1100), "1.36e331")
+
+  def test_fmt_bytes_regular(self):
+    self.assertEqual(_fmt_bytes(1500), "1.46 KiB")
+    self.assertEqual(_fmt_bytes(5 * 2**30), "5.00 GiB")
+
+  def test_fmt_bytes_huge_int_does_not_overflow(self):
+    self.assertEqual(_fmt_bytes(10**400), "1.00e400 B")
+
+
+class TestSummarizeHugeDomain(unittest.TestCase):
+
+  def test_astronomical_domain_size(self):
+    # 1100 binary attributes -> domain size 2**1100, which overflows float.
+    # summarize / str(summary) must not raise OverflowError.
+    domain = Domain([f"x{i}" for i in range(1100)], [2] * 1100)
+    cliques = [(f"x{i}",) for i in range(1100)]
+    summary = summarize(domain, cliques)
+    self.assertIn("1.36e331 total cells", str(summary))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Problem

`mbi.summarize` (and `str(ModelSummary)`) raised `OverflowError: int too large to convert to float` on high-dimensional models. `domain.size()` returns an exact Python int that can far exceed the float range (e.g. a domain of 1100 binary attributes has size `2**1100 ≈ 1e331`). The summary formatters then divided that int by a float:

```python
return f"{n / 1e9:.2f}B"        # _fmt_size
return f"{nbytes / 2**30:.2f} GiB"  # _fmt_bytes
```

Both force an `int -> float` cast, which raises once the value exceeds ~1.8e308. (`float(n)` and `format(n, 'e')` overflow the same way; only `math.log10(n)` handles big ints.)

## Fix

For very large magnitudes, format in scientific notation computed via `math.log10` instead of float division, so the size is reported compactly and never overflows:

```python
def _sci(n: float) -> str:
  """Scientific notation via logs, safe for ints too large to cast to float."""
  log10 = math.log10(n)
  exp = math.floor(log10)
  mantissa = 10 ** (log10 - exp)
  if mantissa >= 9.995:  # would round to "10.00e{exp}"
    mantissa, exp = 1.0, exp + 1
  return f"{mantissa:.2f}e{exp}"
```

- `_fmt_size` uses `_sci` for values `>= 1e12`; `_fmt_bytes` uses it for `>= 2**50`.
- Regular magnitudes keep the existing `K`/`M`/`B` and `KiB`/`MiB`/`GiB` output.

The domain size now prints as e.g. `1.36e331 total cells` instead of crashing.

## Testing

New `test/test_model_summary.py`:
- `_fmt_size`/`_fmt_bytes` on huge ints (`10**331`, `2**1100`, `10**400`) — no overflow, correct scientific output.
- Regular-magnitude formatting is unchanged.
- End-to-end `summarize` on a `2**1100` domain does not raise and reports `1.36e331 total cells`.

`pyink`, `pyrefly` (0 errors), and `pydocstyle` all clean.