### PR TITLE
Make MarkovRandomField.synthetic_data respect constraints

### DIFF
--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -154,6 +154,7 @@ class Estimator(ABC):
           potentials=potentials,
           marginals=oracle(potentials, known_total),
           total=known_total,
+          constraints=constraints,
       )
 
     if "potentials" in kwargs:
@@ -453,6 +454,7 @@ class MirrorDescent(Estimator):
         potentials=state.potentials,
         marginals=marginals,
         total=known_total,
+        constraints=constraints,
     )
 
 
@@ -719,6 +721,7 @@ class LBFGS(Estimator):
         potentials=state.potentials,
         marginals=marginals,
         total=known_total,
+        constraints=constraints,
     )
 
 

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -16,6 +16,7 @@ from jax.typing import ArrayLike
 from . import junction_tree, marginal_oracles
 from .clique_utils import Clique
 from .clique_vector import CliqueVector
+from .constraint import Constraint
 from .dataset import Dataset
 from .domain import Attribute
 from .domain import Domain
@@ -39,11 +40,15 @@ class MarkovRandomField:
       total (ArrayLike): The total count or effective sample size
           represented by the model. This is often used for scaling or
           interpreting the marginals.
+      constraints (tuple[Constraint, ...]): Structural constraints the model
+          was fit under, used by ``synthetic_data`` so generated records
+          respect them. Empty if the model was fit without constraints.
   """
 
   potentials: CliqueVector
   marginals: CliqueVector
   total: ArrayLike = 1
+  constraints: tuple[Constraint, ...] = ()
 
   def project(self, attrs: Attribute | Sequence[Attribute]) -> Factor:
     if isinstance(attrs, (str, int)):
@@ -87,7 +92,15 @@ class MarkovRandomField:
     cliques = [set(cl) for cl in jtree.nodes]
 
     potentials = self.potentials.expand(list(jtree.nodes))
-    marginals = marginal_oracles.message_passing_stable(potentials, self.total)
+    if self.constraints:
+      # Shafer-Shenoy handles the -inf constraint potentials that HUGIN can't.
+      marginals = marginal_oracles.message_passing_shafer_shenoy(
+          potentials, self.total, constraints=self.constraints
+      )
+    else:
+      marginals = marginal_oracles.message_passing_stable(
+          potentials, self.total
+      )
 
     def synthetic_col(counts, total):
       """Generates a synthetic column by sampling or rounding based on counts and total."""

--- a/test/test_markov_random_field.py
+++ b/test/test_markov_random_field.py
@@ -1,11 +1,14 @@
 import unittest
 import numpy as np
 from mbi import (
+    Constraint,
     Domain,
     Factor,
     CliqueVector,
     MarkovRandomField,
     Dataset,
+    estimation,
+    marginal_loss,
     marginal_oracles,
 )
 
@@ -259,6 +262,62 @@ class TestSyntheticDataComprehensive(unittest.TestCase):
     domain = Domain(["A", "B", "C", "D", "E"], [2, 2, 2, 2, 2])
     cliques = [("A", "B"), ("B", "C", "D"), ("C", "D", "E", "A")]  # Loop
     self._test_model_structure(domain, cliques)
+
+
+class TestSyntheticDataConstraints(unittest.TestCase):
+  """Synthetic data must respect the constraints the model was fit under."""
+
+  def _mapping_constraint(self):
+    # b is a deterministic function of a: only b == mapping[a] is valid.
+    domain = Domain(["a", "b"], [4, 2])
+    mapping = np.array([0, 0, 1, 1])
+    return domain, mapping, Constraint(domain=domain, mapping=mapping)
+
+  def test_synthetic_data_respects_stored_constraints(self):
+    domain, mapping, constraint = self._mapping_constraint()
+    # Uniform potentials: absent the constraint ~half the rows would
+    # violate the functional dependency b == mapping[a].
+    potentials = CliqueVector.zeros(domain, [("a", "b")])
+    marginals = marginal_oracles.message_passing_stable(potentials, 1.0)
+    model = MarkovRandomField(
+        potentials=potentials,
+        marginals=marginals,
+        total=5000,
+        constraints=(constraint,),
+    )
+    np.random.seed(0)
+    synth = model.synthetic_data(method="round").to_dict()
+    self.assertEqual(np.sum(synth["b"] != mapping[synth["a"]]), 0)
+
+  def test_synthetic_data_unconstrained_is_unchanged(self):
+    # Without constraints the uniform model violates the dependency, so the
+    # constraint-aware path is not silently always on.
+    domain, mapping, _ = self._mapping_constraint()
+    potentials = CliqueVector.zeros(domain, [("a", "b")])
+    marginals = marginal_oracles.message_passing_stable(potentials, 1.0)
+    model = MarkovRandomField(
+        potentials=potentials, marginals=marginals, total=5000
+    )
+    np.random.seed(0)
+    synth = model.synthetic_data(method="round").to_dict()
+    self.assertGreater(np.sum(synth["b"] != mapping[synth["a"]]), 0)
+
+  def test_estimate_threads_constraints_end_to_end(self):
+    domain, mapping, constraint = self._mapping_constraint()
+    valid = np.zeros((4, 2))
+    valid[np.arange(4), mapping] = 1.0
+    joint = Factor(domain, valid)
+    measurements = [
+        marginal_loss.LinearMeasurement(joint.datavector(), ("a", "b"))
+    ]
+    model = estimation.MirrorDescent().estimate(
+        domain, measurements, 1000.0, constraints=(constraint,), iters=250
+    )
+    self.assertEqual(len(model.constraints), 1)
+    np.testing.assert_array_equal(model.constraints[0].mapping, mapping)
+    np.random.seed(0)
+    synth = model.synthetic_data(method="round").to_dict()
+    self.assertEqual(np.sum(synth["b"] != mapping[synth["a"]]), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make `MarkovRandomField.synthetic_data` respect constraints

## Problem

Constraints passed to `estimate(...)` were applied during inference (the
marginal oracles fold them in as `-inf`/`0` log-space factors), but they were
dropped from the estimated `MarkovRandomField`. As a result,
`MarkovRandomField.synthetic_data()` recomputed marginals from the raw
potentials via `message_passing_stable` (HUGIN) with no knowledge of the
constraints, so generated records could land in forbidden regions of the
domain — e.g. violating a functional dependency or a coarsening map that the
model was explicitly fit to honor.

## Fix

- Store the fitting constraints on the model: add a
  `constraints: tuple[Constraint, ...] = ()` field to `MarkovRandomField`.
- Thread `constraints` through to the `MarkovRandomField(...)` constructed in
  each estimator's `_finalize` (the no-clique short-circuit, `MirrorDescent`,
  and `LBFGS`; the delegating estimators `DualAveraging`, `InteriorGradient`,
  and `UniversalAcceleratedMethod` all route through `LBFGS`).
- In `synthetic_data`, when the model carries constraints, compute marginals
  with `message_passing_shafer_shenoy(..., constraints=self.constraints)`.
  Shafer-Shenoy handles the `-inf` constraint potentials that destabilize
  HUGIN's belief subtraction. The unconstrained path is unchanged.

The field defaults to `()`, so existing code and serialized checkpoints are
unaffected.

## Tests

Adds `TestSyntheticDataConstraints` to `test/test_markov_random_field.py`:

- `test_synthetic_data_respects_stored_constraints`: a model with uniform
  potentials over `(a, b)` plus a functional-dependency constraint
  `b == mapping[a]` generates zero violating rows (would be ~50% without the
  fix).
- `test_synthetic_data_unconstrained_is_unchanged`: the same uniform model
  without constraints still produces violations, confirming the
  constraint-aware path is not silently always on.
- `test_estimate_threads_constraints_end_to_end`: `MirrorDescent().estimate`
  with a constraint returns a model that carries it and whose synthetic data
  respects it.
