### PR TITLE
Make extensions.synthetic_data honor model constraints

### DIFF
--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -8,6 +8,7 @@ import dataclasses
 import functools
 import logging
 import time
+from collections.abc import Sequence
 from typing import Any
 
 import jax
@@ -17,6 +18,7 @@ import numpy as np
 from .. import junction_tree, marginal_oracles
 from ..clique_utils import Clique, clique_mapping
 from ..clique_vector import CliqueVector
+from ..constraint import Constraint
 from ..dataset import Dataset
 from ..domain import Attribute
 from ..domain import Domain
@@ -35,6 +37,7 @@ def precompile(
     domain: Domain,
     cliques: list[Clique],
     rows: int,
+    constraints: Sequence[Constraint] = (),
 ) -> concurrent.futures.Future:
   """Warm the JIT cache for ``synthetic_data`` asynchronously.
 
@@ -50,8 +53,12 @@ def precompile(
     domain: The Domain over which the model is defined.
     cliques: The cliques of the model (known after measurement selection).
     rows: Number of records that will be generated.
+    constraints: Structural constraints the model is fit under.  Their
+        cliques are added to the plan so the warmed JIT cache matches the
+        constraint-aware ``synthetic_data`` call.
   """
   rows = max(1, int(rows))
+  cliques = _plan_cliques(cliques, constraints, domain)
   plan = _build_plan(domain, cliques)
 
   def _compile_all():
