### PR TITLE
Make save() fail fast on non-array pytree leaves

### DIFF
--- a/src/mbi/_serialization.py
+++ b/src/mbi/_serialization.py
@@ -32,7 +32,12 @@ def save(obj: Any, file: str | os.PathLike | io.IOBase) -> None:
       file: Path string or writable binary file-like object.
   """
   leaves, treedef = jax.tree.flatten(obj)
-  arrays = {f"leaf_{i}": np.asarray(leaf) for i, leaf in enumerate(leaves)}
+  arrays = {}
+  for i, leaf in enumerate(leaves):
+    array = np.asarray(leaf)
+    if array.dtype == object:
+      raise TypeError(f"Cannot save non-array leaf {i}: {type(leaf).__name__}.")
+    arrays[f"leaf_{i}"] = array
   arrays["_treedef"] = np.frombuffer(pickle.dumps(treedef), dtype=np.uint8)
   buf = io.BytesIO()
   # numpy stub: allow_pickle precedes **kwds, so unpacking arrays trips it.

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -135,3 +135,26 @@ class TestLinearMeasurements:
         np.asarray(ms[1].query(f)),
         atol=1e-7,
     )
+
+
+class TestInvalidLeaves:
+
+  def test_object_leaf_raises(self):
+    """save() must reject non-array leaves instead of writing a corrupt file."""
+
+    class NotAnArray:
+      pass
+
+    buf = io.BytesIO()
+    with pytest.raises(TypeError):
+      save([NotAnArray()], buf)
+
+  def test_dict_of_objects_raises(self):
+    """A pytree whose leaves are arbitrary objects is rejected up front."""
+
+    class NotAnArray:
+      pass
+
+    buf = io.BytesIO()
+    with pytest.raises(TypeError):
+      save({"a": NotAnArray(), "b": NotAnArray()}, buf)


### PR DESCRIPTION
## Problem

`mbi.save()` calls `np.asarray()` on every pytree leaf. `np.asarray()` never
raises: given a non-array leaf (e.g. an arbitrary Python object), it returns a
0-d **object-dtype** array, which `np.savez_compressed` silently pickles. The
resulting `.npz` cannot be read back by `load()` — `jnp.asarray` on an object
array fails — so `save()` appears to succeed while producing a **corrupt
checkpoint that only fails at load time**.

This also makes it impossible for callers to `try: mbi.save(...) except: ...`
and fall back to another format, because the error surfaces on the read path,
far from the offending write.

## Fix

Detect object-dtype leaves in `save()` and raise a `TypeError` naming the
offending leaf index and type. Callers now get an immediate, actionable error
(and can cleanly fall back to their own serialization) instead of a file that
silently fails later.

Valid pytrees (`CliqueVector`, `MarkovRandomField`, `list[LinearMeasurement]`,
including their query objects) flatten to numeric array leaves and are
unaffected — confirmed by the existing round-trip tests.

## Tests

Adds `TestInvalidLeaves` covering non-array leaves in both a list and a dict
pytree.
