### PR TITLE
Tighten array-type annotations on Dataset and LinearMeasurement.query

### DIFF
--- a/src/mbi/dataset.py
+++ b/src/mbi/dataset.py
@@ -19,7 +19,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax.typing import ArrayLike as JaxArrayLike
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import NDArray
 
 from .domain import Attribute, Domain
 from .factor import Factor
@@ -35,12 +35,12 @@ def _validate_column_meta(data: np.ndarray, attr: Attribute):
     )
 
 
-def _validate_data(data: Mapping[Attribute, ArrayLike], domain: Domain):
+def _validate_data(data: Mapping[Attribute, np.ndarray], domain: Domain):
   if set(data.keys()) != set(domain.attributes):
     raise ValueError("Keys in data dictionary must match domain attributes")
   n = None
   for col in data:
-    column = np.asarray(data[col])
+    column = data[col]
     _validate_column_meta(column, col)
     if n is None:
       n = column.shape[0]
@@ -90,9 +90,9 @@ class Dataset:
       weights: Optional per-row weights (defaults to all ones).
   """
 
-  data: Mapping[Attribute, ArrayLike]
+  data: Mapping[Attribute, np.ndarray]
   domain: Domain
-  weights: ArrayLike | None = dataclasses.field(default=None)
+  weights: np.ndarray | None = dataclasses.field(default=None)
 
   def __post_init__(self):
     object.__setattr__(
@@ -123,7 +123,7 @@ class Dataset:
       )
 
   def to_dict(self) -> dict[Attribute, np.ndarray]:
-    return {k: np.asarray(v) for k, v in self.data.items()}
+    return dict(self.data)
 
   @staticmethod
   def synthetic(domain: Domain, N: int) -> Dataset:
@@ -219,9 +219,7 @@ class Dataset:
       assert self.weights is not None  # guaranteed by __post_init__
       result = np.sum(self.weights)
       return np.array([result]) if flatten else result
-    multi_index = tuple(
-        np.asarray(self.data[a]) for a in self.domain.attributes
-    )
+    multi_index = tuple(self.data[a] for a in self.domain.attributes)
     linear_indices = np.ravel_multi_index(multi_index, dims, order="C")
     counts = np.bincount(
         linear_indices, minlength=math.prod(dims), weights=self.weights
@@ -262,7 +260,7 @@ class Dataset:
             f" size {self.domain[attr]} for attribute {attr}"
         )
 
-      new_col = map_array[np.asarray(self.data[attr])]
+      new_col = map_array[self.data[attr]]
       new_data[attr] = new_col.astype(np.min_scalar_type(np.max(map_array)))
       new_domain_config[attr] = int(np.max(map_array) + 1)
 
@@ -306,7 +304,7 @@ class Dataset:
       starts[1:] = np.cumsum(counts)
       starts = starts[:-1]
 
-      current_col = np.asarray(self.data[attr])
+      current_col = self.data[attr]
 
       col_counts = counts[current_col]
       if np.any(col_counts == 0):

--- a/src/mbi/marginal_loss.py
+++ b/src/mbi/marginal_loss.py
@@ -111,7 +111,7 @@ class LinearMeasurement:
   # Dynamic (traced) leaf, not static aux-data: a static value gets baked into
   # the treedef, changing the jit cache key and defeating precompile() reuse.
   stddev: float = 1.0
-  query: Callable[[Factor], ArrayLike] = jax.tree.static(
+  query: Callable[[Factor], jax.Array] = jax.tree.static(
       default=DatavectorQuery()
   )
 
@@ -212,9 +212,7 @@ def _l2_loss(
   for M in measurements:
     mu = marginals.project(M.clique)
     stddev = jnp.maximum(M.stddev, 1e-12)
-    diff = (
-        jnp.asarray(M.query(mu)) - jnp.asarray(M.noisy_measurement)
-    ) / stddev
+    diff = (M.query(mu) - jnp.asarray(M.noisy_measurement)) / stddev
     loss += 0.5 * jnp.vdot(diff, diff)
   return loss
 
@@ -228,9 +226,7 @@ def _l1_loss(
   for M in measurements:
     mu = marginals.project(M.clique)
     stddev = jnp.maximum(M.stddev, 1e-12)
-    diff = (
-        jnp.asarray(M.query(mu)) - jnp.asarray(M.noisy_measurement)
-    ) / stddev
+    diff = (M.query(mu) - jnp.asarray(M.noisy_measurement)) / stddev
     loss += jnp.sum(jnp.abs(diff))
   return loss
 
@@ -288,7 +284,7 @@ def calculate_l2_lipschitz(
   return float(estimate)
 
 
-def _query_op_norm_sq(query: Callable[[Factor], ArrayLike]) -> float | None:
+def _query_op_norm_sq(query: Callable[[Factor], jax.Array]) -> float | None:
   """Squared operator norm ||Q||_2^2 of a linear query, or None if unknown."""
   fn = getattr(query, "op_norm_sq", None)
   return float(cast(SupportsFloat, fn())) if callable(fn) else None


### PR DESCRIPTION
## What

Narrow two intentionally-loose `ArrayLike` annotations to the types actually stored, and remove the defensive `np.asarray`/`jnp.asarray` re-conversions that looseness forced.

### `Dataset`
`Dataset` is numpy-backed by contract — [`__post_init__`](https://github.com/ryan112358/mbi/blob/master/src/mbi/dataset.py) eagerly coerces every column and the weights via `np.asarray`. So the true invariant is "values are `np.ndarray`", but the field advertised `ArrayLike`, making every reader defensively re-wrap already-numpy values.

- `data: Mapping[Attribute, np.ndarray]`, `weights: np.ndarray | None`
- Drop redundant `np.asarray` in `_validate_data`, `datavector`, `compress`, `decompress`; simplify `to_dict` → `dict(self.data)`
- `__post_init__` **keeps** its `np.asarray` coercion, so construction stays forgiving of list/pandas/etc. inputs at runtime — only the *type* is narrowed.

### `LinearMeasurement.query`
`query` is invoked on a **traced** `Factor` inside the jitted loss, so it must be JIT-traceable; all three built-in queries already return `jax.Array`.

- `query: Callable[[Factor], jax.Array]`
- Drop the two now-redundant `jnp.asarray(M.query(mu))` wrappers in `_l2_loss`/`_l1_loss`
- `noisy_measurement` **stays** `ArrayLike` (genuinely numpy-or-jax) with its `jnp.asarray` normalization intact.

## Why it's safe
The removed conversions were provably no-ops (values already the target type post-coercion). **Behavior-neutral.**

- Full test suite: **1360 passed**
- pyrefly: **0 errors** (26 suppressed, unchanged)

## Stacking
Stacked on #192 (typing burndown) to keep that PR a pure zero-baseline suppression change. Will auto-retarget to `master` once #192 merges.