@@ -130,13 +137,26 @@ def synthetic_data(
   """
   rows = max(1, int(rows))
   domain = model.domain
-  plan = _build_plan(domain, model.cliques)
 
   # Empirically necessary for large models (574-col, ~60 cliques): without
   # this, XLA compilation is orders of magnitude slower. Exact mechanism TBD.
   potentials = jax.tree.map(jnp.asarray, model.potentials)
 
-  # Clique ordering in model.potentials must match the cliques passed to
+  # Fold constraints in as -inf/0 log-space factors so each column's
+  # conditional marginal (reconstructed below from potentials + messages)
+  # puts zero mass on forbidden cells.  Without this, generated records can
+  # violate the constraints the model was fit under.
+  if model.constraints:
+    potentials, _ = marginal_oracles._fold_constraints(
+        potentials, model.constraints
+    )
+    # Constraint factors are weak-typed (built from Python -inf scalars),
+    # but precompile()'s abstract factors are not.  Strip weak types so the
+    # _generate_column JIT signatures match and the warmed cache is reused.
+    potentials = jax.tree.map(lambda x: x.astype(x.dtype), potentials)
+  plan = _build_plan(domain, potentials.cliques)
+
+  # Clique ordering in potentials must match the cliques passed to
   # precompile() for the JIT cache to hit (cliques are pytree metadata).
   _, messages = marginal_oracles.message_passing_implicit(
       potentials,
@@ -216,6 +236,21 @@ class _GenerationPlan:
   columns: dict[Attribute, _ColumnPlan]
   jtree: Any  # nx.Graph
   maximal_cliques: list[Clique]
+
+
+def _plan_cliques(cliques, constraints, domain):
+  """Model cliques plus any constraint cliques not already present.
+
+  Mirrors the clique construction in ``marginal_oracles._fold_constraints``
+  (which ``synthetic_data`` uses) so that ``precompile`` and ``synthetic_data``
+  build the same junction tree and JIT signature.
+  """
+  cliques = list(cliques)
+  for c in constraints:
+    cl = domain.canonical(c.clique)
+    if cl not in cliques:
+      cliques.append(cl)
+  return cliques
 
 
 def _build_plan(domain, cliques):

--- a/test/test_ext_synthetic_data.py
+++ b/test/test_ext_synthetic_data.py
@@ -7,13 +7,14 @@ from mbi import (
     Domain,
     Factor,
     CliqueVector,
+    Constraint,
     MarkovRandomField,
     marginal_oracles,
 )
 from mbi.extensions.synthetic_data import synthetic_data as ext_synthetic_data
 
 
-def _create_random_model(domain, cliques, N):
+def _create_random_model(domain, cliques, N, constraints=()):
   """Creates a random MRF with given cliques and total count N."""
   potentials = {}
   np.random.seed(0)
@@ -27,7 +28,10 @@ def _create_random_model(domain, cliques, N):
   marginals = marginal_oracles.message_passing_stable(potential_vector, total=N)
 
   return MarkovRandomField(
-      potentials=potential_vector, marginals=marginals, total=N
+      potentials=potential_vector,
+      marginals=marginals,
+      total=N,
+      constraints=constraints,
   )
 
 
@@ -370,6 +374,141 @@ class TestExtSyntheticDataCacheHit(unittest.TestCase):
   def test_cache_hit_default(self):
     """Under the default (float32) regime, generation reuses the cache."""
     self._run_regime(enable_x64=False)
+
+
+class TestExtSyntheticDataConstraints(unittest.TestCase):
+  """extensions.synthetic_data must honor the model's structural constraints.
+
+  A fitted MRF stores raw potentials; constraints are folded in only during
+  inference.  The JAX generation path reconstructs each column's conditional
+  marginal from those potentials, so it must re-fold the constraints or it
+  emits records that violate the functional dependencies the model was fit
+  under.  Mirrors TestSyntheticDataConstraints for MRF.synthetic_data.
+  """
+
+  def _count_violations(self, synth, mapping):
+    """Number of rows where b != mapping[a] (a functional dependency)."""
+    data = synth.to_dict()
+    a = np.asarray(data["a"])
+    b = np.asarray(data["b"])
+    return int(np.sum(b != np.asarray(mapping)[a]))
+
+  def test_respects_constraint_on_model_clique(self):
+    """A functional dependency on an existing model clique is honored."""
+    domain = Domain(["a", "b"], [4, 2])
+    mapping = [0, 0, 1, 1]  # b = mapping[a]
+    constraint = Constraint(domain=domain, mapping=np.asarray(mapping))
+    model = _create_random_model(
+        domain, [("a", "b")], N=2000, constraints=(constraint,)
+    )
+
+    synth = ext_synthetic_data(model, rows=2000)
+    self.assertEqual(self._count_violations(synth, mapping), 0)
+
+  def test_respects_constraint_on_new_clique(self):
+    """A constraint whose clique is not a model clique is still honored.
+
+    The (a, b) constraint clique is absent from the model's cliques, so
+    generation must add it to the plan (via _plan_cliques and folding) for
+    the -inf mask to reach the reconstructed conditional marginal.  This is
+    the cross-attribute case that matters in practice (e.g. DP Synth).
+    """
+    domain = Domain(["a", "b", "c"], [4, 2, 3])
+    mapping = [0, 0, 1, 1]  # b = mapping[a]
+    constraint = Constraint(
+        domain=Domain(["a", "b"], [4, 2]), mapping=np.asarray(mapping)
+    )
+    model = _create_random_model(
+        domain, [("a", "c"), ("b", "c")], N=3000, constraints=(constraint,)
+    )
+
+    synth = ext_synthetic_data(model, rows=3000)
+    self.assertEqual(self._count_violations(synth, mapping), 0)
+
+  def test_unconstrained_model_still_covers_domain(self):
+    """With no constraints the fold is skipped and generation is unaffected."""
+    domain = Domain(["a", "b"], [4, 2])
+    model = _create_random_model(domain, [("a", "b")], N=2000)
+    data = ext_synthetic_data(model, rows=2000).to_dict()
+    self.assertEqual(len(np.asarray(data["a"])), 2000)
+    # Both b values should appear when unconstrained.
+    self.assertGreater(len(np.unique(np.asarray(data["b"]))), 1)
+
+  def test_precompile_with_constraints_warms_cache(self):
+    """precompile(constraints=...) warms the cache for a constrained model.
+
+    The constraint adds a clique to the plan, changing _generate_column's
+    input signature.  precompile() must augment its plan identically or the
+    subsequent constraint-aware synthetic_data() call recompiles.
+    """
+    sd = importlib.import_module("mbi.extensions.synthetic_data")
+
+    class _CompileCounter(logging.Handler):
+
+      def __init__(self):
+        super().__init__()
+        self.n = 0
+
+      def emit(self, record):
+        try:
+          msg = record.getMessage()
+        except Exception:  # pylint: disable=broad-exception-caught
+          return
+        if "Compiling" in msg and "_generate_column" in msg:
+          self.n += 1
+
+    prev_x64 = jax.config.jax_enable_x64
+    prev_log = jax.config.jax_log_compiles
+    prev_cache = jax.config.jax_enable_compilation_cache
+    counter = _CompileCounter()
+    loggers = [logging.getLogger(name) for name in ("", "jax", "jax._src")]
+    prev_levels = [(lg, lg.level) for lg in loggers]
+    try:
+      jax.config.update("jax_enable_x64", False)
+      jax.config.update("jax_enable_compilation_cache", False)
+      jax.clear_caches()
+      jax.config.update("jax_log_compiles", True)
+      for lg in loggers:
+        lg.setLevel(logging.DEBUG)
+        lg.addHandler(counter)
+
+      domain = Domain(["a", "b", "c"], [4, 2, 3])
+      mapping = np.asarray([0, 0, 1, 1])
+      constraint = Constraint(
+          domain=Domain(["a", "b"], [4, 2]), mapping=mapping
+      )
+      model = _create_random_model(
+          domain, [("a", "c"), ("b", "c")], N=1000, constraints=(constraint,)
+      )
+      rows = 1000
+
+      sd.precompile(
+          domain, list(model.cliques), rows, constraints=model.constraints
+      ).result()
+      n_after_precompile = counter.n
+      sd.synthetic_data(model, rows)
+      n_after_generate = counter.n
+    finally:
+      for lg in loggers:
+        lg.removeHandler(counter)
+      for lg, level in prev_levels:
+        lg.setLevel(level)
+      jax.config.update("jax_log_compiles", prev_log)
+      jax.config.update("jax_enable_compilation_cache", prev_cache)
+      jax.config.update("jax_enable_x64", prev_x64)
+
+    self.assertGreater(
+        n_after_precompile,
+        0,
+        "precompile() compiled no _generate_column; test is vacuous",
+    )
+    self.assertEqual(
+        n_after_generate,
+        n_after_precompile,
+        "synthetic_data() recompiled _generate_column "
+        f"({n_after_generate - n_after_precompile} new compiles) with "
+        "constraints: the precompile() cache missed.",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Make `mbi.extensions.synthetic_data` respect the structural constraints the
model was fit under. This is the JAX-accelerated counterpart to #209, which
fixed the same class of bug in `MarkovRandomField.synthetic_data`.

## The bug

`estimate(..., constraints=...)` folds constraints into inference, but the
fitted `MarkovRandomField` stores the raw (finite) potentials — the `-inf`
constraint mask is applied only at inference time. The core `synthetic_data`
was fixed in #209 to re-fold the constraints when generating.

The JAX extension (`mbi/extensions/synthetic_data.py`) has the same defect and
was not covered by #209:

- It builds its junction tree/plan from `model.cliques` only, so a constraint
  that folds in as a *new* clique was absent from the tree.
- It reconstructs each column's conditional marginal from the **raw**
  `model.potentials` plus messages, so even constraint-aware messages would not
  put the `-inf` mask on the constrained clique's own factor.

As a result, records generated through this path could violate the functional
dependencies / forbidden combinations the model was fit under. This path is the
default generator for high-performance callers (e.g. DP Synth's SWIFT
mechanism).

## The fix

- `synthetic_data`: fold `model.constraints` into the potentials (via
  `marginal_oracles._fold_constraints`) before building the plan and computing
  messages, and build the plan from the folded clique set. Each column's
  reconstructed marginal then assigns zero mass to forbidden cells.
- Constraint factors are weak-typed (built from Python `-inf` scalars); strip
  weak types so the `_generate_column` JIT signature matches `precompile`'s
  abstract factors (otherwise the warmed cache is missed).
- `precompile`: accept an optional `constraints` argument and add the constraint
  cliques to the plan (via the new `_plan_cliques` helper), mirroring
  `_fold_constraints`' clique construction so `precompile` and `synthetic_data`
  build the same junction tree and JIT signature.

Both entry points remain backward compatible: `synthetic_data`'s signature is
unchanged (it reads `model.constraints`), and `precompile`'s new argument
defaults to `()`.

## Tests

Added `TestExtSyntheticDataConstraints` covering:

- a functional dependency on an existing model clique → zero violations;
- a constraint whose clique is **not** a model clique (the cross-attribute case
  that matters in practice) → zero violations;
- unconstrained generation is unaffected;
- `precompile(constraints=...)` warms the cache so the constraint-aware
  `synthetic_data` call does not recompile.

All extension tests pass (`15 passed`); `pyink --check` and `flake8` are clean.
